### PR TITLE
feat(host): anticipation partition (eligible interior + boundary edges)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -210,6 +210,16 @@ predictable output, no MIDI.
   not covered; a renderer consuming this must layer a host-time check or a per-node
   opt-out on top. There is no anticipative renderer yet — this is the analysis the
   Phase 6 renderer will gate on.
+- **Anticipation partition (`anticipation_partition.{hpp,cpp}`).**
+  `build_anticipation_partition(nodes, connections, eligibility)` carves the
+  renderable eligible INTERIOR (eligible nodes minus the live AudioOutput/MidiOutput
+  sinks, which are consumed at the real deadline and must never be written ahead)
+  and the BOUNDARY edges (interior-source -> outside-the-interior), which are the
+  splice points the renderer pre-computes and the live graph reads. `cost_weight`
+  (the same coarse max(in,out) proxy the parallel cost gate uses) +
+  `worth_anticipating()` gate out trivial/no-boundary partitions. Still pure static
+  analysis — no rendering, no RT path. Builds on the 6a eligibility result and is
+  rejected (ok=false) if that result isn't ok or doesn't match the node span.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.243.0",
+      "version": "0.244.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.243.0"
+  "version": "0.244.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.243.0",
+  "version": "0.244.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.486.0
+    VERSION 0.487.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(pulp-host PRIVATE
     src/node_pack.cpp
     src/signal_graph_executor_routing.cpp
     src/anticipation_eligibility.cpp
+    src/anticipation_partition.cpp
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::format pulp::graph pulp::midi pulp::runtime pulp::state)

--- a/core/host/include/pulp/host/anticipation_partition.hpp
+++ b/core/host/include/pulp/host/anticipation_partition.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/graph_types.hpp>
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace pulp::host {
+
+struct GraphNode;
+struct Connection;
+
+// An edge leaving the anticipation-eligible interior: its source is a node that
+// can be rendered ahead, its destination is NOT (a live/non-eligible node, or a
+// live sink such as AudioOutput/MidiOutput). These are the splice points — the
+// outputs the anticipative renderer pre-computes into a ring and the live graph
+// reads instead of running the interior synchronously.
+struct AnticipationBoundary {
+    NodeId source_node = 0;   // in the eligible interior
+    PortIndex source_port = 0;
+    NodeId dest_node = 0;     // outside the interior
+    PortIndex dest_port = 0;
+};
+
+// The renderable eligible subgraph carved out of a graph: the interior nodes the
+// renderer would run ahead, and the boundary edges whose pre-rendered output the
+// live graph consumes. A partition is only worth anticipating if it both has
+// interior nodes and feeds something outside the interior at non-trivial cost.
+struct AnticipationPartition {
+    // Indices into the input `nodes` span: every eligible node EXCEPT the live
+    // sinks (AudioOutput / MidiOutput), which are consumed at the real deadline
+    // and must not be written ahead. (Live SOURCES never appear — 6a already
+    // excludes them.)
+    std::vector<std::size_t> interior_nodes;
+    std::vector<AnticipationBoundary> boundary;
+    // Sum of a coarse static per-node cost weight over the interior (max(in,out)
+    // ports for processing nodes, 0 for I/O) — the same proxy the parallel cost
+    // gate uses. A worthiness signal, not a CPU-cycle estimate.
+    std::uint64_t cost_weight = 0;
+    bool ok = false;
+
+    // Worth pre-rendering only if there is interior work that something outside
+    // the interior actually consumes, at non-zero cost. An interior with no
+    // boundary produces nothing the live graph reads; a zero-cost interior is not
+    // worth the ring + scheduler overhead.
+    bool worth_anticipating() const {
+        return ok && !interior_nodes.empty() && !boundary.empty() && cost_weight > 0;
+    }
+};
+
+// Carve the anticipation-eligible interior + its boundary edges out of a graph,
+// given 6a's eligibility classification. Pure, deterministic, allocation-bounded;
+// no prepared/live graph required. Returns ok=false if `eligibility` is not ok or
+// does not match `nodes`, if `nodes` contains a duplicate id, or if a connection
+// names a node absent from `nodes` (the absent-id case is normally already caught
+// by 6a, which leaves `eligibility.ok == false`).
+//
+// This identifies WHAT a future anticipative renderer would render ahead and
+// WHERE its output splices into the live graph. It performs no rendering and
+// changes no real-time path. Like 6a it is a static safety/structure analysis;
+// the host-time clearance still applies on top before anything is rendered ahead.
+AnticipationPartition build_anticipation_partition(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections,
+    const AnticipationEligibility& eligibility);
+
+} // namespace pulp::host

