### PR TITLE
feat(host): static anticipative-rendering eligibility analysis

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -195,6 +195,21 @@ predictable output, no MIDI.
   count runtime-variable without a drain handshake. The pool's completion barrier
   counts PARTICIPANTS finished (not tasks): an empty-range participant must still
   register done, or it can race the next batch's published state.
+- **Anticipative-rendering eligibility (`anticipation_eligibility.{hpp,cpp}`).**
+  `analyze_anticipation_eligibility(nodes, connections)` is the static SAFETY
+  contract for rendering a latent subgraph ahead of the audio deadline: it
+  classifies each node `None` (passed) or a hard-exclusion reason — seeds live
+  AudioInput/MidiInput nodes, both endpoints of every feedback edge, and any node
+  with a sidechain inbound edge, then propagates each exclusion forward along
+  feedforward (non-feedback) edges to a fixpoint so anything downstream of an
+  excluded node is excluded too. It's deliberately conservative: a false exclusion
+  only forfeits a speed-up, but a false inclusion would render an unsafe node
+  ahead. GOTCHA: `passes_static_exclusions(i)` is NOT a blanket "safe to
+  anticipate" — host-clock-sensitive plugins (output depends on the transport
+  playhead) are NOT statically detectable from node metadata and are intentionally
+  not covered; a renderer consuming this must layer a host-time check or a per-node
+  opt-out on top. There is no anticipative renderer yet — this is the analysis the
+  Phase 6 renderer will gate on.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.242.0",
+      "version": "0.243.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.242.0"
+  "version": "0.243.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.242.0",
+  "version": "0.243.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.485.0
+    VERSION 0.486.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(pulp-host PRIVATE
     src/isolated_scanner.cpp
     src/node_pack.cpp
     src/signal_graph_executor_routing.cpp
+    src/anticipation_eligibility.cpp
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::format pulp::graph pulp::midi pulp::runtime pulp::state)

--- a/core/host/include/pulp/host/anticipation_eligibility.hpp
+++ b/core/host/include/pulp/host/anticipation_eligibility.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <pulp/host/graph_types.hpp>
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace pulp::host {
+
+struct GraphNode;
+struct Connection;
+
+// Why a node may NOT be rendered ahead of the audio deadline (anticipative
+// rendering, masterwork Phase 6). Anticipation pre-computes a latent subgraph's
+// output into a buffer during earlier blocks' slack so a CPU spike is absorbed
+// off the critical block — but only for work whose result for a FUTURE block can
+// be computed from inputs already available, with no dependence on live or
+// host-clock state. A node is eligible only if it (and its entire feedforward
+// dependency cone) is free of every exclusion below.
+enum class AnticipationExclusion : std::uint8_t {
+    None = 0,        // anticipation-eligible
+    LiveAudioInput,  // is, or transitively reads, a live system AudioInput
+    LiveMidiInput,   // is, or transitively reads, a live system MidiInput
+                     // (a MIDI-instrument feed — the notes aren't known ahead)
+    Feedback,        // participates in, or sits downstream of, a feedback edge
+                     // (its own past output gates it; can't run arbitrarily ahead)
+    Sidechain,       // has, or transitively reads, a sidechain input (live signal)
+};
+
+struct AnticipationEligibility {
+    // Per node, indexed exactly like the input `nodes` span: None = passed the
+    // static topology exclusions, otherwise the reason it (or something it depends
+    // on) cannot be anticipated. A node inherits the exclusion of any feedforward
+    // source it depends on.
+    std::vector<AnticipationExclusion> node_exclusion;
+    bool ok = false;
+
+    // WARNING: `passes_static_exclusions(i)` means ONLY that node i cleared the
+    // statically-detectable hard exclusions (live input / feedback / sidechain).
+    // It is NOT a blanket "safe to render ahead" clearance — host-clock-sensitive
+    // plugins are deliberately not detected here (see the function note). A
+    // renderer must apply the host-time check (or a per-node opt-out) on top of
+    // this; do not treat a true result as sufficient on its own.
+    bool passes_static_exclusions(std::size_t node_index) const {
+        return node_index < node_exclusion.size() &&
+               node_exclusion[node_index] == AnticipationExclusion::None;
+    }
+    bool any_passes_static_exclusions() const {
+        for (auto e : node_exclusion) {
+            if (e == AnticipationExclusion::None) return true;
+        }
+        return false;
+    }
+};
+
+// Classify each node's anticipation eligibility purely from the graph topology:
+// seed the hard-excluded roots (live AudioInput / MidiInput nodes, the endpoints
+// of every feedback edge, and any node with a sidechain inbound edge), then
+// propagate each exclusion forward along feedforward (non-feedback) edges to a
+// fixpoint, so a node downstream of anything excluded is excluded too. The first
+// reason assigned to a node wins (its own seed reason over an inherited one);
+// "excluded for some reason" is the load-bearing bit, the specific reason is
+// diagnostic. Deterministic and allocation-bounded; no prepared/live graph
+// required. Returns ok=false only on a malformed input (a connection naming a
+// node id absent from `nodes`).
+//
+// NOTE: host-clock sensitivity (a plugin whose output depends on the transport
+// playhead) is NOT statically detectable from the current node metadata, so it is
+// NOT covered here — anticipating such a node needs either a per-node opt-out flag
+// or feeding it the correct future transport. That is a deliberate follow-up; the
+// renderer that consumes this analysis must treat host-time exposure separately.
+AnticipationEligibility analyze_anticipation_eligibility(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections);
+
+} // namespace pulp::host

