### PR TITLE
feat(graph): coarse static cost threshold for the parallel graph executor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.484.0
+    VERSION 0.485.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -163,6 +163,11 @@ struct GraphRuntimeExecutorStats {
     std::uint64_t invalid_snapshots = 0;
     std::uint64_t command_scratch_failures = 0;
     std::uint64_t node_failures = 0;
+    // process_parallel() level routing: how many levels were dispatched across
+    // the worker pool vs run serially on the audio thread (single-node levels,
+    // AudioOutput-accumulation levels, or levels below the cost threshold).
+    std::uint64_t parallel_levels_dispatched = 0;
+    std::uint64_t serial_levels_run = 0;
 };
 
 struct GraphRuntimeExecutorResult {
@@ -528,6 +533,23 @@ public:
     GraphRuntimeExecutorStats stats() const noexcept;
     void reset_stats() noexcept;
 
+    // Cost threshold (off-RT setter): process_parallel dispatches a level across
+    // the worker pool only when its static work-weight x frame_count reaches this
+    // many "channel-samples"; below it the level runs serially to avoid losing the
+    // fork/join overhead on trivial work (the break-even guard — fork/join can
+    // lose at 32-64 frames). DEFAULT 0 = parallelize every eligible (width>1,
+    // no-AudioOutput) level; worker-pool dispatch is the executor's job and the
+    // real safety gate is the caller's opt-in (SignalGraph parallel routing is
+    // default-OFF). Set a positive break-even (e.g. 4096 ~= 16 stereo nodes x 128
+    // frames) to keep trivial levels serial once parallel routing is enabled on
+    // small graphs.
+    void set_parallel_min_work_units(std::uint64_t channel_samples) noexcept {
+        parallel_min_work_units_.store(channel_samples, std::memory_order_relaxed);
+    }
+    std::uint64_t parallel_min_work_units() const noexcept {
+        return parallel_min_work_units_.load(std::memory_order_relaxed);
+    }
+
 private:
     GraphRuntimeExecutorResult fail_invalid_block() noexcept;
     GraphRuntimeExecutorResult fail_invalid_snapshot() noexcept;
@@ -554,6 +576,10 @@ private:
     std::atomic<std::uint64_t> invalid_snapshots_{0};
     std::atomic<std::uint64_t> command_scratch_failures_{0};
     std::atomic<std::uint64_t> node_failures_{0};
+    std::atomic<std::uint64_t> parallel_levels_dispatched_{0};
+    std::atomic<std::uint64_t> serial_levels_run_{0};
+    // 0 = no cost gate (parallelize every eligible level); see the setter.
+    std::atomic<std::uint64_t> parallel_min_work_units_{0};
 };
 
 } // namespace pulp::format

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -1047,6 +1047,24 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_parallel(
                 serial = true;
             }
         }
