### PR TITLE
feat(host): anticipation sub-graph extraction (renderable interior + sink)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -220,6 +220,19 @@ predictable output, no MIDI.
   `worth_anticipating()` gate out trivial/no-boundary partitions. Still pure static
   analysis — no rendering, no RT path. Builds on the 6a eligibility result and is
   rejected (ok=false) if that result isn't ok or doesn't match the node span.
+- **Anticipation sub-graph (`anticipation_subgraph.{hpp,cpp}`).**
+  `build_anticipation_subgraph(nodes, connections, partition)` turns a partition
+  into a standalone renderable graph: it copies the interior nodes verbatim (plugin
+  slots/gain/ports preserved) and the internal edges, and synthesizes ONE
+  one-input `AudioOutput` sink per DISTINCT boundary output port (fresh ids above
+  every existing node id, so no collision), fed from that port — so the sub-graph
+  renders through the ordinary `build_executor_snapshot` + `process_routed` and its
+  output bus carries exactly the boundary signals. `outputs[]` maps each sink back
+  to the `(source_node, source_port)` it captures. GOTCHA: the interior plugin
+  GraphNodes are copied by value, so the SAME plugin instances render here — which
+  means a live splice (a later slice) must NOT also process those instances, or
+  their state double-advances. This slice does extraction only; it neither renders
+  nor changes any RT path.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.244.1",
+      "version": "0.245.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.244.1"
+  "version": "0.245.0"
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.244.0",
+      "version": "0.245.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.244.0"
+  "version": "0.245.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.244.1",
+  "version": "0.245.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.244.0",
+  "version": "0.245.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.487.0
+    VERSION 0.488.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.488.0
+    VERSION 0.489.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(pulp-host PRIVATE
     src/signal_graph_executor_routing.cpp
     src/anticipation_eligibility.cpp
     src/anticipation_partition.cpp
+    src/anticipation_subgraph.cpp
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::format pulp::graph pulp::midi pulp::runtime pulp::state)

--- a/core/host/include/pulp/host/anticipation_subgraph.hpp
+++ b/core/host/include/pulp/host/anticipation_subgraph.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <pulp/host/anticipation_partition.hpp>
+#include <pulp/host/graph_types.hpp>
+
+#include <span>
+#include <vector>
+
+namespace pulp::host {
+
+struct GraphNode;
+struct Connection;
+
+// A standalone, renderable graph carved out of a larger one: the anticipation
+// partition's interior, plus a SINGLE synthesized AudioOutput sink whose input
+// ports are the distinct boundary output ports, so the whole thing renders
+// through the ordinary executor (build_executor_snapshot + process_routed) and
+// its output bus carries exactly the boundary signals the live graph needs — each
+// on its own channel. The interior GraphNodes are COPIED verbatim (plugin slots,
+// gain, ports preserved), so the same plugin instances render here — ownership of
+// those instances across the ahead/live boundary is the renderer's concern, not
+// this extraction's. NOTE: this does not check interior executor-eligibility (a
+// Custom or null-slot Plugin interior node would make build_executor_snapshot
+// reject the sub-graph); that gate belongs to the renderer slice.
+struct AnticipationSubgraph {
+    std::vector<GraphNode> nodes;         // interior nodes, then the one sink
+    std::vector<Connection> connections;  // internal edges, then source->sink edges
+
+    // One entry per captured boundary port, in OUTPUT-BUS CHANNEL ORDER: the
+    // output at index i carries the original interior port (source_node,
+    // source_port) on output-bus channel i (the sink's input port i). `sink_node`
+    // is the same synthesized AudioOutput id for every entry. The renderer maps
+    // each live boundary edge to the output that carries its source's signal.
+    struct Output {
+        NodeId source_node = 0;
+        PortIndex source_port = 0;
+        NodeId sink_node = 0;
+    };
+    std::vector<Output> outputs;
+    bool ok = false;
+
+    bool renders_anything() const { return ok && !outputs.empty(); }
+};
+
+// Build the renderable sub-graph for a partition: copy the interior nodes, copy
+// the connections internal to the interior, and for each DISTINCT boundary output
+// port (source_node, source_port) synthesize a one-input AudioOutput sink fed from
+// that port (fresh ids above every existing node id, so they never collide).
+// Deterministic; allocation-bounded. Returns ok=false if `partition` is not ok or
+// references a node absent from `nodes` (it should not, having been built from the
+// same graph). The interior carries no feedback edges (6a excludes feedback
+// endpoints), so every internal edge is feedforward and every boundary edge leaves
+// the interior forward — the sub-graph is acyclic and self-contained.
+AnticipationSubgraph build_anticipation_subgraph(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections,
+    const AnticipationPartition& partition);
+
+} // namespace pulp::host