--- a/core/host/src/anticipation_eligibility.cpp
+++ b/core/host/src/anticipation_eligibility.cpp
@@ -11,11 +11,17 @@ AnticipationEligibility analyze_anticipation_eligibility(
     AnticipationEligibility result;
     result.node_exclusion.assign(nodes.size(), AnticipationExclusion::None);
 
-    // NodeId -> dense index into `nodes`.
+    // NodeId -> dense index into `nodes`. Duplicate ids would collapse a later
+    // node onto an earlier one's classification when edges resolve their
+    // endpoints, so a stale/aliased id could escape an exclusion — reject as
+    // malformed (a safety classifier must be correct by construction, not by an
+    // unstated unique-id assumption on a raw span).
     std::unordered_map<NodeId, std::size_t> index_of;
     index_of.reserve(nodes.size());
     for (std::size_t i = 0; i < nodes.size(); ++i) {
-        index_of.emplace(nodes[i].id, i);
+        if (!index_of.emplace(nodes[i].id, i).second) {
+            return result;  // ok = false
+        }
     }
 
     auto find = [&](NodeId id, std::size_t& out) -> bool {

--- a/core/host/src/anticipation_partition.cpp
+++ b/core/host/src/anticipation_partition.cpp
@@ -1,0 +1,87 @@
+#include <pulp/host/anticipation_partition.hpp>
+
+#include <pulp/host/signal_graph.hpp>
+
+#include <algorithm>
+#include <unordered_map>
+
+namespace pulp::host {
+namespace {
+
+// Coarse static per-node cost weight, mirroring the parallel executor's gate:
+// the per-channel work a processing node does, 0 for pure I/O / sinks.
+std::uint64_t node_cost_weight(const GraphNode& n) {
+    switch (n.type) {
+        case NodeType::Plugin:
+        case NodeType::Gain:
+        case NodeType::Custom:
+            return static_cast<std::uint64_t>(
+                std::max(n.num_input_ports, n.num_output_ports));
+        case NodeType::AudioInput:
+        case NodeType::AudioOutput:
+        case NodeType::MidiInput:
+        case NodeType::MidiOutput:
+            return 0;
+    }
+    return 0;
+}
+
+// A live sink: eligible but consumed at the real deadline, so never rendered
+// ahead even though nothing downstream excludes it. LANDMINE: a node defaults to
+// interior (anticipatable) work, so any NEW NodeType that represents a live
+// endpoint MUST be added here (and a new live SOURCE must be seeded in 6a) — the
+// unsafe direction for a safety classifier is to silently treat it as interior.
+bool is_live_sink(NodeType t) {
+    return t == NodeType::AudioOutput || t == NodeType::MidiOutput;
+}
+
+} // namespace
+
+AnticipationPartition build_anticipation_partition(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections,
+    const AnticipationEligibility& eligibility) {
+    AnticipationPartition result;
+    if (!eligibility.ok || eligibility.node_exclusion.size() != nodes.size()) {
+        return result;  // ok = false
+    }
+
+    // The renderable interior: eligible, minus the live sinks.
+    std::unordered_map<NodeId, std::size_t> index_of;
+    index_of.reserve(nodes.size());
+    std::vector<bool> in_interior(nodes.size(), false);
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        // Duplicate ids would silently collapse a later node onto an earlier one's
+        // classification when the boundary loop resolves connection endpoints —
+        // fabricating or missing a splice point. Reject as malformed; a safety
+        // classifier must be correct by construction, not by an unstated unique-id
+        // assumption on a raw span.
+        if (!index_of.emplace(nodes[i].id, i).second) {
+            return AnticipationPartition{};  // ok = false
+        }
+        if (eligibility.passes_static_exclusions(i) && !is_live_sink(nodes[i].type)) {
+            in_interior[i] = true;
+            result.interior_nodes.push_back(i);
+            result.cost_weight += node_cost_weight(nodes[i]);
+        }
+    }
+
+    // Boundary: every edge whose source is interior and whose destination is not.
+    // (6a excludes all feedback endpoints, so no interior node is a feedback
+    // endpoint — every edge leaving the interior is a feedforward splice point.)
+    for (const auto& c : connections) {
+        const auto si = index_of.find(c.source_node);
+        const auto di = index_of.find(c.dest_node);
+        if (si == index_of.end() || di == index_of.end()) {
+            return AnticipationPartition{};  // malformed: dangling node id
+        }
+        if (in_interior[si->second] && !in_interior[di->second]) {
+            result.boundary.push_back(
+                {c.source_node, c.source_port, c.dest_node, c.dest_port});
+        }
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace pulp::host

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -72,6 +72,12 @@ pulp_add_test_suite(pulp-test-graph-routing-differential-parity
 pulp_add_test_suite(pulp-test-anticipation-eligibility
     SOURCES test_anticipation_eligibility.cpp
     LIBRARIES pulp::host pulp::format pulp::graph)
+# The eligible interior + boundary edges carved out for anticipative rendering:
+# live sinks stay out of the interior, every interior->outside edge is a splice
+# point, and a live-only graph yields nothing worth anticipating.
+pulp_add_test_suite(pulp-test-anticipation-partition
+    SOURCES test_anticipation_partition.cpp
+    LIBRARIES pulp::host pulp::format pulp::graph)
 
 # First sampler/looper storage primitives split by ownership so failures point
 # to the actual layer instead of a catch-all primitive bucket.

--- a/test/test_anticipation_partition.cpp
+++ b/test/test_anticipation_partition.cpp
@@ -1,0 +1,227 @@
+// Coverage for the anticipation partition: given 6a's eligibility classification,
+// it carves out the renderable eligible interior and the boundary edges whose
+// pre-rendered output the live graph would consume. These tests assert that live
+// sinks stay out of the interior, every interior->outside edge is captured as a
+// splice point, the cost weight reflects the interior, and a live-only graph
+// yields nothing worth anticipating.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/anticipation_partition.hpp>
+#include <pulp/host/signal_graph.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace pulp::host;
+
+namespace {
+
+GraphNode mk(NodeId id, NodeType type, int in, int out) {
+    GraphNode n;
+    n.id = id;
+    n.type = type;
+    n.num_input_ports = in;
+    n.num_output_ports = out;
+    return n;
+}
+
+Connection edge(NodeId s, NodeId d) {
+    Connection c;
+    c.source_node = s;
+    c.source_port = 0;
+    c.dest_node = d;
+    c.dest_port = 0;
+    return c;
+}
+
+AnticipationPartition partition_of(std::span<const GraphNode> nodes,
+                                   std::span<const Connection> conns) {
+    const auto elig = analyze_anticipation_eligibility(nodes, conns);
+    return build_anticipation_partition(nodes, conns, elig);
+}
+
+bool interior_has(const AnticipationPartition& p, const std::vector<GraphNode>& nodes,
+                  NodeId id) {
+    return std::any_of(p.interior_nodes.begin(), p.interior_nodes.end(),
+                       [&](std::size_t i) { return nodes[i].id == id; });
+}
+
+bool has_boundary(const AnticipationPartition& p, NodeId src, NodeId dst) {
+    return std::any_of(p.boundary.begin(), p.boundary.end(),
+                       [&](const AnticipationBoundary& b) {
+                           return b.source_node == src && b.dest_node == dst;
+                       });
+}
+
+}  // namespace
+
+TEST_CASE("Partition: a latent generator chain has interior nodes and a sink boundary",
+          "[host][anticipation][partition]") {
+    // gen(2 out) -> gain -> out. Interior = {gen, gain}; the live sink `out` is
+    // excluded from the interior and is the boundary the renderer feeds.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(p.interior_nodes.size() == 2);
+    CHECK(interior_has(p, nodes, 1));
+    CHECK(interior_has(p, nodes, 2));
+    CHECK_FALSE(interior_has(p, nodes, 3));   // live sink stays out
+    CHECK(has_boundary(p, 2, 3));             // gain -> out is the splice point
+    CHECK(p.boundary.size() == 1);
+    CHECK(p.cost_weight == 4);                // gen max(0,2)=2 + gain max(2,2)=2
+    CHECK(p.worth_anticipating());
+}
+
+TEST_CASE("Partition: a fully live graph yields nothing worth anticipating",
+          "[host][anticipation][partition]") {
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3)};
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(p.interior_nodes.empty());
+    CHECK(p.boundary.empty());
+    CHECK(p.cost_weight == 0);
+    CHECK_FALSE(p.worth_anticipating());
+}
+
+TEST_CASE("Partition: an eligible interior feeding a live node makes that edge a boundary",
+          "[host][anticipation][partition]") {
+    // gen -> fx, and in(live) -> fx. fx is excluded (live-fed); gen is interior.
+    // The gen -> fx edge crosses out of the interior and is a splice point.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),    // gen (interior)
+                                 mk(2, NodeType::AudioInput, 0, 2),  // live
+                                 mk(3, NodeType::Plugin, 4, 2),    // fx (excluded)
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 3), edge(2, 3), edge(3, 4)};
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(interior_has(p, nodes, 1));
+    CHECK_FALSE(interior_has(p, nodes, 3));  // fx is live-fed
+    CHECK(has_boundary(p, 1, 3));            // gen -> fx
+    CHECK_FALSE(has_boundary(p, 3, 4));      // fx is not interior; not a boundary
+    CHECK(p.worth_anticipating());
+}
+
+TEST_CASE("Partition: independent latent subgraph is isolated from the live one",
+          "[host][anticipation][partition]") {
+    // Live: in -> g1 -> out1. Latent: gen -> g2 -> out2. Only the latent chain is
+    // interior; its boundary is g2 -> out2.
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0),
+                                 mk(4, NodeType::Plugin, 0, 2),
+                                 mk(5, NodeType::Gain, 2, 2),
+                                 mk(6, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(2, 3), edge(4, 5), edge(5, 6)};
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(interior_has(p, nodes, 4));
+    CHECK(interior_has(p, nodes, 5));
+    CHECK_FALSE(interior_has(p, nodes, 2));  // live chain excluded
+    CHECK(has_boundary(p, 5, 6));
+    CHECK(p.boundary.size() == 1);
+    CHECK(p.worth_anticipating());
+}
+
+TEST_CASE("Partition: a malformed connection or unmatched eligibility is rejected",
+          "[host][anticipation][partition]") {
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2)};
+
+    SECTION("dangling connection id") {
+        std::vector<Connection> conns{edge(1, 99)};
+        // 6a already rejects this, so eligibility is not ok and the partition is
+        // rejected in turn.
+        const auto elig = analyze_anticipation_eligibility(nodes, conns);
+        CHECK_FALSE(elig.ok);
+        const auto p = build_anticipation_partition(nodes, conns, elig);
+        CHECK_FALSE(p.ok);
+    }
+
+    SECTION("eligibility sized for a different graph") {
+        AnticipationEligibility mismatched;
+        mismatched.ok = true;
+        mismatched.node_exclusion.assign(5, AnticipationExclusion::None);
+        const auto p = build_anticipation_partition(nodes, {}, mismatched);
+        CHECK_FALSE(p.ok);
+    }
+
+    SECTION("dangling id with an otherwise-matching eligibility") {
+        // Exercise the partition's own dangling-id rejection directly: a
+        // size-matched, ok eligibility paired with a connection naming an absent
+        // node (the case 6a would normally have rejected first).
+        AnticipationEligibility ok_elig;
+        ok_elig.ok = true;
+        ok_elig.node_exclusion.assign(1, AnticipationExclusion::None);
+        std::vector<Connection> conns{edge(1, 99)};
+        const auto p = build_anticipation_partition(nodes, conns, ok_elig);
+        CHECK_FALSE(p.ok);
+    }
+}
+
+TEST_CASE("Partition: a duplicate node id is rejected as malformed",
+          "[host][anticipation][partition]") {
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(1, NodeType::Gain, 2, 2)};  // duplicate id 1
+    const auto p = partition_of(nodes, {});
+    CHECK_FALSE(p.ok);
+}
+
+TEST_CASE("Partition: an interior node feeding both interior and live nodes",
+          "[host][anticipation][partition]") {
+    // gen -> g (interior), and gen also -> fx where fx is live-fed (excluded). The
+    // gen->g edge is internal (not a boundary); the gen->fx edge is a boundary.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),     // gen (interior)
+                                 mk(2, NodeType::Gain, 2, 2),       // g (interior)
+                                 mk(3, NodeType::AudioInput, 0, 2),   // live
+                                 mk(4, NodeType::Plugin, 4, 2),     // fx (live-fed)
+                                 mk(5, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(1, 2), edge(1, 4), edge(3, 4), edge(2, 5),
+                                  edge(4, 5)};
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(interior_has(p, nodes, 1));
+    CHECK(interior_has(p, nodes, 2));
+    CHECK_FALSE(interior_has(p, nodes, 4));  // live-fed
+    CHECK_FALSE(has_boundary(p, 1, 2));      // internal edge, not a splice point
+    CHECK(has_boundary(p, 1, 4));            // gen -> live fx
+    CHECK(has_boundary(p, 2, 5));            // g -> out
+}
+
+TEST_CASE("Partition: a MIDI boundary edge from the interior is captured",
+          "[host][anticipation][partition]") {
+    // A sequenced (non-live) MIDI generator -> instrument, where the instrument is
+    // excluded for another reason (sidechain). The midi edge crossing out of the
+    // interior is still recorded as a boundary splice point.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 0),    // midi gen (interior)
+                                 mk(2, NodeType::Plugin, 2, 2),    // sidechain src (interior)
+                                 mk(3, NodeType::Plugin, 4, 2),    // instrument (sidechained)
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge(3, 4)};
+    Connection midi_edge = edge(1, 3);
+    midi_edge.midi = true;
+    conns.push_back(midi_edge);
+    Connection sc = edge(2, 3);
+    sc.dest_port = 2;
+    sc.sidechain = true;
+    conns.push_back(sc);
+    const auto p = partition_of(nodes, conns);
+    REQUIRE(p.ok);
+    CHECK(interior_has(p, nodes, 1));
+    CHECK_FALSE(interior_has(p, nodes, 3));  // sidechained
+    CHECK(has_boundary(p, 1, 3));            // the midi edge is a boundary
+}
+
+TEST_CASE("Partition: an empty graph is ok but not worth anticipating",
+          "[host][anticipation][partition]") {
+    const auto p = partition_of({}, {});
+    CHECK(p.ok);
+    CHECK(p.interior_nodes.empty());
+    CHECK_FALSE(p.worth_anticipating());
+}