--- a/core/host/src/anticipation_eligibility.cpp
+++ b/core/host/src/anticipation_eligibility.cpp
@@ -1,0 +1,89 @@
+#include <pulp/host/anticipation_eligibility.hpp>
+
+#include <pulp/host/signal_graph.hpp>
+
+#include <unordered_map>
+
+namespace pulp::host {
+
+AnticipationEligibility analyze_anticipation_eligibility(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections) {
+    AnticipationEligibility result;
+    result.node_exclusion.assign(nodes.size(), AnticipationExclusion::None);
+
+    // NodeId -> dense index into `nodes`.
+    std::unordered_map<NodeId, std::size_t> index_of;
+    index_of.reserve(nodes.size());
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        index_of.emplace(nodes[i].id, i);
+    }
+
+    auto find = [&](NodeId id, std::size_t& out) -> bool {
+        const auto it = index_of.find(id);
+        if (it == index_of.end()) return false;
+        out = it->second;
+        return true;
+    };
+
+    // Assign a reason only if the node has none yet (first reason wins).
+    auto seed = [&](std::size_t i, AnticipationExclusion why) {
+        if (result.node_exclusion[i] == AnticipationExclusion::None) {
+            result.node_exclusion[i] = why;
+        }
+    };
+
+    // Seed live-input roots.
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        if (nodes[i].type == NodeType::AudioInput) {
+            seed(i, AnticipationExclusion::LiveAudioInput);
+        } else if (nodes[i].type == NodeType::MidiInput) {
+            seed(i, AnticipationExclusion::LiveMidiInput);
+        }
+    }
+
+    // Seed the endpoints of every feedback edge and any sidechain consumer.
+    // Validate every connection's node ids up front; a dangling id is malformed.
+    for (const auto& c : connections) {
+        std::size_t s = 0;
+        std::size_t d = 0;
+        if (!find(c.source_node, s) || !find(c.dest_node, d)) {
+            return result;  // ok = false
+        }
+        if (c.feedback) {
+            seed(s, AnticipationExclusion::Feedback);
+            seed(d, AnticipationExclusion::Feedback);
+        }
+        if (c.sidechain) {
+            seed(d, AnticipationExclusion::Sidechain);
+        }
+    }
+
+    // Propagate each exclusion forward along feedforward (non-feedback) edges to a
+    // fixpoint: anything reading an excluded source is itself non-anticipatable.
+    // Monotone (a node only ever flips None -> reason, never back) and bounded by
+    // node_count total flips, so it runs at most node_count + 1 passes; O(V*E)
+    // worst case, acceptable off the audio thread. The find() guards are belt-and-
+    // suspenders: the seed loop already rejected any dangling id with ok=false, but
+    // re-checking here keeps this safety classifier correct by construction rather
+    // than by a non-local invariant (a stray index would otherwise corrupt node 0).
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& c : connections) {
+            if (c.feedback) continue;  // back-edge reads the previous block
+            std::size_t s = 0;
+            std::size_t d = 0;
+            if (!find(c.source_node, s) || !find(c.dest_node, d)) continue;
+            if (result.node_exclusion[s] != AnticipationExclusion::None &&
+                result.node_exclusion[d] == AnticipationExclusion::None) {
+                result.node_exclusion[d] = result.node_exclusion[s];
+                changed = true;
+            }
+        }
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace pulp::host

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -66,6 +66,12 @@ pulp_add_test_suite(pulp-test-signal-graph-executor-parity
 pulp_add_test_suite(pulp-test-graph-routing-differential-parity
     SOURCES test_graph_routing_differential_parity.cpp
     LIBRARIES pulp::host pulp::format pulp::graph)
+# Anticipative-rendering safety contract: the static eligibility analysis must
+# exclude every live-input / feedback / sidechain-dependent node and propagate
+# those exclusions downstream, so no unsafe subgraph is ever rendered ahead.
+pulp_add_test_suite(pulp-test-anticipation-eligibility
+    SOURCES test_anticipation_eligibility.cpp
+    LIBRARIES pulp::host pulp::format pulp::graph)
 
 # First sampler/looper storage primitives split by ownership so failures point
 # to the actual layer instead of a catch-all primitive bucket.

--- a/test/test_anticipation_eligibility.cpp
+++ b/test/test_anticipation_eligibility.cpp
@@ -1,0 +1,226 @@
+// Coverage for the anticipative-rendering safety contract (masterwork Phase 6):
+// the static analysis that decides which nodes may be rendered ahead of the audio
+// deadline. The contract is conservative — a node is eligible ONLY if its whole
+// feedforward dependency cone is free of live inputs, feedback, and sidechains —
+// so these tests assert both the seeded exclusions and their downstream
+// propagation, plus that a genuinely independent latent subgraph stays eligible.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/signal_graph.hpp>
+
+#include <vector>
+
+using namespace pulp::host;
+
+namespace {
+
+GraphNode mk(NodeId id, NodeType type, int in, int out) {
+    GraphNode n;
+    n.id = id;
+    n.type = type;
+    n.num_input_ports = in;
+    n.num_output_ports = out;
+    return n;
+}
+
+Connection edge(NodeId s, NodeId d) {
+    Connection c;
+    c.source_node = s;
+    c.source_port = 0;
+    c.dest_node = d;
+    c.dest_port = 0;
+    return c;
+}
+
+}  // namespace
+
+TEST_CASE("Anticipation: everything downstream of a live AudioInput is excluded",
+          "[host][anticipation]") {
+    // in(live) -> gain -> out. None can be anticipated: the input isn't known ahead.
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.node_exclusion[0] == AnticipationExclusion::LiveAudioInput);
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::LiveAudioInput);  // inherited
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::LiveAudioInput);
+    CHECK_FALSE(a.any_passes_static_exclusions());
+}
+
+TEST_CASE("Anticipation: a generator subgraph with no live input is eligible",
+          "[host][anticipation]") {
+    // A source plugin (0 inputs) -> gain -> out. Nothing live/feedback/sidechain,
+    // so the chain can be rendered ahead.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.passes_static_exclusions(0));
+    CHECK(a.passes_static_exclusions(1));
+    CHECK(a.passes_static_exclusions(2));
+    CHECK(a.any_passes_static_exclusions());
+}
+
+TEST_CASE("Anticipation: a MIDI instrument and its tail are excluded as live",
+          "[host][anticipation]") {
+    // midi(live) -> instrument plugin -> reverb -> out. The notes aren't known
+    // ahead, so the whole voice is non-anticipatable.
+    std::vector<GraphNode> nodes{mk(1, NodeType::MidiInput, 0, 0),
+                                 mk(2, NodeType::Plugin, 0, 2),
+                                 mk(3, NodeType::Plugin, 2, 2),
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3), edge(3, 4)};
+    conns[0].midi = true;  // the MIDI feed into the instrument
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.node_exclusion[0] == AnticipationExclusion::LiveMidiInput);
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::LiveMidiInput);
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::LiveMidiInput);
+    CHECK(a.node_exclusion[3] == AnticipationExclusion::LiveMidiInput);
+}
+
+TEST_CASE("Anticipation: a feedback edge excludes both endpoints and the tail",
+          "[host][anticipation]") {
+    // gen -> a -> out, with a self-feedback on a. `a` depends on its own past, so
+    // it (and out, downstream) can't run arbitrarily ahead. gen stays eligible.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    Connection fb = edge(2, 2);
+    fb.feedback = true;
+    conns.push_back(fb);
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.passes_static_exclusions(0));  // the generator is upstream of the loop, still eligible
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::Feedback);
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::Feedback);  // downstream
+}
+
+TEST_CASE("Anticipation: a sidechain input excludes the consumer and its tail",
+          "[host][anticipation]") {
+    // gen -> comp(sidechain from gen2) -> out. The sidechained compressor reads a
+    // live-treated signal, so it and its tail are excluded; the two generators
+    // feeding it stay eligible.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),   // main gen
+                                 mk(2, NodeType::Plugin, 0, 2),   // sidechain gen
+                                 mk(3, NodeType::Plugin, 4, 2),   // compressor
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 3), edge(3, 4)};
+    Connection sc = edge(2, 3);
+    sc.dest_port = 2;
+    sc.sidechain = true;
+    conns.push_back(sc);
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.passes_static_exclusions(0));
+    CHECK(a.passes_static_exclusions(1));
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::Sidechain);
+    CHECK(a.node_exclusion[3] == AnticipationExclusion::Sidechain);  // downstream
+}
+
+TEST_CASE("Anticipation: independent live and latent subgraphs are classified apart",
+          "[host][anticipation]") {
+    // Live: in -> g1 -> out1. Latent/eligible: gen -> g2 -> out2. The two share no
+    // edges, so the live exclusion must not bleed into the generator chain.
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0),
+                                 mk(4, NodeType::Plugin, 0, 2),
+                                 mk(5, NodeType::Gain, 2, 2),
+                                 mk(6, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3), edge(4, 5), edge(5, 6)};
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.node_exclusion[0] == AnticipationExclusion::LiveAudioInput);
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::LiveAudioInput);
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::LiveAudioInput);
+    CHECK(a.passes_static_exclusions(3));
+    CHECK(a.passes_static_exclusions(4));
+    CHECK(a.passes_static_exclusions(5));
+}
+
+TEST_CASE("Anticipation: a sidechain fed by a live input excludes the consumer",
+          "[host][anticipation]") {
+    // in(live) --sidechain--> comp -> out. The sidechain source is itself live, so
+    // the consumer is excluded both by the sidechain seed and by propagation from
+    // the live input — the first-reason-wins reason is diagnostic, exclusion is
+    // the load-bearing bit.
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Plugin, 4, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(2, 3)};
+    Connection sc = edge(1, 2);
+    sc.dest_port = 2;
+    sc.sidechain = true;
+    conns.push_back(sc);
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.node_exclusion[0] == AnticipationExclusion::LiveAudioInput);
+    CHECK_FALSE(a.passes_static_exclusions(1));  // excluded (live and/or sidechain)
+    CHECK_FALSE(a.passes_static_exclusions(2));  // downstream
+}
+
+TEST_CASE("Anticipation: a two-node feedback cycle excludes both members",
+          "[host][anticipation]") {
+    // gen -> a -> b -> out, with b feeding back into a (b->a marked feedback). Both
+    // a and b are on the loop and must be excluded; gen upstream stays eligible.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::Gain, 2, 2),
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3), edge(3, 4)};
+    Connection fb = edge(3, 2);  // b -> a, the loop's back-edge
+    fb.feedback = true;
+    conns.push_back(fb);
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.passes_static_exclusions(0));  // generator upstream of the loop
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::Feedback);  // a (feedback dest)
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::Feedback);  // b (feedback source)
+    CHECK(a.node_exclusion[3] == AnticipationExclusion::Feedback);  // out, downstream
+}
+
+TEST_CASE("Anticipation: a live input modulating a latent plugin's param excludes it",
+          "[host][anticipation]") {
+    // gen -> fx -> out, with in(live) automating fx's gain param. The modulation
+    // source is live, so fx (and its tail) can't be rendered ahead even though the
+    // audio path is a latent generator.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),    // latent gen
+                                 mk(2, NodeType::Plugin, 2, 2),    // fx
+                                 mk(3, NodeType::AudioOutput, 2, 0),
+                                 mk(4, NodeType::AudioInput, 0, 1)};  // live modulator
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    Connection mod = edge(4, 2);
+    mod.automation = true;
+    mod.automation_param_id = 1;
+    conns.push_back(mod);
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    REQUIRE(a.ok);
+    CHECK(a.passes_static_exclusions(0));  // the generator itself is independent
+    CHECK(a.node_exclusion[1] == AnticipationExclusion::LiveAudioInput);  // via the mod edge
+    CHECK(a.node_exclusion[2] == AnticipationExclusion::LiveAudioInput);  // downstream
+    CHECK(a.node_exclusion[3] == AnticipationExclusion::LiveAudioInput);  // the modulator
+}
+
+TEST_CASE("Anticipation: a connection naming an absent node is malformed",
+          "[host][anticipation]") {
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2)};
+    std::vector<Connection> conns{edge(1, 99)};  // 99 doesn't exist
+    const auto a = analyze_anticipation_eligibility(nodes, conns);
+    CHECK_FALSE(a.ok);
+}
+
+TEST_CASE("Anticipation: an empty graph analyzes cleanly with nothing eligible",
+          "[host][anticipation]") {
+    const auto a = analyze_anticipation_eligibility({}, {});
+    CHECK(a.ok);
+    CHECK(a.node_exclusion.empty());
+    CHECK_FALSE(a.any_passes_static_exclusions());
+}