--- a/core/host/src/anticipation_subgraph.cpp
+++ b/core/host/src/anticipation_subgraph.cpp
@@ -1,0 +1,96 @@
+#include <pulp/host/anticipation_subgraph.hpp>
+
+#include <pulp/host/signal_graph.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace pulp::host {
+
+// port_key packs (NodeId, PortIndex) losslessly into 64 bits. Both are 32-bit, so
+// the node occupies the high half and the port the low half with no aliasing; the
+// static_assert guards the day someone widens either type (which would silently
+// collapse two distinct boundary ports onto one captured output).
+static_assert(sizeof(NodeId) <= 4 && sizeof(PortIndex) <= 4,
+              "anticipation_subgraph::port_key assumes 32-bit NodeId/PortIndex");
+
+AnticipationSubgraph build_anticipation_subgraph(
+    std::span<const GraphNode> nodes, std::span<const Connection> connections,
+    const AnticipationPartition& partition) {
+    AnticipationSubgraph result;
+    if (!partition.ok) return result;  // ok = false
+
+    // Interior id set + a fresh-id seed above every existing node id.
+    std::unordered_set<NodeId> interior;
+    interior.reserve(partition.interior_nodes.size());
+    NodeId max_id = 0;
+    for (const auto& n : nodes) max_id = std::max(max_id, n.id);
+    for (const auto idx : partition.interior_nodes) {
+        if (idx >= nodes.size()) return AnticipationSubgraph{};  // malformed
+        interior.insert(nodes[idx].id);
+        result.nodes.push_back(nodes[idx]);
+    }
+
+    // Internal edges: both endpoints in the interior. (No feedback edges can be
+    // internal — 6a excludes both endpoints of every feedback edge from the
+    // interior — so the copied sub-graph is acyclic.)
+    for (const auto& c : connections) {
+        if (interior.count(c.source_node) && interior.count(c.dest_node)) {
+            result.connections.push_back(c);
+        }
+    }
+
+    // Distinct boundary output ports (source_node, source_port), in encounter
+    // order: several live consumers of the same interior port share one captured
+    // output. Each becomes one channel of a SINGLE synthesized AudioOutput sink.
+    std::unordered_map<std::uint64_t, bool> seen_port;
+    seen_port.reserve(partition.boundary.size());
+    auto port_key = [](NodeId n, PortIndex p) -> std::uint64_t {
+        return (static_cast<std::uint64_t>(n) << 32) ^ static_cast<std::uint32_t>(p);
+    };
+    std::vector<std::pair<NodeId, PortIndex>> ports;
+    for (const auto& b : partition.boundary) {
+        if (seen_port.emplace(port_key(b.source_node, b.source_port), true).second) {
+            ports.push_back({b.source_node, b.source_port});
+        }
+    }
+    if (ports.empty()) {
+        result.ok = true;
+        return result;  // interior with no boundary: nothing to capture
+    }
+
+    // ONE AudioOutput sink with one input port per captured boundary port. The
+    // executor maps an AudioOutput node's input port p to output-bus channel p
+    // (accumulating), so wiring boundary port i into the sink's dest_port i lands
+    // each captured signal on its OWN channel — distinct, never summed together.
+    // `outputs[i]` therefore corresponds to output-bus channel i.
+    if (max_id == std::numeric_limits<NodeId>::max()) {
+        return AnticipationSubgraph{};  // no room for a fresh id without wrapping
+    }
+    const NodeId sink_id = max_id + 1;
+    GraphNode sink;
+    sink.id = sink_id;
+    sink.type = NodeType::AudioOutput;
+    sink.num_input_ports = static_cast<int>(ports.size());
+    sink.num_output_ports = 0;
+    result.nodes.push_back(std::move(sink));
+
+    for (std::size_t i = 0; i < ports.size(); ++i) {
+        Connection cap;
+        cap.source_node = ports[i].first;
+        cap.source_port = ports[i].second;
+        cap.dest_node = sink_id;
+        cap.dest_port = static_cast<PortIndex>(i);
+        result.connections.push_back(cap);
+        result.outputs.push_back({ports[i].first, ports[i].second, sink_id});
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace pulp::host

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -78,6 +78,12 @@ pulp_add_test_suite(pulp-test-anticipation-eligibility
 pulp_add_test_suite(pulp-test-anticipation-partition
     SOURCES test_anticipation_partition.cpp
     LIBRARIES pulp::host pulp::format pulp::graph)
+# The renderable sub-graph carved from a partition: interior nodes + internal
+# edges + one synthesized AudioOutput sink per distinct boundary output port, with
+# fresh non-colliding ids.
+pulp_add_test_suite(pulp-test-anticipation-subgraph
+    SOURCES test_anticipation_subgraph.cpp
+    LIBRARIES pulp::host pulp::format pulp::graph)
 
 # First sampler/looper storage primitives split by ownership so failures point
 # to the actual layer instead of a catch-all primitive bucket.

--- a/test/test_anticipation_subgraph.cpp
+++ b/test/test_anticipation_subgraph.cpp
@@ -1,0 +1,178 @@
+// Coverage for the anticipation sub-graph extraction: the renderable interior
+// carved from a partition, with one synthesized AudioOutput sink per distinct
+// boundary output port. These tests assert the interior nodes and internal edges
+// are copied, each distinct boundary port gets exactly one sink fed from it,
+// synthesized ids never collide with existing ones, and a graph with no eligible
+// interior renders nothing.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/anticipation_partition.hpp>
+#include <pulp/host/anticipation_subgraph.hpp>
+#include <pulp/host/signal_graph.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace pulp::host;
+
+namespace {
+
+GraphNode mk(NodeId id, NodeType type, int in, int out) {
+    GraphNode n;
+    n.id = id;
+    n.type = type;
+    n.num_input_ports = in;
+    n.num_output_ports = out;
+    return n;
+}
+
+Connection edge_p(NodeId s, PortIndex sp, NodeId d, PortIndex dp) {
+    Connection c;
+    c.source_node = s;
+    c.source_port = sp;
+    c.dest_node = d;
+    c.dest_port = dp;
+    return c;
+}
+
+AnticipationSubgraph subgraph_of(std::span<const GraphNode> nodes,
+                                 std::span<const Connection> conns) {
+    const auto elig = analyze_anticipation_eligibility(nodes, conns);
+    const auto part = build_anticipation_partition(nodes, conns, elig);
+    return build_anticipation_subgraph(nodes, conns, part);
+}
+
+const GraphNode* find_node(const AnticipationSubgraph& g, NodeId id) {
+    const auto it = std::find_if(g.nodes.begin(), g.nodes.end(),
+                                 [&](const GraphNode& n) { return n.id == id; });
+    return it == g.nodes.end() ? nullptr : &*it;
+}
+
+bool has_conn(const AnticipationSubgraph& g, NodeId s, PortIndex sp, NodeId d) {
+    return std::any_of(g.connections.begin(), g.connections.end(),
+                       [&](const Connection& c) {
+                           return c.source_node == s && c.source_port == sp &&
+                                  c.dest_node == d;
+                       });
+}
+
+bool has_conn_port(const AnticipationSubgraph& g, NodeId s, PortIndex sp, NodeId d,
+                   PortIndex dp) {
+    return std::any_of(g.connections.begin(), g.connections.end(),
+                       [&](const Connection& c) {
+                           return c.source_node == s && c.source_port == sp &&
+                                  c.dest_node == d && c.dest_port == dp;
+                       });
+}
+
+int count_sinks(const AnticipationSubgraph& g) {
+    return static_cast<int>(std::count_if(
+        g.nodes.begin(), g.nodes.end(),
+        [](const GraphNode& n) { return n.type == NodeType::AudioOutput; }));
+}
+
+}  // namespace
+
+TEST_CASE("Subgraph: a stereo generator chain copies the interior and synthesizes sinks",
+          "[host][anticipation][subgraph]") {
+    // gen(0/2) -> gain(2/2) -> out(2/0), stereo. Interior = {gen, gain}; out is a
+    // live sink. Two boundary ports (gain:0, gain:1) -> two synthesized sinks.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge_p(1, 0, 2, 0), edge_p(1, 1, 2, 1),
+                                  edge_p(2, 0, 3, 0), edge_p(2, 1, 3, 1)};
+    const auto g = subgraph_of(nodes, conns);
+    REQUIRE(g.ok);
+
+    // Interior copied verbatim.
+    REQUIRE(find_node(g, 1) != nullptr);
+    REQUIRE(find_node(g, 2) != nullptr);
+    CHECK(find_node(g, 3) == nullptr);  // the live sink is not in the sub-graph
+
+    // Internal edges copied (both ports of gen -> gain).
+    CHECK(has_conn(g, 1, 0, 2));
+    CHECK(has_conn(g, 1, 1, 2));
+
+    // Two distinct boundary ports -> ONE synthesized AudioOutput sink with two
+    // input ports, each boundary port wired to its OWN sink dest_port so it lands
+    // on its own output-bus channel (never summed). outputs[i] == channel i.
+    REQUIRE(g.outputs.size() == 2);
+    CHECK(g.renders_anything());
+    CHECK(count_sinks(g) == 1);
+    const NodeId sink = g.outputs[0].sink_node;
+    CHECK(g.outputs[1].sink_node == sink);  // one shared sink
+    const GraphNode* sink_node = find_node(g, sink);
+    REQUIRE(sink_node != nullptr);
+    CHECK(sink_node->type == NodeType::AudioOutput);
+    CHECK(sink_node->num_input_ports == 2);  // one channel per captured port
+    CHECK(sink_node->num_output_ports == 0);
+    CHECK(sink_node->id > 3);  // fresh, above every original id
+    for (std::size_t i = 0; i < g.outputs.size(); ++i) {
+        const auto& o = g.outputs[i];
+        CHECK(o.source_node == 2);
+        // boundary port i -> sink dest_port i (== output-bus channel i)
+        CHECK(has_conn_port(g, o.source_node, o.source_port, sink,
+                            static_cast<PortIndex>(i)));
+    }
+    CHECK(g.outputs[0].source_port != g.outputs[1].source_port);  // ports 0 and 1
+}
+
+TEST_CASE("Subgraph: several consumers of one interior port share a single sink",
+          "[host][anticipation][subgraph]") {
+    // gen -> gain, and gain:0 feeds two live sinks. The interior port (gain,0) is
+    // captured once, not per consumer.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 1),
+                                 mk(2, NodeType::Gain, 1, 1),
+                                 mk(3, NodeType::AudioOutput, 1, 0),
+                                 mk(4, NodeType::AudioOutput, 1, 0)};
+    std::vector<Connection> conns{edge_p(1, 0, 2, 0), edge_p(2, 0, 3, 0),
+                                  edge_p(2, 0, 4, 0)};
+    const auto g = subgraph_of(nodes, conns);
+    REQUIRE(g.ok);
+    REQUIRE(g.outputs.size() == 1);  // (gain,0) captured once
+    CHECK(g.outputs[0].source_node == 2);
+    CHECK(g.outputs[0].source_port == 0);
+}
+
+TEST_CASE("Subgraph: a fully live graph renders nothing",
+          "[host][anticipation][subgraph]") {
+    std::vector<GraphNode> nodes{mk(1, NodeType::AudioInput, 0, 2),
+                                 mk(2, NodeType::Gain, 2, 2),
+                                 mk(3, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge_p(1, 0, 2, 0), edge_p(2, 0, 3, 0)};
+    const auto g = subgraph_of(nodes, conns);
+    REQUIRE(g.ok);
+    CHECK(g.nodes.empty());
+    CHECK(g.outputs.empty());
+    CHECK_FALSE(g.renders_anything());
+}
+
+TEST_CASE("Subgraph: an interior feeding a live node captures the boundary port",
+          "[host][anticipation][subgraph]") {
+    // gen -> fx, in(live) -> fx. fx is excluded; gen is interior. The gen -> fx
+    // edge is a boundary, so gen's output port is captured by a sink.
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2),
+                                 mk(2, NodeType::AudioInput, 0, 2),
+                                 mk(3, NodeType::Plugin, 4, 2),
+                                 mk(4, NodeType::AudioOutput, 2, 0)};
+    std::vector<Connection> conns{edge_p(1, 0, 3, 0), edge_p(1, 1, 3, 1),
+                                  edge_p(2, 0, 3, 2), edge_p(2, 1, 3, 3),
+                                  edge_p(3, 0, 4, 0), edge_p(3, 1, 4, 1)};
+    const auto g = subgraph_of(nodes, conns);
+    REQUIRE(g.ok);
+    CHECK(find_node(g, 1) != nullptr);
+    CHECK(find_node(g, 3) == nullptr);  // fx excluded
+    REQUIRE(g.outputs.size() == 2);     // gen's two ports captured
+    for (const auto& o : g.outputs) CHECK(o.source_node == 1);
+}
+
+TEST_CASE("Subgraph: a not-ok partition yields a not-ok sub-graph",
+          "[host][anticipation][subgraph]") {
+    AnticipationPartition bad;  // ok == false
+    std::vector<GraphNode> nodes{mk(1, NodeType::Plugin, 0, 2)};
+    const auto g = build_anticipation_subgraph(nodes, {}, bad);
+    CHECK_FALSE(g.ok);
+}