### PR DESCRIPTION
## Summary

Second slice of **masterwork Phase 6** (anticipative rendering). Given 6a's static eligibility classification (#4820), `build_anticipation_partition` carves a graph into:
- the **eligible interior** — every eligible node *except* the live sinks (`AudioOutput`/`MidiOutput`, consumed at the real deadline, never written ahead), and
- the **boundary edges** — every edge leaving the interior, the splice points where pre-rendered output feeds the live graph.

A coarse `cost_weight` (the same `max(in,out)` proxy the parallel cost gate uses) and `worth_anticipating()` gate out trivial / no-boundary partitions. Pure static analysis — no renderer, no real-time path. This identifies *what* the Phase 6 renderer will run ahead and *where* its output connects (per the design doc, `planning/2026-06-25-phase6-anticipative-rendering-design.md`).

Also hardens **both** anticipation analyses (6a + 6b) to reject a duplicate node id as malformed — a span-taking safety classifier must be correct by construction, not rely on an unstated unique-id assumption a stray aliased id could exploit to escape an exclusion.

## Tests (9 cases)

Latent generator chain interior/boundary; fully live graph (nothing worth anticipating); eligible interior feeding a live node; independent latent subgraph; an interior node feeding both interior and live nodes; a MIDI boundary edge; duplicate-id and dangling-id rejection; empty graph.

Adversarial review: no MUST-FIX; applied SHOULD-FIX (duplicate-id rejection, dangling-id contract tightening, the "new NodeType defaults to interior" landmine comment) and added the review-flagged test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the anticipation partition for Phase 6, carving the eligible interior and boundary edges so we know what to pre-render and where it connects to the live graph. Also hardens safety by rejecting duplicate node IDs and malformed connections.

- New Features
  - Added build_anticipation_partition to select interior nodes from eligibility, excluding live sinks (AudioOutput/MidiOutput).
  - Captures all edges from interior to non-interior as boundary splice points.
  - Computes a coarse cost_weight and provides worth_anticipating() to skip trivial or no-boundary partitions. Pure static analysis; no RT path changes.

- Bug Fixes
  - Rejects duplicate NodeId in both anticipation analyses.
  - Partition builder rejects mismatched eligibility spans and dangling node IDs in connections.

<sup>Written for commit 2c433fceb186426839235b27f20843b89b841bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