### PR DESCRIPTION
## Summary

The foundational slice of **masterwork Phase 6** (anticipative rendering — a separate opt-in mode that renders expensive *latent* subgraphs ahead of the audio deadline to absorb CPU spikes, gated by a hard exclusion list). This PR adds **only the static safety analysis** — no renderer, no real-time path change.

`analyze_anticipation_eligibility(nodes, connections)` classifies each node `None` (passed) or the reason it can't be rendered ahead:
- Seeds live `AudioInput`/`MidiInput` nodes, both endpoints of every feedback edge, and any node with a sidechain inbound edge.
- Propagates each exclusion forward along feedforward (non-feedback) edges to a fixpoint, so anything downstream of an excluded node is excluded too (monotone; ≤ node_count+1 passes; O(V·E), off-RT).

Conservative by design: a false exclusion only forfeits a speed-up, while a **false inclusion would render an unsafe node ahead** — so the propagation is the load-bearing safety property.

**Known gap (documented in the API + a struct-level warning):** host-clock-sensitive plugins (output depends on the transport playhead) are *not* statically detectable from node metadata and are intentionally not covered. `passes_static_exclusions()` is named to signal it is only the topology check — a renderer must layer a host-time check or a per-node opt-out on top.

## Tests (11 cases)

Live-input / MIDI-instrument / feedback / sidechain exclusion and downstream propagation; a live-fed sidechain source; a two-node feedback cycle; a live input modulating a latent plugin's parameter; an independent latent generator staying eligible; malformed input (`ok=false`); the empty graph.