+        // Cost gate: skip the fork/join when the level's static work-weight x this
+        // block's frame count is below the break-even threshold. level_work_weight
+        // is precomputed off-RT (per the levelization); the audio-thread check is a
+        // single multiply-compare. A zero threshold parallelizes every eligible
+        // level. (Empty level_work_weight — a plan with no precomputed weights —
+        // leaves `serial` as-is rather than reading out of bounds.)
+        if (!serial && level < levels.level_work_weight.size()) {
+            const std::uint64_t work =
+                levels.level_work_weight[level] * static_cast<std::uint64_t>(frames);
+            if (work < parallel_min_work_units_.load(std::memory_order_relaxed)) {
+                serial = true;
+            }
+        }
+        if (serial) {
+            serial_levels_run_.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            parallel_levels_dispatched_.fetch_add(1, std::memory_order_relaxed);
+        }
 
         if (serial) {
             for (std::uint32_t k = 0; k < width; ++k) {
@@ -1095,6 +1113,8 @@ GraphRuntimeExecutorStats GraphRuntimeExecutor::stats() const noexcept {
         invalid_snapshots_.load(std::memory_order_relaxed),
         command_scratch_failures_.load(std::memory_order_relaxed),
         node_failures_.load(std::memory_order_relaxed),
+        parallel_levels_dispatched_.load(std::memory_order_relaxed),
+        serial_levels_run_.load(std::memory_order_relaxed),
     };
 }
 
@@ -1109,6 +1129,8 @@ void GraphRuntimeExecutor::reset_stats() noexcept {
     invalid_snapshots_.store(0, std::memory_order_relaxed);
     command_scratch_failures_.store(0, std::memory_order_relaxed);
     node_failures_.store(0, std::memory_order_relaxed);
+    parallel_levels_dispatched_.store(0, std::memory_order_relaxed);
+    serial_levels_run_.store(0, std::memory_order_relaxed);
 }
 
 GraphRuntimeExecutorResult GraphRuntimeExecutor::fail_invalid_block() noexcept {

--- a/core/graph/include/pulp/graph/graph_runtime_levelization.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_levelization.hpp
@@ -33,8 +33,27 @@ struct GraphRuntimeLevelization {
     // level_count + 1 entries; level_nodes has one entry per node.
     std::vector<std::uint32_t> level_offsets;
     std::vector<std::uint32_t> level_nodes;
+    // Per level (level_count entries): a static, deterministic work-weight =
+    // sum of graph_runtime_node_cost_weight() over the level's nodes. A coarse
+    // shape score (per-channel work proxy), NOT a CPU-cycle estimate; multiplied
+    // by the runtime frame count it gives a "channel-samples" figure a parallel
+    // executor compares against a fork/join break-even threshold to decide
+    // whether dispatching the level across workers is worth the overhead.
+    std::vector<std::uint64_t> level_work_weight;
     bool ok = false;
 };
+
+// Static per-node work weight feeding level_work_weight: the per-channel work a
+// node does, approximated as max(input_ports, output_ports) for audio-processing
+// kinds (Processor / Utility / Custom) and 0 for pure I/O (AudioInput /
+// AudioOutput / MidiInput / MidiOutput), which neither justify a worker hop nor
+// (for AudioOutput) ever run in parallel. Deterministic and allocation-free.
+// NOTE: Gain and hosted-plugin nodes both map to Processor, so this cannot tell a
+// cheap gain from an expensive plugin — per-node DSP-cost discrimination needs
+// the runtime measured-load feed (masterwork §6.4), a later refinement.
+std::uint64_t graph_runtime_node_cost_weight(GraphRuntimeNodeKind kind,
+                                             std::uint32_t input_ports,
+                                             std::uint32_t output_ports) noexcept;
 
 // Compute the levelization for `plan`. Returns ok=false only on allocation
 // failure or a malformed plan (processing order not covering every node); an

--- a/core/graph/src/graph_runtime_levelization.cpp
+++ b/core/graph/src/graph_runtime_levelization.cpp
@@ -5,6 +5,28 @@
 
 namespace pulp::graph {
 
+std::uint64_t graph_runtime_node_cost_weight(GraphRuntimeNodeKind kind,
+                                             std::uint32_t input_ports,
+                                             std::uint32_t output_ports) noexcept {
+    // Exhaustive over GraphRuntimeNodeKind on purpose (no default): -Wswitch flags
+    // a newly added kind here. A new AUDIO-PROCESSING kind MUST join the first
+    // group, or it scores 0 and never tips a level over the parallel threshold (a
+    // silent missed-parallelism, not a correctness bug). The trailing return is
+    // the unreachable fallthrough for unknown values.
+    switch (kind) {
+        case GraphRuntimeNodeKind::Processor:
+        case GraphRuntimeNodeKind::Utility:
+        case GraphRuntimeNodeKind::Custom:
+            return std::max(input_ports, output_ports);
+        case GraphRuntimeNodeKind::AudioInput:
+        case GraphRuntimeNodeKind::AudioOutput:
+        case GraphRuntimeNodeKind::MidiInput:
+        case GraphRuntimeNodeKind::MidiOutput:
+            return 0;
+    }
+    return 0;
+}
+
 GraphRuntimeLevelization build_graph_runtime_levelization(const GraphRuntimePlan& plan) {
     GraphRuntimeLevelization result;
     const std::size_t node_count = plan.nodes.size();
@@ -60,6 +82,17 @@ GraphRuntimeLevelization build_graph_runtime_levelization(const GraphRuntimePlan
         for (const auto n : plan.processing_order_indices) {
             const std::uint32_t level = result.node_level[n];
             result.level_nodes[cursor[level]++] = n;
+        }
+
+        // Per-level static work-weight: sum each level's node cost weights. Used
+        // off the audio thread to precompute a parallel-vs-serial break-even
+        // figure (weight x frames) the executor checks per block.
+        result.level_work_weight.assign(result.level_count, 0);
+        for (std::size_t n = 0; n < node_count; ++n) {
+            const auto& node = plan.nodes[n];
+            result.level_work_weight[result.node_level[n]] +=
+                graph_runtime_node_cost_weight(node.kind, node.input_ports,
+                                               node.output_ports);
         }
     } catch (...) {
         result = {};

--- a/test/test_graph_executor_routing.cpp
+++ b/test/test_graph_executor_routing.cpp
@@ -763,3 +763,69 @@ TEST_CASE("Parallel routing matches serial: deep and wide (two parallel levels)"
                 par.outs[0][static_cast<std::size_t>(i)]);
     }
 }
+
+TEST_CASE("Parallel routing cost gate: a sub-threshold level runs serially",
+          "[format][graph][executor][routing][parallel][cost]") {
+    // in(1) -> 4 mono gains -> out(1). The 4-gain level is the only parallel-
+    // eligible level (width>1, no AudioOutput); its static weight is 4*max(1,1)=4,
+    // so at 64 frames it carries 256 channel-samples of work. The cost gate routes
+    // it serially when the threshold exceeds that, and dispatches it when the
+    // threshold is 0 — without ever changing the output.
+    constexpr int kFrames = 64;
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 1},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{5, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{6, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0}, GraphRuntimeConnectionSpec{1, 0, 3, 0},
+        GraphRuntimeConnectionSpec{1, 0, 4, 0}, GraphRuntimeConnectionSpec{1, 0, 5, 0},
+        GraphRuntimeConnectionSpec{2, 0, 6, 0}, GraphRuntimeConnectionSpec{3, 0, 6, 0},
+        GraphRuntimeConnectionSpec{4, 0, 6, 0}, GraphRuntimeConnectionSpec{5, 0, 6, 0},
+    };
+    GainState g2{0.1f}, g3{0.2f}, g4{0.3f}, g5{0.4f};
+    const std::array bindings = {
+        GraphRuntimeNodeBinding{1, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{2, routing_gain, &g2, true},
+        GraphRuntimeNodeBinding{3, routing_gain, &g3, true},
+        GraphRuntimeNodeBinding{4, routing_gain, &g4, true},
+        GraphRuntimeNodeBinding{5, routing_gain, &g5, true},
+        GraphRuntimeNodeBinding{6, nullptr, nullptr, false},
+    };
+    GraphRuntimeSnapshot psnapshot;
+    REQUIRE(make_snapshot(psnapshot, nodes, conns, bindings, /*parallel_safe=*/true));
+    const auto levels = pulp::graph::build_graph_runtime_levelization(psnapshot.plan());
+    REQUIRE(levels.ok);
+
+    const std::vector<std::vector<float>> in{test_signal(kFrames, 0.8f)};
+    GraphRuntimeExecutor exec;
+    pulp::format::GraphRuntimeWorkerPool workers;
+    REQUIRE(workers.start(4));
+
+    // Threshold above the level's 256 channel-samples: it stays serial.
+    exec.set_parallel_min_work_units(1000);
+    exec.reset_stats();
+    auto pool_hi = make_pool(psnapshot, kFrames);
+    RoutedHarness hi(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(hi.block, psnapshot, levels, pool_hi, workers).ok());
+    CHECK(exec.stats().parallel_levels_dispatched == 0);
+    CHECK(exec.stats().serial_levels_run >= 1);
+
+    // Threshold 0: the gain level dispatches across the worker pool.
+    exec.set_parallel_min_work_units(0);
+    exec.reset_stats();
+    auto pool_lo = make_pool(psnapshot, kFrames);
+    RoutedHarness lo(kSr, kFrames, in, 1);
+    REQUIRE(exec.process_parallel(lo.block, psnapshot, levels, pool_lo, workers).ok());
+    CHECK(exec.stats().parallel_levels_dispatched >= 1);
+    workers.stop();
+
+    // The gate only chooses the path; output is identical either way.
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(hi.outs[0][static_cast<std::size_t>(i)] ==
+                lo.outs[0][static_cast<std::size_t>(i)]);
+    }
+}

--- a/test/test_graph_runtime_levelization.cpp
+++ b/test/test_graph_runtime_levelization.cpp
@@ -182,3 +182,46 @@ TEST_CASE("Levelization: an empty plan is a valid zero-level schedule",
     REQUIRE(lv.level_offsets.size() == 1);
     CHECK(lv.level_offsets[0] == 0);
 }
+
+TEST_CASE("Levelization: per-node cost weight reflects audio-processing channels",
+          "[graph][levelization][cost]") {
+    using pulp::graph::graph_runtime_node_cost_weight;
+    // Audio-processing kinds weigh max(in,out) channels; pure I/O weighs 0.
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::Processor, 2, 2) == 2);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::Processor, 1, 4) == 4);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::Utility, 3, 1) == 3);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::Custom, 2, 2) == 2);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::AudioInput, 0, 2) == 0);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::AudioOutput, 2, 0) == 0);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::MidiInput, 0, 1) == 0);
+    CHECK(graph_runtime_node_cost_weight(GraphRuntimeNodeKind::MidiOutput, 1, 0) == 0);
+}
+
+TEST_CASE("Levelization: per-level work weight sums its nodes' cost weights",
+          "[graph][levelization][cost]") {
+    // in(0/2) -> 3 stereo processors -> out(2/0). Levels: {in}=0, {p1,p2,p3}=2*3,
+    // {out}=0. Only the processor level carries weight.
+    const std::array nodes = {
+        node(1, 0, 2, GraphRuntimeNodeKind::AudioInput),
+        node(2, 2, 2),
+        node(3, 2, 2),
+        node(4, 2, 2),
+        node(5, 2, 0, GraphRuntimeNodeKind::AudioOutput),
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0}, GraphRuntimeConnectionSpec{1, 0, 3, 0},
+        GraphRuntimeConnectionSpec{1, 0, 4, 0}, GraphRuntimeConnectionSpec{2, 0, 5, 0},
+        GraphRuntimeConnectionSpec{3, 0, 5, 0}, GraphRuntimeConnectionSpec{4, 0, 5, 0},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    REQUIRE(lv.ok);
+    REQUIRE(lv.level_work_weight.size() == lv.level_count);
+    const std::uint32_t in_lvl = lv.node_level[index_of(plan.plan, 1)];
+    const std::uint32_t proc_lvl = lv.node_level[index_of(plan.plan, 2)];
+    const std::uint32_t out_lvl = lv.node_level[index_of(plan.plan, 5)];
+    CHECK(lv.level_work_weight[in_lvl] == 0);
+    CHECK(lv.level_work_weight[proc_lvl] == 6);  // 3 nodes * max(2,2)
+    CHECK(lv.level_work_weight[out_lvl] == 0);
+}


