### PR TITLE
feat(host): opt-in levelized parallel graph execution in SignalGraph::process

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -170,6 +170,31 @@ predictable output, no MIDI.
   and built into the same per-node event queue. A node exceeding
   `kMaxParamsPerNode` (64) distinct sparse OR dense params is kept on the legacy
   walk.
+- **Parallel-executor routing (opt-in, default OFF, independent of the serial
+  opt-in).** `set_parallel_routing_enabled(true)` drives the SAME eligible subset
+  through `GraphRuntimeExecutor::process_parallel` — a levelized fork-join over a
+  persistent `GraphRuntimeWorkerPool` (the audio thread is participant 0). Output
+  is bit-identical to the serial executor and the legacy walk; the per-node body
+  (`run_routed_node`) is shared. Dispatch order in `process()`: parallel (if
+  enabled + valid + pool running + fits) → serial executor (if its toggle on) →
+  legacy walk. The two routed branches share one `dispatch_routed` bridge, and
+  every executor zeroes the output bus + the MIDI ingress is idempotent (consumed
+  mailbox sequences aren't committed until `run()` succeeds), so a failed parallel
+  attempt re-renders the block on a lower tier with no doubled output or
+  double-consumed MIDI. GOTCHAS: (1) the parallel snapshot uses a REUSE-FREE
+  buffer assignment (`parallel_safe=true`) — concurrent same-level nodes must not
+  alias a recycled scratch slot; `process_parallel` refuses a non-parallel-safe
+  snapshot. (2) Levels containing an AudioOutput node run SERIALLY in topo order
+  (AudioOutput `+=` accumulates into the shared output bus; float add is
+  non-associative, so order is load-bearing for ≥3 sinks). (3) WORKER-POOL
+  LIFECYCLE is load-bearing: the pool is started ONCE (size = clamped hardware
+  concurrency, guarded by `worker_count() == 0`) and NEVER stopped/resized on a
+  re-prepare — `start()`/`stop()` join threads + reset the epoch/completion
+  counters, a UAF if run against an in-flight audio `run()`. The only legal stop
+  is `~GraphRuntimeWorkerPool` at SignalGraph destruction. Don't make the thread
+  count runtime-variable without a drain handshake. The pool's completion barrier
+  counts PARTICIPANTS finished (not tasks): an empty-range participant must still
+  register done, or it can race the next batch's published state.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.483.0
+    VERSION 0.484.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/graph_runtime_worker_pool.cpp
+++ b/core/format/src/graph_runtime_worker_pool.cpp
@@ -82,8 +82,15 @@ void GraphRuntimeWorkerPool::run(std::uint32_t task_count, TaskFn fn,
            "GraphRuntimeWorkerPool::run() is not re-entrant and must not run concurrently");
 
     // Publish the batch, then release it to the parked workers via the epoch.
-    // completed_ is monotonic: this batch is done when it reaches base + count.
-    const std::uint64_t target = completed_base_ + task_count;
+    // completed_ counts PARTICIPANTS finished (not tasks): every participant —
+    // including one handed an empty range — bumps it by 1 after it has read the
+    // published batch (task_count_/fn_/context_) in run_range. Waiting for all
+    // worker_count_ participants therefore guarantees no straggler is still
+    // reading those members when the next batch overwrites them. (Counting tasks
+    // instead lets an empty-range worker's +0 go un-awaited, so it could still be
+    // reading task_count_ as the next run() writes it — a data race.) completed_
+    // is monotonic across batches; this one is done at base + worker_count_.
+    const std::uint64_t target = completed_base_ + worker_count_;
     fn_ = fn;
     context_ = context;
     task_count_ = task_count;
@@ -92,7 +99,7 @@ void GraphRuntimeWorkerPool::run(std::uint32_t task_count, TaskFn fn,
     // The caller is participant 0.
     run_range(0);
 
-    // Spin until every participant has added its range (all task writes are then
+    // Spin until every participant has registered done (all task writes are then
     // visible via the completed_ acquire/release barrier).
     // `< target` (not `!=`): completed_ reaches target exactly, but a `<` guard
     // can never deadlock the spin if the count ever overshoots.
@@ -118,7 +125,10 @@ void GraphRuntimeWorkerPool::run_range(std::uint32_t worker_index) noexcept {
     for (std::uint32_t i = r.begin; i < r.end; ++i) {
         fn_(context_, i);
     }
-    completed_.fetch_add(r.end - r.begin, std::memory_order_acq_rel);
+    // +1 per participant (see run()): the barrier counts participants finished,
+    // so even an empty range must register that this worker is done reading the
+    // published batch and writing its tasks.
+    completed_.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void GraphRuntimeWorkerPool::worker_loop(std::uint32_t worker_index) noexcept {

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -446,6 +446,22 @@ public:
         return canonical_executor_routing_enabled_.load(std::memory_order_relaxed);
     }
 
+    // Opt into the LEVELIZED PARALLEL executor for eligible graphs (default OFF,
+    // independent of the serial executor opt-in). Enable BEFORE prepare(): the
+    // parallel-safe routing snapshot + levelization are built at compile time and
+    // the worker pool is started there, so flipping this on after prepare() has
+    // no effect until the next prepare(). When enabled + eligible + the pool is
+    // running + the parallel pool fits the block, process() routes through
+    // GraphRuntimeExecutor::process_parallel; otherwise it falls back to the
+    // serial executor (if its opt-in is set) and then the legacy walk. Output is
+    // bit-identical across all three paths.
+    void set_parallel_routing_enabled(bool enabled) noexcept {
+        parallel_routing_enabled_.store(enabled, std::memory_order_relaxed);
+    }
+    bool parallel_routing_enabled() const noexcept {
+        return parallel_routing_enabled_.load(std::memory_order_relaxed);
+    }
+
     RuntimeBudgetReport evaluate_optional_runtime_budget(
         runtime::RuntimeBudgetFrame& frame,
         runtime::RuntimeWorkLane lane = runtime::RuntimeWorkLane::Background,
@@ -697,6 +713,20 @@ private:
         // sparse automation, owned per-snapshot like exec_pool. Empty (node_count
         // 0) for graphs with no sparse automation.
         format::GraphRuntimeAutomationScratch routing_automation;
+
+        // Levelized PARALLEL routing for this snapshot (built only when parallel
+        // routing is enabled at compile time). Same plan as routing_snapshot but
+        // with a reuse-free buffer assignment (parallel_safe) so concurrent
+        // same-level nodes never alias a slot, plus its own (larger) scratch pool
+        // and the static level schedule. The MIDI/automation scratch and the
+        // MidiInput/Output node lists above are SHARED (identical plan; only ONE
+        // path runs per block). routing_plugin_ctx_parallel holds the parallel
+        // snapshot's Plugin bindings' stable user_data.
+        format::GraphRuntimeSnapshot routing_snapshot_parallel;
+        format::GraphRuntimeBufferPool exec_pool_parallel;
+        graph::GraphRuntimeLevelization routing_levelization;
+        std::vector<PluginBindingContext> routing_plugin_ctx_parallel;
+        bool routing_parallel_valid = false;
     };
 
     std::vector<GraphNode> nodes_;
@@ -721,6 +751,13 @@ private:
     // so it rides the existing RCU lifetime and is never resized under a reader.
     std::atomic<bool> canonical_executor_routing_enabled_{false};
     format::GraphRuntimeExecutor executor_;
+    // Levelized parallel routing opt-in + its persistent worker pool. The pool is
+    // a long-lived SignalGraph member (NOT per-RCU-snapshot): started off-RT in
+    // compile_() when parallel routing is enabled, joined in the destructor. The
+    // parallel-safe snapshot + levelization + scratch pool ride the CompiledGraph
+    // (see CompiledGraph::routing_*_parallel).
+    std::atomic<bool> parallel_routing_enabled_{false};
+    format::GraphRuntimeWorkerPool worker_pool_;
     std::atomic<std::uint32_t> active_process_readers_{0};
     std::atomic<int64_t> total_latency_samples_{0};  // reflected for const-query access
     std::atomic<std::size_t> prepared_node_count_{0};

--- a/core/host/include/pulp/host/signal_graph_executor_routing.hpp
+++ b/core/host/include/pulp/host/signal_graph_executor_routing.hpp
@@ -87,13 +87,17 @@ bool signal_graph_executor_eligible(const SignalGraph& graph);
 // leaves `out` empty) if the topology is not eligible, a Gain atomic or Plugin
 // slot is missing, or the canonical plan/snapshot cannot be built under its
 // limits. Does NOT size a pool or set a keepalive — the caller owns those.
+// `parallel_safe` builds the snapshot's buffer assignment without slot reuse so
+// it can drive GraphRuntimeExecutor::process_parallel (concurrent same-level
+// nodes never alias a recycled slot); default false = the compact serial layout.
 bool build_executor_snapshot(std::span<const GraphNode> nodes,
                              std::span<const Connection> connections,
                              const std::function<std::atomic<float>*(NodeId)>& gain_for,
                              const std::function<PluginSlot*(NodeId)>& plugin_for,
                              std::vector<PluginBindingContext>& plugin_ctx,
                              PluginRoutingScratch& scratch,
-                             format::GraphRuntimeSnapshot& out);
+                             format::GraphRuntimeSnapshot& out,
+                             bool parallel_safe = false);
 
 // Translate a prepared, eligible `graph` into `out` (snapshot + sized pool +
 // keepalive). Returns false (out.valid == false) when ineligible/unprepared. On

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1212,6 +1212,67 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
                     plan, static_cast<std::uint32_t>(max_block_size));
             }
         }