Adversarial review: one MUST-FIX (the propagation loop ignored `find()`'s bool — a latent false-inclusion landmine resting on a non-local invariant) now guarded; SHOULD-FIX items (wrong termination comment, `eligible()` naming + host-time-doc hardening) applied; review-flagged test gaps added.

**Honest scoping note:** anticipation benefits latent subgraphs fed by non-live sources; Pulp's primary live-hosting use case is mostly live-input-bound, so most real graphs will have little eligible work. The analysis is the correct safety foundation regardless; the renderer slices (ring buffer + off-deadline scheduler; opt-in mode + host-time guard) are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static analysis that marks which graph nodes are safe for anticipative rendering by excluding live inputs, feedback, and sidechain paths, then propagating those exclusions downstream. This is the safety gate for Phase 6; no renderer or real-time changes yet.

- **New Features**
  - Introduces `analyze_anticipation_eligibility(nodes, connections)` returning `AnticipationEligibility`.
  - Seeds exclusions for live `AudioInput`/`MidiInput`, both endpoints of feedback edges, and sidechain consumers; propagates along non-feedback edges to a fixpoint (off-RT, O(V·E)).
  - Documents that host-clock-sensitive plugins are not statically detectable; callers must apply a transport-time guard. Adds targeted tests for live/MIDI/feedback/sidechain and propagation.

- **Dependencies**
  - Bumps project version to 0.486.0.
  - Bumps plugin manifest version to 0.243.0.

<sup>Written for commit 3a58402ce7b9995ce2bc5311be40a21b1357887b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

