### PR TITLE
feat(format): levelized parallel graph execution (process_parallel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.482.0
+    VERSION 0.483.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -3,8 +3,10 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/format/process_block.hpp>
 #include <pulp/graph/graph_runtime_buffer_assignment.hpp>
+#include <pulp/graph/graph_runtime_levelization.hpp>
 #include <pulp/graph/graph_runtime_plan.hpp>
 #include <pulp/graph/graph_runtime_queue.hpp>
+#include <pulp/format/graph_runtime_worker_pool.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/ump_buffer.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
@@ -106,9 +108,18 @@ struct GraphRuntimeNodeBinding {
 /// still reference it; use a publish/lifetime policy above this primitive.
 class GraphRuntimeSnapshot {
 public:
+    // `parallel_safe` builds the buffer assignment without slot reuse so the
+    // snapshot can drive process_parallel (concurrent nodes never alias a
+    // recycled slot). Default false = the compact serial layout for
+    // process_routed. Both layouts produce identical output; parallel just costs
+    // more slots.
     bool reset(graph::GraphRuntimePlan plan,
-               std::span<const GraphRuntimeNodeBinding> bindings);
+               std::span<const GraphRuntimeNodeBinding> bindings,
+               bool parallel_safe = false);
     void clear() noexcept;
+
+    // True if this snapshot's assignment is reuse-free (safe for process_parallel).
+    bool parallel_safe() const noexcept { return parallel_safe_; }
 
     bool valid() const noexcept;
     const graph::GraphRuntimePlan& plan() const noexcept { return plan_; }
@@ -129,6 +140,7 @@ private:
     graph::GraphRuntimePlan plan_;
     std::vector<GraphRuntimeNodeBinding> bindings_;
     graph::GraphRuntimeBufferAssignment assignment_;
+    bool parallel_safe_ = false;
 };
 
 struct GraphRuntimeEventSink {
@@ -484,6 +496,28 @@ public:
         ProcessBlock& block,
         const GraphRuntimeSnapshot& snapshot,
         GraphRuntimeBufferPool& pool,
+        GraphRuntimeMidiScratch* midi = nullptr,
+        GraphRuntimeAutomationScratch* automation = nullptr,
+        std::span<const graph::GraphTimedCommand> commands = {},
+        std::span<GraphRuntimeCommandDecision> command_results = {},
+        GraphRuntimeCommandHandler command_handler = {},
+        GraphRuntimeEventSink event_sink = {}) noexcept;
+
+    // Levelized PARALLEL routing path: same per-node work as process_routed, but
+    // each topological level's independent nodes are dispatched across `workers`
+    // (the audio thread is participant 0), barriered between levels. Output is
+    // bit-identical to process_routed: each node owns disjoint scratch, its
+    // fan-in sum is single-threaded, and the level barrier orders producers
+    // before consumers. A level that contains an AudioOutput node (which
+    // accumulates into the shared output bus) or has a single node runs serially.
+    // `levels` must be the levelization of `snapshot`'s plan and `workers` must be
+    // started; pool/midi/automation must fit() the snapshot as for process_routed.
+    GraphRuntimeExecutorResult process_parallel(
+        ProcessBlock& block,
+        const GraphRuntimeSnapshot& snapshot,
+        const graph::GraphRuntimeLevelization& levels,
+        GraphRuntimeBufferPool& pool,
+        GraphRuntimeWorkerPool& workers,
         GraphRuntimeMidiScratch* midi = nullptr,
         GraphRuntimeAutomationScratch* automation = nullptr,
         std::span<const graph::GraphTimedCommand> commands = {},

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -441,6 +441,95 @@ constexpr std::size_t kRoutedMidiEventCapacity = 1024;
 constexpr std::size_t kRoutedMidiSysexCapacity = 128;
 constexpr std::size_t kRoutedMidiSysexPayloadCapacity = 4096;
 
+// Run ONE node of the routing walk: gather its audio / MIDI / automation inputs,
+// then either copy the I/O bus (AudioInput/AudioOutput) or invoke its binding.
+// Returns the error code (None on success). This is the per-node seam shared by
+// the serial walk and the parallel (levelized) walk, so both produce identical
+// output by construction. It touches only this node's own scratch (disjoint
+// output slots, per-node MIDI/automation buffers, per-connection inbound rings),
+// so distinct nodes may run concurrently — EXCEPT AudioOutput, which accumulates
+// into the shared output bus and must be run serially by the caller.
+GraphRuntimeExecutorErrorCode run_routed_node(
+    std::uint32_t node_index,
+    const graph::GraphRuntimePlan& plan,
+    std::span<const GraphRuntimeNodeBinding> bindings,
+    const graph::GraphRuntimeBufferAssignment& assignment,
+    GraphRuntimeBufferPool& pool,
+    GraphRuntimeMidiScratch* midi,
+    GraphRuntimeAutomationScratch* automation,
+    ProcessBlock& block,
+    const BusBuffer* in_bus,
+    BusBuffer* out_bus,
+    std::span<const GraphRuntimeCommandDecision> command_results,
+    std::uint32_t frames) noexcept {
+    const auto& node = plan.nodes[node_index];
+    const auto& slots = assignment.nodes[node_index];
+
+    if (node.input_ports > GraphRuntimeExecutor::kMaxRoutedPortsPerNode ||
+        node.output_ports > GraphRuntimeExecutor::kMaxRoutedPortsPerNode) {
+        return GraphRuntimeExecutorErrorCode::NodePortLimitExceeded;
+    }
+
+    gather_node_inputs(plan, assignment, pool, node, slots, frames);
+    if (midi != nullptr) {
+        gather_node_midi(plan, *midi, node, node_index);
+    }
+    if (automation != nullptr) {
+        gather_node_automation(plan, assignment, pool, *automation, node, node_index,
+                               frames, block.sample_rate);
+    }
+
+    if (node.kind == graph::GraphRuntimeNodeKind::AudioInput ||
+        node.kind == graph::GraphRuntimeNodeKind::AudioOutput) {
+        copy_io_bus(node.kind, pool, node, slots, in_bus, out_bus, frames);
+        return GraphRuntimeExecutorErrorCode::None;
+    }
+
+    const auto& binding = bindings[node_index];
+    if (!binding.process) {
+        return binding.required ? GraphRuntimeExecutorErrorCode::MissingRequiredProcessor
+                                : GraphRuntimeExecutorErrorCode::None;
+    }
+
+    // Marshal the node's mono slots into contiguous channel views.
+    std::array<const float*, GraphRuntimeExecutor::kMaxRoutedPortsPerNode> in_ptrs{};
+    std::array<float*, GraphRuntimeExecutor::kMaxRoutedPortsPerNode> out_ptrs{};
+    for (std::uint32_t p = 0; p < node.input_ports; ++p) {
+        in_ptrs[p] = pool.slot_data(slots.input_base + p);
+    }
+    for (std::uint32_t p = 0; p < node.output_ports; ++p) {
+        out_ptrs[p] = pool.slot_data(slots.output_base + p);
+    }
+
+    GraphRuntimeNodeProcessContext context;
+    context.plan = &plan;
+    context.node = &node;
+    context.node_index = node_index;
+    context.command_results = command_results;
+    context.routed = true;
+    context.node_inputs = audio::BufferView<const float>(
+        in_ptrs.data(), node.input_ports, frames);
+    context.node_outputs = audio::BufferView<float>(
+        out_ptrs.data(), node.output_ports, frames);
+    if (midi != nullptr) {
+        context.node_midi_in = midi->in(node_index);
+        context.node_midi_out = midi->out(node_index);
+    }
+    if (automation != nullptr) {
+        context.node_param_events = automation->events(node_index);
+    }
+    if (!binding.process(block, context, binding.user_data)) {
+        return GraphRuntimeExecutorErrorCode::NodeProcessorFailed;
+    }
+    if (midi != nullptr && context.node_midi_out != nullptr) {
+        midi->set_out_incomplete(
+            node_index,
+            midi->in_incomplete(node_index) ||
+                routed_midi_has_drops(*context.node_midi_out));
+    }
+    return GraphRuntimeExecutorErrorCode::None;
+}
+
 } // namespace
 
 bool GraphRuntimeMidiScratch::reset(std::uint32_t node_count) {
@@ -600,7 +689,8 @@ void GraphRuntimeBufferPool::clear() noexcept {
 
 bool GraphRuntimeSnapshot::reset(
     graph::GraphRuntimePlan plan,
-    std::span<const GraphRuntimeNodeBinding> bindings) {
+    std::span<const GraphRuntimeNodeBinding> bindings,
+    bool parallel_safe) {
     clear();
     if (bindings.size() != plan.nodes.size()) return false;
     if (plan.processing_order_indices.size() != plan.nodes.size()) return false;
@@ -613,10 +703,12 @@ bool GraphRuntimeSnapshot::reset(
 
     try {
         // The buffer assignment is a pure function of the plan, so it is built
-        // here off the audio thread alongside plan validation. Per-worker
-        // scratch sizing for a parallel executor depends on worker count, not
-        // the plan — it belongs to the executor/pool, NOT here.
-        auto assignment = graph::build_graph_runtime_buffer_assignment(plan);
+        // here off the audio thread alongside plan validation. parallel_safe
+        // disables slot reuse so concurrent same-level nodes never alias a
+        // recycled slot. Per-worker scratch sizing for a parallel executor
+        // depends on worker count, not the plan — it belongs to the pool.
+        auto assignment =
+            graph::build_graph_runtime_buffer_assignment(plan, /*allow_reuse=*/!parallel_safe);
         if (!assignment.ok) {
             clear();
             return false;
@@ -624,6 +716,7 @@ bool GraphRuntimeSnapshot::reset(
         plan_ = std::move(plan);
         bindings_.assign(bindings.begin(), bindings.end());
         assignment_ = std::move(assignment);
+        parallel_safe_ = parallel_safe;
     } catch (...) {
         clear();
         return false;
@@ -635,6 +728,7 @@ void GraphRuntimeSnapshot::clear() noexcept {
     plan_.clear();
     bindings_.clear();
     assignment_ = {};
+    parallel_safe_ = false;
 }
 
 bool GraphRuntimeSnapshot::valid() const noexcept {
@@ -811,96 +905,176 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
         }
     }
 
+    const auto command_decisions = command_results.first(commands.size());
     for (const auto node_index : plan.processing_order_indices) {
         if (node_index >= bindings.size()) return fail_invalid_snapshot();
 
-        const auto& node = plan.nodes[node_index];
-        const auto& slots = assignment.nodes[node_index];
-
-        if (node.input_ports > kMaxRoutedPortsPerNode ||
-            node.output_ports > kMaxRoutedPortsPerNode) {
-            result.error = GraphRuntimeExecutorErrorCode::NodePortLimitExceeded;
+        const auto error = run_routed_node(node_index, plan, bindings, assignment,
+                                           pool, midi, automation, block, in_bus,
+                                           out_bus, command_decisions, frames);
+        if (error != GraphRuntimeExecutorErrorCode::None) {
+            result.error = error;
             result.failed_node_index = node_index;
             node_failures_.fetch_add(1, std::memory_order_relaxed);
             return result;
         }
-
-        gather_node_inputs(plan, assignment, pool, node, slots, frames);
-        if (midi != nullptr) {
-            gather_node_midi(plan, *midi, node, node_index);
-        }
-        if (automation != nullptr) {
-            gather_node_automation(plan, assignment, pool, *automation, node,
-                                   node_index, frames, block.sample_rate);
-        }
-
-        if (node.kind == graph::GraphRuntimeNodeKind::AudioInput ||
-            node.kind == graph::GraphRuntimeNodeKind::AudioOutput) {
-            copy_io_bus(node.kind, pool, node, slots, in_bus, out_bus, frames);
-        } else {
-            const auto& binding = bindings[node_index];
-            if (!binding.process) {
-                if (binding.required) {
-                    result.error =
-                        GraphRuntimeExecutorErrorCode::MissingRequiredProcessor;
-                    result.failed_node_index = node_index;
-                    node_failures_.fetch_add(1, std::memory_order_relaxed);
-                    return result;
-                }
-                // optional no-op; its output slots stay silent
-                ++result.nodes_processed;
-                nodes_processed_.fetch_add(1, std::memory_order_relaxed);
-                continue;
-            }
-
-            // Marshal the node's mono slots into contiguous channel views. This
-            // is the per-node body a parallel executor would schedule onto
-            // worker threads.
-            std::array<const float*, kMaxRoutedPortsPerNode> in_ptrs{};
-            std::array<float*, kMaxRoutedPortsPerNode> out_ptrs{};
-            for (std::uint32_t p = 0; p < node.input_ports; ++p) {
-                in_ptrs[p] = pool.slot_data(slots.input_base + p);
-            }
-            for (std::uint32_t p = 0; p < node.output_ports; ++p) {
-                out_ptrs[p] = pool.slot_data(slots.output_base + p);
-            }
-
-            GraphRuntimeNodeProcessContext context;
-            context.plan = &plan;
-            context.node = &node;
-            context.node_index = node_index;
-            context.command_results = command_results.first(commands.size());
-            context.routed = true;
-            context.node_inputs = audio::BufferView<const float>(
-                in_ptrs.data(), node.input_ports, frames);
-            context.node_outputs = audio::BufferView<float>(
-                out_ptrs.data(), node.output_ports, frames);
-            if (midi != nullptr) {
-                context.node_midi_in = midi->in(node_index);
-                context.node_midi_out = midi->out(node_index);
-            }
-            if (automation != nullptr) {
-                context.node_param_events = automation->events(node_index);
-            }
-            if (!binding.process(block, context, binding.user_data)) {
-                result.error = GraphRuntimeExecutorErrorCode::NodeProcessorFailed;
-                result.failed_node_index = node_index;
-                node_failures_.fetch_add(1, std::memory_order_relaxed);
-                return result;
-            }
-            // A MIDI-emitting binding's output is incomplete if its gathered
-            // input was, or if the binding itself dropped output events —
-            // matching the host walk's per-node midi_out_incomplete.
-            if (midi != nullptr && context.node_midi_out != nullptr) {
-                midi->set_out_incomplete(
-                    node_index,
-                    midi->in_incomplete(node_index) ||
-                        routed_midi_has_drops(*context.node_midi_out));
-            }
-        }
-
         ++result.nodes_processed;
         nodes_processed_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    capture_feedback(plan, assignment, pool, frames);
+
+    blocks_processed_.fetch_add(1, std::memory_order_relaxed);
+    return result;
+}
+
+namespace {
+
+// Worker-pool task context for one level's parallel nodes. Holds the shared
+// (read-mostly) walk state plus this level's node-index slice and an error sink.
+struct ParallelLevelTask {
+    const graph::GraphRuntimePlan* plan;
+    std::span<const GraphRuntimeNodeBinding> bindings;
+    const graph::GraphRuntimeBufferAssignment* assignment;
+    GraphRuntimeBufferPool* pool;
+    GraphRuntimeMidiScratch* midi;
+    GraphRuntimeAutomationScratch* automation;
+    ProcessBlock* block;
+    const BusBuffer* in_bus;
+    BusBuffer* out_bus;
+    std::span<const GraphRuntimeCommandDecision> command_results;
+    std::uint32_t frames;
+    const std::uint32_t* level_nodes;          // this level's node indices
+    std::atomic<std::uint32_t>* error_code;    // 0 = None, else (code + 1)
+    std::atomic<std::uint32_t>* failed_node;
+};
+
+void run_level_node(void* ctx, std::uint32_t i) noexcept {
+    auto* t = static_cast<ParallelLevelTask*>(ctx);
+    const std::uint32_t node_index = t->level_nodes[i];
+    const auto e = run_routed_node(node_index, *t->plan, t->bindings, *t->assignment,
+                                   *t->pool, t->midi, t->automation, *t->block,
+                                   t->in_bus, t->out_bus, t->command_results,
+                                   t->frames);
+    if (e != GraphRuntimeExecutorErrorCode::None) {
+        std::uint32_t expected = 0;
+        if (t->error_code->compare_exchange_strong(
+                expected, static_cast<std::uint32_t>(e) + 1,
+                std::memory_order_relaxed)) {
+            t->failed_node->store(node_index, std::memory_order_relaxed);
+        }
+    }
+}
+
+} // namespace
+
+GraphRuntimeExecutorResult GraphRuntimeExecutor::process_parallel(
+    ProcessBlock& block,
+    const GraphRuntimeSnapshot& snapshot,
+    const graph::GraphRuntimeLevelization& levels,
+    GraphRuntimeBufferPool& pool,
+    GraphRuntimeWorkerPool& workers,
+    GraphRuntimeMidiScratch* midi,
+    GraphRuntimeAutomationScratch* automation,
+    std::span<const graph::GraphTimedCommand> commands,
+    std::span<GraphRuntimeCommandDecision> command_results,
+    GraphRuntimeCommandHandler command_handler,
+    GraphRuntimeEventSink event_sink) noexcept {
+    if (!block.validate()) return fail_invalid_block();
+    if (!snapshot.valid()) return fail_invalid_snapshot();
+
+    const auto& plan = snapshot.plan();
+    const auto bindings = snapshot.bindings();
+    const auto& assignment = snapshot.buffer_assignment();
+    const auto frames = block.frame_count;
+
+    // The levelization must describe THIS plan (a stale one would mis-schedule),
+    // and the snapshot must use the reuse-free layout — a serial (reused) layout
+    // would let concurrent same-level nodes alias a recycled slot and race.
+    if (!levels.ok || levels.node_level.size() != plan.nodes.size() ||
+        !snapshot.parallel_safe()) {
+        return fail_invalid_snapshot();
+    }
+    if (!pool.fits(snapshot, frames) ||
+        (automation != nullptr &&
+         !automation->fits(plan.node_count(), plan.connection_count(), frames)) ||
+        (midi != nullptr && !midi->fits(plan.node_count()))) {
+        GraphRuntimeExecutorResult fail;
+        fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
+        return fail;
+    }
+
+    GraphRuntimeExecutorResult result;
+    if (!drain_commands(block, plan, commands, command_results, command_handler,
+                        event_sink, result)) {
+        return fail_command_scratch_too_small();
+    }
+
+    const BusBuffer* in_bus =
+        block.buses ? block.buses->first(BusDirection::Input, BusRole::Main) : nullptr;
+    BusBuffer* out_bus =
+        block.buses ? block.buses->first(BusDirection::Output, BusRole::Main) : nullptr;
+    if (out_bus != nullptr) {
+        for (std::size_t c = 0; c < out_bus->output.num_channels(); ++c) {
+            std::fill_n(out_bus->output.channel_ptr(c), frames, 0.0f);
+        }
+    }
+
+    const auto command_decisions = command_results.first(commands.size());
+    std::atomic<std::uint32_t> error_code{0};
+    std::atomic<std::uint32_t> failed_node{0};
+
+    auto report_failure = [&](GraphRuntimeExecutorErrorCode e,
+                              std::uint32_t node) -> GraphRuntimeExecutorResult {
+        result.error = e;
+        result.failed_node_index = node;
+        node_failures_.fetch_add(1, std::memory_order_relaxed);
+        return result;
+    };
+
+    for (std::uint32_t level = 0; level < levels.level_count; ++level) {
+        const std::uint32_t base = levels.level_offsets[level];
+        const std::uint32_t width = levels.level_offsets[level + 1] - base;
+        if (width == 0) continue;
+
+        // A level runs serially when it can't safely parallelize: a single node
+        // (no benefit), no worker threads, or it contains an AudioOutput node
+        // (which accumulates into the shared output bus — see the header).
+        bool serial = width == 1 || workers.worker_count() <= 1;
+        for (std::uint32_t k = 0; !serial && k < width; ++k) {
+            if (plan.nodes[levels.level_nodes[base + k]].kind ==
+                graph::GraphRuntimeNodeKind::AudioOutput) {
+                serial = true;
+            }
+        }
+
+        if (serial) {
+            for (std::uint32_t k = 0; k < width; ++k) {
+                const std::uint32_t node_index = levels.level_nodes[base + k];
+                const auto e = run_routed_node(node_index, plan, bindings, assignment,
+                                               pool, midi, automation, block, in_bus,
+                                               out_bus, command_decisions, frames);
+                if (e != GraphRuntimeExecutorErrorCode::None) {
+                    return report_failure(e, node_index);
+                }
+            }
+        } else {
+            ParallelLevelTask task{
+                &plan, bindings, &assignment, &pool, midi, automation, &block,
+                in_bus, out_bus, command_decisions, frames,
+                levels.level_nodes.data() + base, &error_code, &failed_node,
+            };
+            workers.run(width, run_level_node, &task);
+            if (const std::uint32_t code = error_code.load(std::memory_order_relaxed);
+                code != 0) {
+                return report_failure(
+                    static_cast<GraphRuntimeExecutorErrorCode>(code - 1),
+                    failed_node.load(std::memory_order_relaxed));
+            }
+        }
+
+        result.nodes_processed += width;
+        nodes_processed_.fetch_add(width, std::memory_order_relaxed);
     }
 
     capture_feedback(plan, assignment, pool, frames);

--- a/core/graph/include/pulp/graph/graph_runtime_buffer_assignment.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_buffer_assignment.hpp
@@ -72,7 +72,15 @@ struct GraphRuntimeBufferAssignment {
 
 // Compute the slot layout for `plan`. Returns ok=false (and slot_count=0) only
 // on allocation failure; an empty plan yields ok=true with slot_count=0.
+//
+// `allow_reuse` (default true) is the serial layout: a scratch region is recycled
+// by strictly-later nodes once its last reader has run, minimizing slot_count.
+// Pass false for the PARALLEL executor: reuse keys on serial topological order,
+// but same-level nodes run concurrently, so a recycled slot would alias and race
+// two live values. With allow_reuse=false every node gets fresh, never-recycled
+// input/output regions (larger slot_count, but no inter-node aliasing); feedback-
+// prev and delay-ring slots are unaffected (already never recycled).
 GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
-    const GraphRuntimePlan& plan);
+    const GraphRuntimePlan& plan, bool allow_reuse = true);
 
 } // namespace pulp::graph

--- a/core/graph/src/graph_runtime_buffer_assignment.cpp
+++ b/core/graph/src/graph_runtime_buffer_assignment.cpp
@@ -55,7 +55,7 @@ private:
 } // namespace
 
 GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
-    const GraphRuntimePlan& plan) {
+    const GraphRuntimePlan& plan, bool allow_reuse) {
     GraphRuntimeBufferAssignment assignment;
     const std::size_t node_count = plan.nodes.size();
     try {
@@ -123,28 +123,32 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
             const auto& node = plan.nodes[node_index];
             auto& slots = assignment.nodes[node_index];
 
-            slots.input_base = alloc.alloc(node.input_ports);
+            // With reuse disabled (parallel layout), every region is fresh and
+            // never recycled — concurrent nodes can't alias a recycled slot.
+            slots.input_base = allow_reuse ? alloc.alloc(node.input_ports)
+                                           : alloc.alloc_fresh(node.input_ports);
             // A persistent-output node's output region must be dedicated: fresh
             // slots that no other node ever writes (see alloc_fresh). Pairs with
             // last_use == pinned below, which also keeps it from being recycled
             // by a later node.
-            slots.output_base = node.persistent_output
+            slots.output_base = (node.persistent_output || !allow_reuse)
                                     ? alloc.alloc_fresh(node.output_ports)
                                     : alloc.alloc(node.output_ports);
 
-            // Input region dies after this node runs.
-            if (node.input_ports > 0) {
-                frees_at[t].push_back({slots.input_base, node.input_ports});
-            }
-            // Output region dies after its last consumer (or never, if pinned).
-            if (node.output_ports > 0) {
-                const std::uint32_t death = last_use[node_index];
-                if (death < node_count) {
-                    frees_at[death].push_back({slots.output_base, node.output_ports});
+            if (allow_reuse) {
+                // Input region dies after this node runs.
+                if (node.input_ports > 0) {
+                    frees_at[t].push_back({slots.input_base, node.input_ports});
                 }
+                // Output region dies after its last consumer (or never, if pinned).
+                if (node.output_ports > 0) {
+                    const std::uint32_t death = last_use[node_index];
+                    if (death < node_count) {
+                        frees_at[death].push_back({slots.output_base, node.output_ports});
+                    }
+                }
+                for (const auto& f : frees_at[t]) alloc.free(f.base, f.size);
             }
-
-            for (const auto& f : frees_at[t]) alloc.free(f.base, f.size);
         }
 
         std::uint32_t cursor = alloc.high_water();

--- a/core/graph/src/graph_runtime_levelization.cpp
+++ b/core/graph/src/graph_runtime_levelization.cpp
@@ -48,11 +48,16 @@ GraphRuntimeLevelization build_graph_runtime_levelization(const GraphRuntimePlan
         for (std::uint32_t l = 0; l < result.level_count; ++l) {
             result.level_offsets[l + 1] += result.level_offsets[l];
         }
-        // Place nodes in ascending node-index order within each level (stable,
-        // deterministic) using a per-level write cursor seeded from the offsets.
+        // Place nodes within each level in PROCESSING (topological) order, not
+        // node-index order, by walking processing_order_indices. Same-level nodes
+        // are independent so a parallel executor may run them in any order, but a
+        // serial fallback for a level (e.g. one containing an AudioOutput node
+        // that accumulates into the shared bus) then iterates this slice in the
+        // exact order the serial walk would — preserving bit-identical, non-
+        // associative float accumulation.
         std::vector<std::uint32_t> cursor(result.level_offsets.begin(),
                                           result.level_offsets.end());
-        for (std::uint32_t n = 0; n < node_count; ++n) {
+        for (const auto n : plan.processing_order_indices) {
             const std::uint32_t level = result.node_level[n];
             result.level_nodes[cursor[level]++] = n;
         }

--- a/test/harness/graph_routing_harness.hpp
+++ b/test/harness/graph_routing_harness.hpp
@@ -62,10 +62,11 @@ inline std::vector<float> test_signal(int n, float seed) {
 inline bool make_snapshot(pulp::format::GraphRuntimeSnapshot& snapshot,
                           std::span<const pulp::graph::GraphRuntimeNodeSpec> nodes,
                           std::span<const pulp::graph::GraphRuntimeConnectionSpec> conns,
-                          std::span<const pulp::format::GraphRuntimeNodeBinding> bindings) {
+                          std::span<const pulp::format::GraphRuntimeNodeBinding> bindings,
+                          bool parallel_safe = false) {
     auto plan = pulp::graph::build_graph_runtime_plan(nodes, conns);
     if (!plan.ok()) return false;
-    return snapshot.reset(std::move(plan.plan), bindings);
+    return snapshot.reset(std::move(plan.plan), bindings, parallel_safe);
 }
 
 inline pulp::format::GraphRuntimeBufferPool make_pool(

--- a/test/test_graph_executor_routing.cpp
+++ b/test/test_graph_executor_routing.cpp
@@ -485,3 +485,281 @@ TEST_CASE("GraphRuntimeExecutor feedback routing path does not allocate",
         REQUIRE_FALSE(probe.saw_allocation());
     }
 }
+
+// ── Levelized parallel execution (process_parallel) ─────────────────────────
+// process_parallel must produce output bit-identical to the serial process_routed
+// path (each node owns disjoint scratch; the level barrier orders producers
+// before consumers). A wide fan-out graph puts many independent gains on one
+// level so the parallel dispatch actually runs.
+
+namespace {
+
+// in(1ch) -> N parallel gains -> out(1ch) (fan-in sum). The N gains share level 1.
+void build_wide_fanout(std::vector<GraphRuntimeNodeSpec>& nodes,
+                       std::vector<GraphRuntimeConnectionSpec>& conns,
+                       std::vector<GainState>& gains,
+                       std::vector<GraphRuntimeNodeBinding>& bindings, int n) {
+    nodes.push_back({1, GraphRuntimeNodeKind::AudioInput, 0, 1});
+    const pulp::graph::NodeId out_id = static_cast<pulp::graph::NodeId>(n + 2);
+    gains.assign(static_cast<std::size_t>(n), GainState{});
+    for (int i = 0; i < n; ++i) {
+        const auto id = static_cast<pulp::graph::NodeId>(i + 2);
+        nodes.push_back({id, GraphRuntimeNodeKind::Processor, 1, 1});
+        gains[static_cast<std::size_t>(i)].gain = 0.1f + 0.01f * static_cast<float>(i);
+        conns.push_back({1, 0, id, 0});       // in -> gain
+        conns.push_back({id, 0, out_id, 0});  // gain -> out (fan-in)
+    }
+    nodes.push_back({out_id, GraphRuntimeNodeKind::AudioOutput, 1, 0});
+    bindings.push_back({1, nullptr, nullptr, false});
+    for (int i = 0; i < n; ++i) {
+        bindings.push_back({static_cast<pulp::graph::NodeId>(i + 2), routing_gain,
+                            &gains[static_cast<std::size_t>(i)], true});
+    }
+    bindings.push_back({out_id, nullptr, nullptr, false});
+}
+
+} // namespace
+
+TEST_CASE("Parallel routing matches the serial routed path: wide fan-out",
+          "[format][graph][executor][routing][parallel]") {
+    constexpr int kFrames = 64;
+    std::vector<GraphRuntimeNodeSpec> nodes;
+    std::vector<GraphRuntimeConnectionSpec> conns;
+    std::vector<GainState> gains;
+    std::vector<GraphRuntimeNodeBinding> bindings;
+    build_wide_fanout(nodes, conns, gains, bindings, /*n=*/16);
+
+    // Serial uses the compact (reuse) layout; parallel uses the reuse-free
+    // layout. Comparing their outputs also proves both layouts compute identically.
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings));
+    GraphRuntimeSnapshot psnapshot;
+    REQUIRE(make_snapshot(psnapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(psnapshot.plan());
+    REQUIRE(levels.ok);
+
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.8f)};
+    GraphRuntimeExecutor exec;
+
+    auto pool_serial = make_pool(snapshot, kFrames);
+    RoutedHarness serial(kSr, kFrames, in, 1);
+    REQUIRE(serial.run(exec, snapshot, pool_serial).ok());
+
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+    auto pool_parallel = make_pool(psnapshot, kFrames);
+    RoutedHarness par(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(par.block, psnapshot, levels, pool_parallel, workers).ok());
+    workers.stop();
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(serial.outs[0][static_cast<std::size_t>(i)] ==
+                par.outs[0][static_cast<std::size_t>(i)]);
+    }
+}
+
+TEST_CASE("Parallel routing matches the serial routed path: multi-output mixing",
+          "[format][graph][executor][routing][parallel]") {
+    constexpr int kFrames = 64;
+    // Two AudioOutput nodes accumulate into the same bus — they must run serially
+    // in the parallel path (their level is forced serial). Output must still match.
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 1},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+        GraphRuntimeNodeSpec{5, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0}, GraphRuntimeConnectionSpec{1, 0, 3, 0},
+        GraphRuntimeConnectionSpec{2, 0, 4, 0}, GraphRuntimeConnectionSpec{3, 0, 5, 0},
+    };
+    GainState g2{0.5f}, g3{0.25f};
+    const std::array bindings = {
+        GraphRuntimeNodeBinding{1, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{2, routing_gain, &g2, true},
+        GraphRuntimeNodeBinding{3, routing_gain, &g3, true},
+        GraphRuntimeNodeBinding{4, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{5, nullptr, nullptr, false},
+    };
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings));
+    GraphRuntimeSnapshot psnapshot;
+    REQUIRE(make_snapshot(psnapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(psnapshot.plan());
+    REQUIRE(levels.ok);
+
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.6f)};
+    GraphRuntimeExecutor exec;
+    auto pool_serial = make_pool(snapshot, kFrames);
+    RoutedHarness serial(kSr, kFrames, in, 1);
+    REQUIRE(serial.run(exec, snapshot, pool_serial).ok());
+
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+    auto pool_parallel = make_pool(psnapshot, kFrames);
+    RoutedHarness par(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(par.block, psnapshot, levels, pool_parallel, workers).ok());
+    workers.stop();
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(serial.outs[0][static_cast<std::size_t>(i)] ==
+                par.outs[0][static_cast<std::size_t>(i)]);
+    }
+}
+
+TEST_CASE("Parallel routing is allocation-free on the audio thread",
+          "[format][graph][executor][routing][parallel][rt-safety]") {
+    constexpr int kFrames = 64;
+    std::vector<GraphRuntimeNodeSpec> nodes;
+    std::vector<GraphRuntimeConnectionSpec> conns;
+    std::vector<GainState> gains;
+    std::vector<GraphRuntimeNodeBinding> bindings;
+    build_wide_fanout(nodes, conns, gains, bindings, /*n=*/16);
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(snapshot.plan());
+    auto pool = make_pool(snapshot, kFrames);
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.8f)};
+    GraphRuntimeExecutor exec;
+    {
+        RoutedHarness warm(kSr, kFrames, in, 1);
+        REQUIRE(exec.process_parallel(warm.block, snapshot, levels, pool, workers).ok());
+    }
+    {
+        RoutedHarness h(kSr, kFrames, in, 1);
+        pulp::test::RtAllocationProbe probe;
+        REQUIRE(exec.process_parallel(h.block, snapshot, levels, pool, workers).ok());
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
+    workers.stop();
+}
+
+TEST_CASE("Parallel routing matches serial: 3 sinks accumulate in topo order",
+          "[format][graph][executor][routing][parallel]") {
+    // Three AudioOutput nodes sum into the same output channel at one level. The
+    // serial-fallback for that level must accumulate in the SAME order the serial
+    // walk does (processing order), or non-associative float += diverges. The
+    // gains feeding the sinks are wired highest-id-first so processing order is
+    // NOT ascending node-index — exercising the ordering guarantee.
+    constexpr int kFrames = 64;
+    // ids: in=1; gains 2,3,4; sinks 5,6,7. Wire in->gain edges in REVERSE so the
+    // sink fed by the highest-id gain is processed first.
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 1},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{5, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+        GraphRuntimeNodeSpec{6, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+        GraphRuntimeNodeSpec{7, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 4, 0},  // in -> g4 (readied first)
+        GraphRuntimeConnectionSpec{1, 0, 3, 0},
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},
+        GraphRuntimeConnectionSpec{4, 0, 7, 0},  // g4 -> sink7
+        GraphRuntimeConnectionSpec{3, 0, 6, 0},
+        GraphRuntimeConnectionSpec{2, 0, 5, 0},
+    };
+    // Order-sensitive gains: a large term and two small ones so (a+b)+c float-
+    // differs from a different order.
+    GainState g2{1.0f}, g3{1.0e7f}, g4{1.0f};
+    const std::array bindings = {
+        GraphRuntimeNodeBinding{1, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{2, routing_gain, &g2, true},
+        GraphRuntimeNodeBinding{3, routing_gain, &g3, true},
+        GraphRuntimeNodeBinding{4, routing_gain, &g4, true},
+        GraphRuntimeNodeBinding{5, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{6, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{7, nullptr, nullptr, false},
+    };
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings));
+    GraphRuntimeSnapshot psnapshot;
+    REQUIRE(make_snapshot(psnapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(psnapshot.plan());
+    REQUIRE(levels.ok);
+
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.9f)};
+    GraphRuntimeExecutor exec;
+    auto pool_serial = make_pool(snapshot, kFrames);
+    RoutedHarness serial(kSr, kFrames, in, 1);
+    REQUIRE(serial.run(exec, snapshot, pool_serial).ok());
+
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+    auto pool_parallel = make_pool(psnapshot, kFrames);
+    RoutedHarness par(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(par.block, psnapshot, levels, pool_parallel, workers).ok());
+    workers.stop();
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(serial.outs[0][static_cast<std::size_t>(i)] ==
+                par.outs[0][static_cast<std::size_t>(i)]);
+    }
+}
+
+TEST_CASE("Parallel routing matches serial: deep and wide (two parallel levels)",
+          "[format][graph][executor][routing][parallel]") {
+    // in -> A[0..3] -> B[0..3] -> out. A is level 1 (parallel), B is level 2
+    // (parallel), out level 3. Exercises two consecutive parallel levels and the
+    // cross-level barrier (level-1 writes visible to level-2 workers).
+    constexpr int kFrames = 64;
+    constexpr int kW = 4;
+    std::vector<GraphRuntimeNodeSpec> nodes;
+    std::vector<GraphRuntimeConnectionSpec> conns;
+    nodes.push_back({1, GraphRuntimeNodeKind::AudioInput, 0, 1});
+    const auto out_id = static_cast<pulp::graph::NodeId>(2 + 2 * kW);
+    for (int i = 0; i < kW; ++i) {
+        const auto a = static_cast<pulp::graph::NodeId>(2 + i);
+        const auto b = static_cast<pulp::graph::NodeId>(2 + kW + i);
+        nodes.push_back({a, GraphRuntimeNodeKind::Processor, 1, 1});
+        nodes.push_back({b, GraphRuntimeNodeKind::Processor, 1, 1});
+        conns.push_back({1, 0, a, 0});       // in -> A[i]
+        conns.push_back({a, 0, b, 0});       // A[i] -> B[i]
+        conns.push_back({b, 0, out_id, 0});  // B[i] -> out (fan-in)
+    }
+    nodes.push_back({out_id, GraphRuntimeNodeKind::AudioOutput, 1, 0});
+
+    std::vector<GainState> gains(static_cast<std::size_t>(2 * kW));
+    std::vector<GraphRuntimeNodeBinding> bindings;
+    bindings.push_back({1, nullptr, nullptr, false});
+    for (int i = 0; i < kW; ++i) {
+        gains[static_cast<std::size_t>(2 * i)].gain = 0.3f + 0.01f * static_cast<float>(i);
+        gains[static_cast<std::size_t>(2 * i + 1)].gain = 0.5f - 0.02f * static_cast<float>(i);
+        bindings.push_back({static_cast<pulp::graph::NodeId>(2 + i), routing_gain,
+                            &gains[static_cast<std::size_t>(2 * i)], true});
+        bindings.push_back({static_cast<pulp::graph::NodeId>(2 + kW + i), routing_gain,
+                            &gains[static_cast<std::size_t>(2 * i + 1)], true});
+    }
+    bindings.push_back({out_id, nullptr, nullptr, false});
+
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings));
+    GraphRuntimeSnapshot psnapshot;
+    REQUIRE(make_snapshot(psnapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(psnapshot.plan());
+    REQUIRE(levels.ok);
+    REQUIRE(levels.level_count == 4);  // in / A / B / out
+
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.7f)};
+    GraphRuntimeExecutor exec;
+    auto pool_serial = make_pool(snapshot, kFrames);
+    RoutedHarness serial(kSr, kFrames, in, 1);
+    REQUIRE(serial.run(exec, snapshot, pool_serial).ok());
+
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+    auto pool_parallel = make_pool(psnapshot, kFrames);
+    RoutedHarness par(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(par.block, psnapshot, levels, pool_parallel, workers).ok());
+    workers.stop();
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(serial.outs[0][static_cast<std::size_t>(i)] ==
+                par.outs[0][static_cast<std::size_t>(i)]);
+    }
+}