### PR DESCRIPTION
## Summary

Adds the break-even **cost gate** that keeps the levelized parallel executor from losing fork/join overhead on trivial work — the "coarse cost-thresholded parallelism" + serial fallback the masterwork risk section calls mandatory. Completes **Phase 5** (engine + SignalGraph opt-in #4812 + determinism golden #4815 + this cost threshold).

- `build_graph_runtime_levelization` precomputes a per-level `level_work_weight` = Σ `graph_runtime_node_cost_weight(kind,in,out)` — `max(in,out)` for audio-processing kinds (Processor/Utility/Custom), 0 for pure I/O. Static, deterministic, alloc-free.
- `GraphRuntimeExecutor::process_parallel` dispatches a parallel-eligible level (width>1, no AudioOutput) to the worker pool only when `level_work_weight × frames ≥ parallel_min_work_units_` (an off-RT atomic setter; the RT-path check is a relaxed load + multiply-compare).
- New executor stats `parallel_levels_dispatched` / `serial_levels_run` make the routing decision observable.

**Default 0 = no gate** (parallelize every eligible level): worker-pool dispatch is the executor's job, and the real safety gate is the caller's opt-in (SignalGraph parallel routing is default-OFF). A caller enabling parallel routing on small graphs sets a positive break-even (≈4096 = 16 stereo nodes × 128 frames) to keep trivial levels serial. **The gate only selects the path; output is bit-identical either way** (asserted by an exact-equality test across thresholds).

**Honest limitation:** Gain and hosted-plugin nodes both map to the `Processor` kind, so this static model can't distinguish a cheap gain from an expensive plugin — per-node DSP-cost discrimination needs the §6.4 runtime measured-load feed (a later refinement, documented in the cost-weight contract).

## Tests

Per-node cost weight across all node kinds, per-level weight summation, and a `process_parallel` gate test asserting a sub-threshold level runs serially while a zero threshold dispatches it — with identical output across both. TSan-clean; full graph/executor suites green.

Adversarial review: no MUST-FIX; the one SHOULD-FIX (a future enum kind silently scoring 0) addressed with a `-Wswitch` guard comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a coarse cost threshold to the parallel graph executor to avoid fork/join overhead on trivial work. Default is 0, so behavior is unchanged unless you configure a threshold.

- **New Features**
  - Levelization now computes a per-level work weight: sum of node weights where each node is max(input_ports, output_ports) for Processor/Utility/Custom, and 0 for pure I/O.
  - `process_parallel` only dispatches a parallel-eligible level when weight × frames ≥ `parallel_min_work_units_`.
  - Added stats: `parallel_levels_dispatched` and `serial_levels_run`.
  - Off-RT setter/getter to tune the threshold; output remains bit-identical for serial vs parallel paths.

- **Migration**
  - No action needed. With threshold=0, all eligible levels still parallelize.
  - When enabling parallel routing on small graphs, set a positive threshold (e.g., 4096) and use the new stats to tune.

<sup>Written for commit 0753fe3ebeb0901cd0d4e268b634697493e83d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