+
+        // Levelized parallel routing: when enabled (at this prepare), build a
+        // PARALLEL-SAFE (reuse-free) snapshot of the same eligible graph + its
+        // levelization + a dedicated scratch pool, and ensure the persistent
+        // worker pool is running. The MIDI/automation scratch and MidiInput/Output
+        // node lists are SHARED with the serial path (identical plan). On any
+        // failure the parallel path stays invalid and process() falls back.
+        cg->routing_parallel_valid = false;
+        if (cg->routing_valid && parallel_routing_enabled_.load(std::memory_order_relaxed) &&
+            max_block_size > 0) {
+            CompiledGraph& cgr = *cg;
+            bool ok = build_executor_snapshot(
+                nodes_, connections_,
+                [&cgr](NodeId id) -> std::atomic<float>* {
+                    auto it = cgr.runtime.find(id);
+                    return it == cgr.runtime.end() ? nullptr : it->second.gain.get();
+                },
+                [&cgr](NodeId id) -> PluginSlot* {
+                    auto it = cgr.plugins.find(id);
+                    return it == cgr.plugins.end() ? nullptr : it->second.get();
+                },
+                cg->routing_plugin_ctx_parallel, cg->routing_plugin_scratch,
+                cg->routing_snapshot_parallel, /*parallel_safe=*/true);
+            if (ok) {
+                cg->routing_levelization = graph::build_graph_runtime_levelization(
+                    cg->routing_snapshot_parallel.plan());
+                ok = cg->routing_levelization.ok &&
+                     cg->exec_pool_parallel.reset(
+                         cg->routing_snapshot_parallel.buffer_slot_count(),
+                         static_cast<std::uint32_t>(max_block_size),
+                         cg->routing_snapshot_parallel.buffer_assignment()
+                             .connection_delay_samples);
+            }
+            if (ok) {
+                // Start the persistent worker pool off the audio thread, ONCE.
+                // Hardware concurrency capped to a sane bound; participant 0 is
+                // the audio thread, so the pool spawns worker_count - 1 threads.
+                //
+                // INVARIANT (load-bearing for audio-thread safety): the pool size
+                // is fixed for the SignalGraph's lifetime and the pool is never
+                // stopped/resized on a re-prepare. start()/stop() join worker
+                // threads and reset epoch_/completed_/worker_count_; running them
+                // concurrently with an in-flight process_parallel -> run() on the
+                // audio thread would be a use-after-free. The only legal stop is
+                // ~GraphRuntimeWorkerPool during ~SignalGraph, after the audio
+                // thread has (by contract) stopped calling process(). So: start
+                // only when not yet started (worker_count() == 0 — also retries a
+                // previously failed start, safe because routing_parallel_valid was
+                // false so process() never entered the parallel branch). A re-
+                // prepare just re-checks running(); it must not restart the pool.
+                if (worker_pool_.worker_count() == 0) {
+                    const unsigned hw = std::thread::hardware_concurrency();
+                    const std::uint32_t workers =
+                        std::clamp<std::uint32_t>(hw == 0 ? 2 : hw, 2, 16);
+                    ok = worker_pool_.start(workers);
+                } else {
+                    ok = worker_pool_.running();
+                }
+            }
+            cg->routing_parallel_valid = ok;
+        }
     }
     return cg;
 }