--- a/test/test_graph_runtime_buffer_assignment.cpp
+++ b/test/test_graph_runtime_buffer_assignment.cpp
@@ -313,3 +313,44 @@ TEST_CASE("Buffer assignment reports no delay when no node adds latency",
     CHECK_FALSE(a.has_delay);
     for (const auto d : a.connection_delay_samples) CHECK(d == 0u);
 }
+
+TEST_CASE("Buffer assignment with reuse disabled gives every node disjoint regions",
+          "[graph][buffer-assignment][parallel]") {
+    // The parallel layout (allow_reuse=false) must never share a scratch slot
+    // between two nodes — concurrent same-level nodes would otherwise alias it.
+    // Diamond: in -> {g1, g2} -> out (g1/g2 are an independent parallel pair).
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 2},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 2, 2},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 2, 2},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::AudioOutput, 2, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0}, GraphRuntimeConnectionSpec{1, 1, 2, 1},
+        GraphRuntimeConnectionSpec{1, 0, 3, 0}, GraphRuntimeConnectionSpec{1, 1, 3, 1},
+        GraphRuntimeConnectionSpec{2, 0, 4, 0}, GraphRuntimeConnectionSpec{2, 1, 4, 1},
+        GraphRuntimeConnectionSpec{3, 0, 4, 0}, GraphRuntimeConnectionSpec{3, 1, 4, 1},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto a = build_graph_runtime_buffer_assignment(plan.plan, /*allow_reuse=*/false);
+    check_invariants(plan.plan, a);
+
+    // Mark every slot each node's input/output region occupies; no slot may be
+    // claimed by two distinct regions (across all nodes).
+    std::vector<int> used(a.slot_count, 0);
+    for (std::size_t i = 0; i < plan.plan.nodes.size(); ++i) {
+        const auto& node = plan.plan.nodes[i];
+        const auto& s = a.nodes[i];
+        for (std::uint32_t p = 0; p < node.input_ports; ++p) ++used[s.input_base + p];
+        for (std::uint32_t p = 0; p < node.output_ports; ++p) ++used[s.output_base + p];
+    }
+    for (const auto u : used) CHECK(u <= 1);  // no slot shared by two regions
+
+    // Reuse-free slot_count is exactly the sum of every node's port regions.
+    CHECK(a.slot_count == total_ports(nodes));
+
+    // The compact (reuse) layout for the same graph uses strictly fewer slots.
+    const auto reuse = build_graph_runtime_buffer_assignment(plan.plan, /*allow_reuse=*/true);
+    CHECK(reuse.slot_count < a.slot_count);
+}