### PR DESCRIPTION
## Summary

Third slice of **masterwork Phase 6**. `build_anticipation_subgraph(nodes, connections, partition)` turns the anticipation partition (6b) into a **standalone renderable graph** the future ahead-renderer drives:
- copies the interior nodes verbatim (plugin slots / gain / ports preserved) and the internal edges, and
- synthesizes a **single** `AudioOutput` sink whose input ports are the distinct boundary output ports, fed so each captured signal lands on its **own** output-bus channel. The synthesized id is fresh (above every existing node id) and overflow-guarded.

Pure transformation — no rendering, no real-time path.

## Review-caught MUST-FIX (M1)

The executor maps an `AudioOutput` node's input port *p* → output-bus channel *p* and **accumulates** (`+=`). The first draft made one 1-input sink *per* boundary port, all wired to `dest_port 0` — which would have summed every captured signal onto channel 0 (silent on the rest). Fixed to one sink with *N* input ports, boundary port *i* → `dest_port i` (= bus channel *i*); `outputs[i]` corresponds to channel *i*. The structural test now locks that exact wiring. Also applied SHOULD-FIX: a fresh-id wrap guard and a `static_assert` on the port-dedup key's 32-bit packing.

**Follow-up flagged for 6d:** the structural tests alone did not catch M1 — 6d must add an executor render-path proof (push the sub-graph through `build_executor_snapshot` + `process_routed`, assert each boundary lands on its own channel).

## Tests (5 cases)

Stereo generator chain (interior copy, internal edges, one *N*-port sink with per-channel wiring); several consumers of one interior port collapsing to one captured channel; an interior feeding a live node; a fully live graph (renders nothing); a not-ok partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the anticipation sub-graph for ahead rendering: copies interior nodes/edges and adds a single N‑input `AudioOutput` sink so each boundary signal lands on its own output‑bus channel. Fixes the previous wiring that summed into channel 0; adds tests and guards with no RT path changes.

- **New Features**
  - `build_anticipation_subgraph(...)` creates a standalone renderable graph from a partition.
  - Synthesizes one N‑input `AudioOutput` sink; boundary port i → sink port i (bus channel i).
  - Copies interior nodes and internal connections; assigns a fresh, non‑colliding id; returns ok=false for invalid partitions.
  - Guards and tests: id overflow check, `static_assert` for 32‑bit port‑key packing, and structural tests for per‑channel wiring.

- **Dependencies**
  - Version bumps: project 0.489.0; `pulp` plugin metadata 0.245.0.

<sup>Written for commit 858bd0e567e355b2051b57000da762a179dc133c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