@@ -1512,62 +1573,59 @@ void SignalGraph::process(audio::BufferView<float>& output,
         return;
     }
 
-    // Canonical-executor path (opt-in): for an eligible snapshot, route the
-    // block through GraphRuntimeExecutor instead of the legacy walk. The
-    // executor zeroes the output bus and accumulates AudioOutput itself, so this
-    // returns before the legacy zero+walk below. The dispatch stays inside the
-    // ProcessReadGuard, so `cg` (and its routing snapshot + gain atomics) is
-    // pinned for the whole routed call.
-    if (canonical_executor_routing_enabled_.load(std::memory_order_relaxed) &&
-        cg->routing_valid &&
-        cg->exec_pool.fits(cg->routing_snapshot, static_cast<std::uint32_t>(num_samples))) {
+    // Routed dispatch (opt-in): try the levelized PARALLEL executor first (if
+    // enabled), then the SERIAL executor, then fall through to the legacy walk.
+    // Both routed paths run GraphRuntimeExecutor (which zeroes the output bus and
+    // accumulates AudioOutput itself, so a successful routed call returns before
+    // the legacy zero+walk below) and SHARE the MIDI mailbox bridge (the MIDI
+    // scratch + MidiInput/Output node lists are shared — identical plan). The
+    // dispatch stays inside the ProcessReadGuard, so `cg` (snapshots, pools, gain
+    // atomics) is pinned for the whole call. Output is bit-identical across paths.
+    {
+        const auto frames32 = static_cast<std::uint32_t>(num_samples);
+        const bool has_midi = cg->routing_midi.node_count() > 0;
+        const bool has_automation = cg->routing_automation.node_count() > 0;
+
         pulp::format::BusBufferSet buses;
-        if (buses.add_input("main", input, pulp::format::BusRole::Main) &&
-            buses.add_output("main", output, pulp::format::BusRole::Main)) {
+        const bool buses_ok =
+            buses.add_input("main", input, pulp::format::BusRole::Main) &&
+            buses.add_output("main", output, pulp::format::BusRole::Main);
+        if (buses_ok) {
             pulp::format::ProcessBlock block;
             block.sample_rate = cg->sample_rate;
-            block.frame_count = static_cast<std::uint32_t>(num_samples);
+            block.frame_count = frames32;
             block.buses = &buses;
 
-            const bool has_midi = cg->routing_midi.node_count() > 0;
-            // Bridge MIDI ingress: copy each MidiInput node's freshly-injected
-            // mailbox snapshot into its routed MIDI-output buffer (the same
-            // unseen-sequence dedup the legacy walk applies), so the executor's
-            // MIDI gather sees it. The executor never touches a node's MIDI
-            // output, so this pre-fill survives the walk. The consumed sequence
-            // is captured in `pending_seq` and committed to
-            // midi_input_sequence_seen only after the dispatch succeeds — a
-            // fallback to the legacy walk must re-consume the same block.
-            if (has_midi) {
-                for (auto& mi : cg->routing_midi_inputs) {
-                    mi.pending_seq = 0;
-                    midi::MidiBuffer* out_buf = cg->routing_midi.out(mi.plan_index);
-                    if (out_buf == nullptr) continue;
-                    clear_midi_block(*out_buf);
-                    cg->routing_midi.set_out_incomplete(mi.plan_index, false);
-                    auto rt_it = cg->runtime.find(mi.id);
-                    if (rt_it == cg->runtime.end() || !rt_it->second.midi_input_mailbox) {
-                        continue;
-                    }
-                    const auto& injected = rt_it->second.midi_input_mailbox->published.read();
-                    if (injected.sequence != 0 &&
-                        injected.sequence != rt_it->second.midi_input_sequence_seen) {
-                        cg->routing_midi.set_out_incomplete(
-                            mi.plan_index, !injected.copy_to_midi(*out_buf));
-                        mi.pending_seq = injected.sequence;
+            // Run one routed path with the shared MIDI mailbox bridge around it.
+            // `run` returns the executor result; this returns true iff routing
+            // succeeded (took the path). On failure the consumed MIDI sequences
+            // are NOT committed, so a fallback path re-consumes the same block.
+            auto dispatch_routed = [&](auto&& run) -> bool {
+                if (!block.validate()) return false;
+                if (has_midi) {
+                    for (auto& mi : cg->routing_midi_inputs) {
+                        mi.pending_seq = 0;
+                        midi::MidiBuffer* out_buf = cg->routing_midi.out(mi.plan_index);
+                        if (out_buf == nullptr) continue;
+                        clear_midi_block(*out_buf);
+                        cg->routing_midi.set_out_incomplete(mi.plan_index, false);
+                        auto rt_it = cg->runtime.find(mi.id);
+                        if (rt_it == cg->runtime.end() ||
+                            !rt_it->second.midi_input_mailbox) {
+                            continue;
+                        }
+                        const auto& injected =
+                            rt_it->second.midi_input_mailbox->published.read();
+                        if (injected.sequence != 0 &&
+                            injected.sequence != rt_it->second.midi_input_sequence_seen) {
+                            cg->routing_midi.set_out_incomplete(
+                                mi.plan_index, !injected.copy_to_midi(*out_buf));
+                            mi.pending_seq = injected.sequence;
+                        }
                     }
                 }
-            }
-
-            const bool has_automation = cg->routing_automation.node_count() > 0;
-            if (block.validate() &&
-                executor_.process_routed(
-                    block, cg->routing_snapshot, cg->exec_pool,
-                    has_midi ? &cg->routing_midi : nullptr,
-                    has_automation ? &cg->routing_automation : nullptr).ok()) {
+                if (!run().ok()) return false;
                 if (has_midi) {
-                    // Commit the consumed mailbox sequences now that routing
-                    // succeeded.
                     for (const auto& mi : cg->routing_midi_inputs) {
                         if (mi.pending_seq == 0) continue;
                         auto rt_it = cg->runtime.find(mi.id);
@@ -1575,9 +1633,6 @@ void SignalGraph::process(audio::BufferView<float>& output,
                             rt_it->second.midi_input_sequence_seen = mi.pending_seq;
                         }
                     }
-                    // Bridge MIDI egress: publish each MidiOutput node's gathered
-                    // routed MIDI-input buffer to its mailbox for extract_midi(),
-                    // carrying the same incompleteness the legacy walk reports.
                     for (const auto& mo : cg->routing_midi_outputs) {
                         midi::MidiBuffer* in_buf = cg->routing_midi.in(mo.plan_index);
                         auto rt_it = cg->runtime.find(mo.id);
@@ -1590,10 +1645,47 @@ void SignalGraph::process(audio::BufferView<float>& output,
                         rt_it->second.midi_output_mailbox->write(cg->midi_publish_scratch);
                     }
                 }
-                return;
+                return true;
+            };
+
+            // worker_pool_.running() is a plain flag read here; it is safe without
+            // a drain handshake only because running_ is flipped false exactly
+            // once, by ~GraphRuntimeWorkerPool, when no audio-thread reader exists
+            // (see the compile_ start invariant). Each dispatch is idempotent: it
+            // re-clears the MIDI ingress buffers and does not commit consumed
+            // sequences until run() succeeds, and every executor zeroes the output
+            // bus before accumulating — so a parallel attempt that returns false
+            // (a node failed, or it does not fit) can fall through to the serial
+            // executor and then the legacy walk re-rendering the same block with
+            // no double-consumed MIDI and no doubled output.
+            if (parallel_routing_enabled_.load(std::memory_order_relaxed) &&
+                cg->routing_parallel_valid && worker_pool_.running() &&
+                cg->exec_pool_parallel.fits(cg->routing_snapshot_parallel, frames32)) {
+                if (dispatch_routed([&] {
+                        return executor_.process_parallel(
+                            block, cg->routing_snapshot_parallel,
+                            cg->routing_levelization, cg->exec_pool_parallel,
+                            worker_pool_, has_midi ? &cg->routing_midi : nullptr,
+                            has_automation ? &cg->routing_automation : nullptr);
+                    })) {
+                    return;
+                }
+            }
+
+            if (canonical_executor_routing_enabled_.load(std::memory_order_relaxed) &&
+                cg->routing_valid &&
+                cg->exec_pool.fits(cg->routing_snapshot, frames32)) {
+                if (dispatch_routed([&] {
+                        return executor_.process_routed(
+                            block, cg->routing_snapshot, cg->exec_pool,
+                            has_midi ? &cg->routing_midi : nullptr,
+                            has_automation ? &cg->routing_automation : nullptr);
+                    })) {
+                    return;
+                }
             }
         }
-        // Any setup failure falls through to the legacy walk (safe).
+        // Any setup failure / disabled path falls through to the legacy walk.
     }
 
     // Clear the final destination; AudioOutput nodes accumulate into it.

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -209,7 +209,8 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
                              const std::function<PluginSlot*(NodeId)>& plugin_for,
                              std::vector<PluginBindingContext>& plugin_ctx,
                              PluginRoutingScratch& scratch,
-                             fmt::GraphRuntimeSnapshot& out) {
+                             fmt::GraphRuntimeSnapshot& out,
+                             bool parallel_safe) {
     out.clear();
     plugin_ctx.clear();
     if (!signal_graph_topology_executor_eligible(nodes, connections)) return false;
@@ -353,7 +354,7 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
         }
     }
 
-    return out.reset(std::move(plan.plan), bindings);
+    return out.reset(std::move(plan.plan), bindings, parallel_safe);
 }
 
 bool build_signal_graph_executor_routing(const SignalGraph& graph,

--- a/test/test_graph_runtime_worker_pool.cpp
+++ b/test/test_graph_runtime_worker_pool.cpp
@@ -10,6 +10,7 @@
 #include <pulp/format/graph_runtime_worker_pool.hpp>
 
 #include <atomic>
+#include <thread>
 #include <cstdint>
 #include <numeric>
 #include <vector>
@@ -145,4 +146,62 @@ TEST_CASE("WorkerPool stop is idempotent",
     pool.stop();
     pool.stop();  // second stop is a no-op, not a crash
     CHECK_FALSE(pool.running());
+}
+
+TEST_CASE("WorkerPool started on one thread, run() driven from another, is race-free",
+          "[format][graph][worker-pool][threads][rt-safety]") {
+    // The SignalGraph parallel path starts the pool off the control thread (during
+    // prepare) but drives run() from the audio thread. Exercise that exact split:
+    // start here, then run() repeatedly from a separate thread while this thread
+    // re-validates the pool. Surfaces a first-batch publish race under TSan.
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(8));
+    constexpr std::uint32_t kTasks = 500;
+    SquareCtx ctx;
+    ctx.out.assign(kTasks, 0);
+    std::atomic<bool> stop{false};
+    std::atomic<std::uint64_t> batches{0};
+    std::thread driver([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            ctx.runs.store(0, std::memory_order_relaxed);
+            pool.run(kTasks, square_task, &ctx);
+            batches.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+    for (int i = 0; i < 100; ++i) {
+        (void)pool.running();
+        (void)pool.worker_count();
+        std::this_thread::yield();
+    }
+    stop.store(true, std::memory_order_relaxed);
+    driver.join();
+    CHECK(batches.load() > 0);
+    for (std::uint32_t i = 0; i < kTasks; ++i) CHECK(ctx.out[i] == i * i);
+}
+
+TEST_CASE("WorkerPool rapid back-to-back batches from a separate thread are race-free",
+          "[format][graph][worker-pool][threads][rt-safety]") {
+    // process_parallel fires several run() calls in quick succession (one per
+    // level) within a single audio block; mimic that exactly: start on this
+    // thread, then a driver fires 3 tiny back-to-back batches per "block", many
+    // times. width(8) < workers(16) leaves participant 0 + even workers with
+    // empty ranges, matching the wide-level partition.
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(16));
+    SquareCtx ctx;
+    ctx.out.assign(8, 0);
+    std::atomic<bool> stop{false};
+    std::atomic<std::uint64_t> blocks{0};
+    std::thread driver([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            pool.run(8, square_task, &ctx);
+            pool.run(8, square_task, &ctx);
+            pool.run(8, square_task, &ctx);
+            blocks.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+    for (int i = 0; i < 200; ++i) std::this_thread::yield();
+    stop.store(true, std::memory_order_relaxed);
+    driver.join();
+    CHECK(blocks.load() > 0);
 }

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -1780,3 +1780,121 @@ TEST_CASE("SignalGraph::process automation matches legacy: dense Replace + Add o
                      run_legacy(routed, kFrames, input, 2));
     }
 }
+
+namespace {
+
+// in(2ch) -> N parallel gains -> out(2ch). A wide level so the parallel executor
+// actually dispatches across workers. `parallel` opts into the parallel path.
+void build_wide_signal_graph(SignalGraph& g, int n, bool parallel) {
+    const auto in = g.add_input_node(2, "In");
+    const auto out = g.add_output_node(2, "Out");
+    for (int i = 0; i < n; ++i) {
+        const auto gn = g.add_gain_node("G");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, gn, c));
+            REQUIRE(g.connect(gn, c, out, c));
+        }
+        REQUIRE(g.set_node_gain(gn, 0.02f + 0.003f * static_cast<float>(i)));
+    }
+    g.set_parallel_routing_enabled(parallel);
+    REQUIRE(g.prepare(kSr, kFrames));
+}
+
+}  // namespace
+
+TEST_CASE("SignalGraph::process parallel path matches legacy: wide graph",
+          "[host][graph][executor][routing][parity][parallel]") {
+    SignalGraph legacy, par;
+    build_wide_signal_graph(legacy, 16, /*parallel=*/false);
+    build_wide_signal_graph(par, 16, /*parallel=*/true);
+    REQUIRE(signal_graph_executor_eligible(par));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.04f * static_cast<float>(blk)),
+            ramp(kFrames, 0.5f - 0.02f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(par, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process parallel path matches legacy: feedback across blocks",
+          "[host][graph][executor][routing][parity][parallel]") {
+    // The parallel executor captures feedback after the level walk (serial), so a
+    // feedback graph must match the legacy walk block-for-block on the parallel path.
+    SignalGraph legacy, par;
+    build_feedback_graph(legacy, 0.5f, /*route_executor=*/false);
+    par.set_parallel_routing_enabled(true);
+    {
+        const auto in = par.add_input_node(1, "In");
+        const auto a = par.add_gain_node("A");
+        const auto out = par.add_output_node(1, "Out");
+        REQUIRE(par.connect(in, 0, a, 0));
+        REQUIRE(par.connect(a, 0, out, 0));
+        REQUIRE(par.connect_feedback(a, 0, a, 0));
+        REQUIRE(par.set_node_gain(a, 0.5f));
+        REQUIRE(par.prepare(kSr, kFrames));
+    }
+    REQUIRE(signal_graph_executor_eligible(par));
+    for (int blk = 0; blk < 6; ++blk) {
+        const auto x = ramp(kFrames, 0.4f + 0.1f * static_cast<float>(blk));
+        expect_equal(run_legacy(legacy, kFrames, {x}, 1),
+                     run_legacy(par, kFrames, {x}, 1));
+    }
+}
+
+TEST_CASE("SignalGraph::process parallel path does not allocate on the audio thread",
+          "[host][graph][executor][routing][rt-safety][parallel]") {
+    SignalGraph g;
+    build_wide_signal_graph(g, 16, /*parallel=*/true);
+    REQUIRE(signal_graph_executor_eligible(g));
+    const auto l = ramp(kFrames, 0.8f), r = ramp(kFrames, 0.6f);
+    std::vector<float> li = l, ri = r, lo(kFrames, 0.0f), ro(kFrames, 0.0f);
+    std::array<const float*, 2> ic{li.data(), ri.data()};
+    std::array<float*, 2> oc{lo.data(), ro.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 2, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 2, kFrames);
+    g.process(ov, iv, kFrames);  // warm up the workers outside the probe
+    {
+        pulp::test::RtAllocationProbe probe;
+        g.process(ov, iv, kFrames);
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
+}
+
+TEST_CASE("SignalGraph re-prepare while the parallel path renders is race-free",
+          "[host][graph][executor][routing][rt-safety][threads][parallel]") {
+    // Hammer process() (parallel path, multi-threaded) on the audio thread while
+    // another thread re-prepares. The worker pool is a long-lived member (not
+    // restarted on same-worker-count re-prepares), and each routed snapshot/pool
+    // rides the RCU lifetime — surfaces a pool-lifecycle or retired-snapshot race
+    // under TSan.
+    SignalGraph g;
+    build_wide_signal_graph(g, 8, /*parallel=*/true);
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> started{false};
+    std::atomic<std::uint64_t> blocks{0};
+    std::thread audio([&] {
+        std::vector<float> li(kFrames, 0.3f), ri(kFrames, 0.2f);
+        std::vector<float> lo(kFrames, 0.0f), ro(kFrames, 0.0f);
+        std::array<const float*, 2> ic{li.data(), ri.data()};
+        std::array<float*, 2> oc{lo.data(), ro.data()};
+        pulp::audio::BufferView<const float> iv(ic.data(), 2, kFrames);
+        pulp::audio::BufferView<float> ov(oc.data(), 2, kFrames);
+        started.store(true, std::memory_order_release);
+        while (!stop.load(std::memory_order_relaxed)) {
+            g.process(ov, iv, kFrames);
+            blocks.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+    while (!started.load(std::memory_order_acquire)) std::this_thread::yield();
+    bool prepared_all = true;
+    for (int i = 0; i < 200; ++i) {
+        if (!g.prepare(kSr, kFrames)) prepared_all = false;
+    }
+    stop.store(true, std::memory_order_relaxed);
+    audio.join();
+    REQUIRE(prepared_all);
+    CHECK(blocks.load() > 0);
+}


### PR DESCRIPTION
## Summary

Wire `SignalGraph::process` to dispatch eligible graphs through the levelized `GraphRuntimeExecutor::process_parallel` behind a **default-OFF** `set_parallel_routing_enabled` toggle (independent of the serial canonical-executor opt-in). This completes Phase 5b (static levelized multicore) on the SignalGraph live path — the engine pieces (worker pool #4801, levelization #4798, `process_parallel` #4806) were already merged; this slice connects them to `SignalGraph::process`.

- SignalGraph owns a persistent `GraphRuntimeWorkerPool` started **once** at prepare off the audio thread; `compile_` builds a parallel-safe routing snapshot + levelization that ride the RCU `CompiledGraph`.
- The serial and parallel routed branches share one `dispatch_routed` bridge for the MIDI mailbox (idempotent ingress re-clear + deferred sequence commit), so a parallel attempt returning false falls through to the serial executor then the legacy walk with **no double-consumed MIDI and no doubled output**. Output is bit-identical across all three tiers.

## Worker-pool barrier fix (found by the TSan hammer)

The fork-join completion barrier counted **tasks** done, so a participant handed an empty range (`width < worker_count` leaves participant 0 + some workers with `[b,b)`) did `fetch_add(0)` and was never awaited — it could still be reading the published batch (`task_count_`/`fn_`/`context_`) as the next `run()` overwrote it. The barrier now counts **participants finished** (`+1` each; `target = base + worker_count_`). Regression repros added: cross-thread `run()` caller, and rapid back-to-back batches from a separate thread.

## Tests

- Legacy-vs-parallel three-way bit-exact: wide 16-gain graph + feedback across blocks.
- Parallel-path no-alloc (`RtAllocationProbe`).
- Re-prepare-while-parallel-rendering TSan hammer.
- TSan-clean 3×; full parity / worker-pool / routing / levelization / buffer-assignment suites green in Release.

Adversarial review: no MUST-FIX. SHOULD-FIX items (worker-pool lifecycle invariant + multi-tier fall-through idempotence) addressed with code comments + the one-time-start guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in, levelized parallel execution path in `SignalGraph::process` using a persistent worker pool; it’s default OFF and preserves bit‑identical output with safe fallbacks to the serial executor and legacy walk.

- **New Features**
  - New `set_parallel_routing_enabled` toggle (independent of the serial executor opt‑in).
  - Build a parallel‑safe, reuse‑free routing snapshot and levelization at prepare; start a persistent `GraphRuntimeWorkerPool` once.
  - Dispatch order: parallel → serial executor → legacy; shared MIDI bridge with idempotent ingress prevents double‑consumed MIDI and doubled output.
  - Tests: legacy vs parallel parity (wide and feedback graphs), no‑alloc on audio thread, re‑prepare while rendering (TSan).

- **Bug Fixes**
  - Worker‑pool completion barrier now counts participants finished (not tasks) to avoid an empty‑range race between batches.
  - Regression tests added for cross‑thread `run()` and rapid back‑to‑back batches.

<sup>Written for commit e5192bf205540f167a5de79b07b31a416a0ce239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