### PR DESCRIPTION
Phase-5 slice 5b-3. Adds `GraphRuntimeExecutor::process_parallel` — runs each topological level's independent nodes concurrently across the persistent worker pool (audio thread = participant 0), barriered between levels, behind the canonical seam (**default-OFF; no SignalGraph caller yet**). Output is **bit-identical** to the serial `process_routed` path.

## What
- Extracted the per-node body into `run_routed_node`, shared by `process_routed` and `process_parallel` so both compute identically by construction (the 41-case serial parity suite guards the extraction).
- **Bit-exact parallelism:** every node owns disjoint scratch via a new **reuse-free** buffer-assignment mode (`build_graph_runtime_buffer_assignment(plan, allow_reuse=false)`; `GraphRuntimeSnapshot::reset(..., parallel_safe=true)`). The serial reuse layout recycles slots in topo order, so concurrent same-level nodes would alias a recycled slot — **this exact race was caught by TSan on the first draft**. `process_parallel` refuses a non-parallel-safe snapshot. Fan-in sums stay single-threaded in connection order; the level barrier orders producers before consumers.
- **AudioOutput** accumulates into the shared output bus, so any level containing one runs **serially, in processing (topo) order** — matching the serial walk's non-associative float accumulation. The levelization now orders nodes within each level in processing order for this reason (**an adversarial review caught** that node-index order diverges for 3+ sinks on a channel — MUST-FIX, fixed + regression-tested).

## Tests (bit-exact vs `process_routed`, TSan-clean 5×, RT no-alloc)
wide fan-out (one parallel level), multi-output mixing, **3-sink topo-order accumulation**, **deep + wide (two consecutive parallel levels)**, and the reuse-free assignment's pairwise-disjoint-regions invariant.

Adversarially reviewed (concurrency + bit-exactness): aliasing, cross-level happens-before, AudioOutput serialization, and error propagation all confirmed correct; the one MUST-FIX (accumulation order) is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds levelized parallel graph execution via `GraphRuntimeExecutor::process_parallel`, dispatching independent nodes per topological level across the worker pool with barriers. Output is bit-identical to `process_routed`, and parallel safety is opt-in via a reuse-free buffer layout.

- **New Features**
  - `process_parallel`: runs each level across `GraphRuntimeWorkerPool` (audio thread is participant 0); levels with `AudioOutput` or width 1 run serially; fan-in sums remain single-threaded.
  - Shared per-node seam `run_routed_node` is used by both serial and parallel paths to guarantee identical results.
  - Opt-in parallel-safe snapshots: `GraphRuntimeSnapshot::reset(..., parallel_safe=true)` and `parallel_safe()`; parallel path rejects reused layouts.
  - Buffer layout API: `build_graph_runtime_buffer_assignment(plan, allow_reuse=false)` gives disjoint slots for parallel runs.
  - Levelization now orders nodes within a level by processing order to preserve `AudioOutput` accumulation order.

- **Migration**
  - Default behavior stays serial.
  - To use parallel:
    - Build the snapshot with `parallel_safe=true`.
    - Build `graph::build_graph_runtime_levelization(plan)` for the same plan.
    - Start a `GraphRuntimeWorkerPool`, then call `process_parallel(...)`.
  - Existing calls to `build_graph_runtime_buffer_assignment` are unchanged; `allow_reuse` defaults to `true`.

<sup>Written for commit be42c4aab61255c59457e0e576db346bea68147a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

