### PR TITLE
feat(host): anticipation lane — render an eligible sub-graph ahead of the deadline

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -238,6 +238,22 @@ predictable output, no MIDI.
   means a live splice (a later slice) must NOT also process those instances, or
   their state double-advances. This slice does extraction only; it neither renders
   nor changes any RT path.
+- **Anticipation lane (`anticipation_lane.{hpp,cpp}`).** `AnticipationLane` renders
+  an eligible sub-graph AHEAD of the deadline into a `PlanarAudioRingBuffer`:
+  `prepare()` (off-RT, quiescent) builds the executor snapshot + sizes the ring for
+  a FIXED block size; `render_ahead()` (single background producer) advances the
+  interior's plugin state and pushes whole blocks; `consume()` (audio thread,
+  RT-safe, no-alloc) pops a pre-rendered block or reports underrun so the caller
+  falls back to a synchronous render. The block size is PINNED at prepare (before
+  any thread exists) so producer/consumer stay in lockstep and there's no
+  cross-thread block-size field — the consumed sequence is bit-identical to a
+  block-by-block synchronous render. GOTCHAS: (1) the interior plugins are advanced
+  ONLY by render_ahead — a live splice that uses a lane must not also process those
+  nodes or their state double-advances; (2) render_ahead is SINGLE-producer (all
+  calls, including priming, must be serialized — they share unsynchronized
+  executor/pool/scratch); only the ring mediates against the consumer. There is no
+  SignalGraph splice wiring this into the live path yet — that's the final Phase 6
+  slice.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.245.0",
+      "version": "0.246.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.245.0"
+  "version": "0.246.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.245.0",
+  "version": "0.246.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.489.0
+    VERSION 0.490.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(pulp-host PRIVATE
     src/anticipation_eligibility.cpp
     src/anticipation_partition.cpp
     src/anticipation_subgraph.cpp
+    src/anticipation_lane.cpp
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::format pulp::graph pulp::midi pulp::runtime pulp::state)

--- a/core/host/include/pulp/host/anticipation_lane.hpp
+++ b/core/host/include/pulp/host/anticipation_lane.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <pulp/audio/buffer.hpp>
+#include <pulp/audio/planar_audio_ring_buffer.hpp>
+#include <pulp/format/graph_runtime_executor.hpp>
+#include <pulp/host/anticipation_subgraph.hpp>
+#include <pulp/host/graph_types.hpp>
+#include <pulp/host/signal_graph_executor_routing.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace pulp::host {
+
+class PluginSlot;
+
+// Renders an anticipation sub-graph AHEAD of the audio deadline into a ring, so
+// the live graph reads the pre-computed boundary signals instead of paying the
+// sub-graph's cost on the critical block (masterwork Phase 6). Single-producer /
+// single-consumer:
+//   - render_ahead() runs OFF the audio thread (a background/idle worker). It
+//     advances the interior's plugin state and pushes whole blocks into the ring.
+//   - consume() runs ON the audio thread. It pops one pre-rendered block, or
+//     reports underrun so the caller can fall back to a synchronous render.
+// The interior plugins are advanced ONLY here; a live splice that uses a lane
+// must not also process those nodes, or their state double-advances.
+//
+// Determinism: the producer renders the sub-graph for blocks in order, so the
+// block sequence the consumer pops is bit-identical to rendering the same
+// sub-graph synchronously block by block.
+class AnticipationLane {
+public:
+    AnticipationLane() = default;
+    AnticipationLane(const AnticipationLane&) = delete;
+    AnticipationLane& operator=(const AnticipationLane&) = delete;
+
+    // Off-RT, and requires no concurrent render_ahead/consume (quiescent, like the
+    // underlying ring). Build the executor snapshot for `sub` (resolving each
+    // interior node's gain atomic / plugin slot), size the scratch pool for
+    // `block_frames`, and size an output-channel ring holding `lead_blocks` blocks.
+    // The lane operates on ONE fixed block size — pinning it here (before any
+    // producer/consumer thread exists) keeps the producer and consumer in lockstep
+    // so the consumed sequence is deterministic, and avoids a cross-thread block-
+    // size field. Returns false if `sub` isn't renderable (ineligible interior, no
+    // outputs) or any sizing fails. block_frames and lead_blocks must be >= 1.
+    bool prepare(const AnticipationSubgraph& sub,
+                 const std::function<std::atomic<float>*(NodeId)>& gain_for,
+                 const std::function<PluginSlot*(NodeId)>& plugin_for,
+                 double sample_rate, int block_frames, int lead_blocks);
+
+    bool prepared() const noexcept { return prepared_; }
+    std::size_t output_channels() const noexcept { return out_channels_; }
+    int block_frames() const noexcept { return block_frames_; }
+    std::uint64_t buffered_frames() const noexcept { return ring_.available_frames(); }
+    std::uint64_t lead_capacity_frames() const noexcept { return ring_.capacity_frames(); }
+
+    // PRODUCER (off the audio thread): render fixed-size blocks until the ring
+    // can't hold another whole block or `max_blocks` have been rendered, whichever
+    // first. Advances interior plugin state. Returns the number of blocks rendered.
+    // Runs off the realtime thread (the per-block bus setup may allocate); never
+    // call it from the audio callback. SINGLE PRODUCER: all render_ahead calls
+    // (including any priming) must be serialized — they share unsynchronized
+    // executor/pool/scratch + plugin state with each other (only the ring mediates
+    // against the consumer).
+    int render_ahead(int max_blocks);
+
+    // CONSUMER (audio thread): pop one block into `out`, which must have
+    // output_channels() channels and at least block_frames() samples. Returns true
+    // on a hit; false on underrun (a whole block isn't buffered — the caller should
+    // render synchronously this block) or a malformed `out`. Real-time-safe: no
+    // allocation, no locks.
+    bool consume(pulp::audio::BufferView<float>& out) noexcept;
+
+private:
+    bool render_one_block();
+
+    format::GraphRuntimeSnapshot snapshot_;
+    std::vector<PluginBindingContext> plugin_ctx_;
+    PluginRoutingScratch scratch_;
+    format::GraphRuntimeBufferPool pool_;
+    format::GraphRuntimeExecutor exec_;
+    pulp::audio::PlanarAudioRingBuffer ring_;
+
+    // Producer-side scratch (pre-allocated): a zeroed main input bus the interior
+    // ignores, and the capture buffers process_routed writes the boundary channels
+    // into before they go to the ring.
+    std::vector<std::vector<float>> prod_in_;
+    std::vector<std::vector<float>> prod_out_;
+    std::vector<const float*> prod_in_ptrs_;
+    std::vector<float*> prod_out_ptrs_;
+
+    double sample_rate_ = 0.0;
+    int block_frames_ = 0;
+    std::size_t out_channels_ = 0;
+    bool prepared_ = false;
+};
+
+} // namespace pulp::host

--- a/core/host/src/anticipation_lane.cpp
+++ b/core/host/src/anticipation_lane.cpp
@@ -1,0 +1,101 @@
+#include <pulp/host/anticipation_lane.hpp>
+
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/host/signal_graph.hpp>
+
+#include <cstdint>
+
+namespace pulp::host {
+
+bool AnticipationLane::prepare(
+    const AnticipationSubgraph& sub,
+    const std::function<std::atomic<float>*(NodeId)>& gain_for,
+    const std::function<PluginSlot*(NodeId)>& plugin_for, double sample_rate,
+    int block_frames, int lead_blocks) {
+    // Reset to a clean not-prepared state so a mid-way failure can't leave the
+    // lane half-configured (every method gates on prepared_, but keep it tidy for
+    // a re-prepare).
+    prepared_ = false;
+    out_channels_ = 0;
+    block_frames_ = 0;
+    if (!sub.ok || sub.outputs.empty() || block_frames <= 0 || lead_blocks < 1) {
+        return false;
+    }
+    if (!build_executor_snapshot(sub.nodes, sub.connections, gain_for, plugin_for,
+                                 plugin_ctx_, scratch_, snapshot_)) {
+        return false;
+    }
+    if (!pool_.reset(snapshot_.buffer_slot_count(),
+                     static_cast<std::uint32_t>(block_frames),
+                     snapshot_.buffer_assignment().connection_delay_samples)) {
+        return false;
+    }
+
+    const std::size_t channels = sub.outputs.size();
+    if (!ring_.prepare(static_cast<std::uint32_t>(channels),
+                       static_cast<std::uint64_t>(lead_blocks) *
+                           static_cast<std::uint64_t>(block_frames))) {
+        return false;
+    }
+
+    // Producer scratch: a zeroed two-channel main input the interior ignores (the
+    // partition guarantees the interior has no live boundary input), and the
+    // boundary-channel capture the executor writes before each block goes to the
+    // ring.
+    prod_in_.assign(2, std::vector<float>(static_cast<std::size_t>(block_frames), 0.0f));
+    prod_out_.assign(channels,
+                     std::vector<float>(static_cast<std::size_t>(block_frames), 0.0f));
+    prod_in_ptrs_.clear();
+    prod_out_ptrs_.clear();
+    for (auto& c : prod_in_) prod_in_ptrs_.push_back(c.data());
+    for (auto& c : prod_out_) prod_out_ptrs_.push_back(c.data());
+
+    sample_rate_ = sample_rate;
+    block_frames_ = block_frames;
+    out_channels_ = channels;
+    prepared_ = true;
+    return true;
+}
+
+bool AnticipationLane::render_one_block() {
+    const auto frames = static_cast<std::uint32_t>(block_frames_);
+    pulp::audio::BufferView<const float> iv(prod_in_ptrs_.data(), prod_in_ptrs_.size(),
+                                            frames);
+    pulp::audio::BufferView<float> ov(prod_out_ptrs_.data(), prod_out_ptrs_.size(),
+                                      frames);
+    pulp::format::BusBufferSet buses;
+    if (!buses.add_input("main", iv, pulp::format::BusRole::Main)) return false;
+    if (!buses.add_output("main", ov, pulp::format::BusRole::Main)) return false;
+    pulp::format::ProcessBlock block;
+    block.sample_rate = sample_rate_;
+    block.frame_count = frames;
+    block.buses = &buses;
+    if (!block.validate()) return false;
+    if (!exec_.process_routed(block, snapshot_, pool_).ok()) return false;
+    return ring_.write(ov, block_frames_) == static_cast<std::uint64_t>(block_frames_);
+}
+
+int AnticipationLane::render_ahead(int max_blocks) {
+    if (!prepared_ || max_blocks <= 0) return 0;
+    int rendered = 0;
+    const auto f = static_cast<std::uint64_t>(block_frames_);
+    while (rendered < max_blocks &&
+           ring_.available_frames() + f <= ring_.capacity_frames()) {
+        if (!render_one_block()) break;
+        ++rendered;
+    }
+    return rendered;
+}
+
+bool AnticipationLane::consume(pulp::audio::BufferView<float>& out) noexcept {
+    if (!prepared_ || out.num_channels() != out_channels_ ||
+        out.num_samples() < static_cast<std::size_t>(block_frames_)) {
+        return false;
+    }
+    if (ring_.available_frames() < static_cast<std::uint64_t>(block_frames_)) {
+        return false;  // underrun
+    }
+    return ring_.read(out, static_cast<std::uint64_t>(block_frames_));
+}
+
+} // namespace pulp::host

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -87,6 +87,13 @@ pulp_add_test_suite(pulp-test-anticipation-partition
 pulp_add_test_suite(pulp-test-anticipation-subgraph
     SOURCES test_anticipation_subgraph.cpp
     LIBRARIES pulp::host pulp::format pulp::graph)
+# Render-ahead lane: pre-render the eligible sub-graph into a ring off the audio
+# thread and consume pre-rendered blocks on it — consumed output matches a
+# synchronous render, underruns cleanly, allocates nothing on consume, and the
+# producer/consumer pair is race-free.
+pulp_add_test_suite(pulp-test-anticipation-lane
+    SOURCES test_anticipation_lane.cpp harness/rt_allocation_probe.cpp
+    LIBRARIES pulp::host pulp::format pulp::graph pulp::audio)
 
 # First sampler/looper storage primitives split by ownership so failures point
 # to the actual layer instead of a catch-all primitive bucket.

--- a/test/test_anticipation_lane.cpp
+++ b/test/test_anticipation_lane.cpp
@@ -1,0 +1,289 @@
+// Coverage for the AnticipationLane: render an eligible sub-graph ahead of the
+// deadline into a ring and consume the pre-rendered blocks on the audio thread.
+// The lane's consumed sequence must be bit-identical to rendering the same
+// sub-graph synchronously block by block (a stateful generator proves block order
+// and state evolution are preserved), consume must underrun cleanly and allocate
+// nothing, and a background producer racing the consumer must be race-free.
+
+#include "harness/rt_allocation_probe.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/audio/buffer.hpp>
+#include <pulp/format/graph_runtime_executor.hpp>
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/anticipation_lane.hpp>
+#include <pulp/host/anticipation_partition.hpp>
+#include <pulp/host/anticipation_subgraph.hpp>
+#include <pulp/host/signal_graph.hpp>
+#include <pulp/host/signal_graph_executor_routing.hpp>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace pulp::host;
+using pulp::host::PluginSlot;
+
+namespace {
+
+constexpr double kSr = 48000.0;
+constexpr int kFrames = 64;
+
+PluginInfo gen_info(int out_ch) {
+    PluginInfo info{};
+    info.name = "CountingGenerator";
+    info.format = PluginFormat::CLAP;
+    info.num_inputs = 0;
+    info.num_outputs = out_ch;
+    info.category = "Generator";
+    return info;
+}
+
+// Stateful source: block n, channel c -> (c+1)*10 + n (constant within the
+// block). The per-block counter makes a dropped/duplicated/reordered block show
+// up immediately as a divergence.
+class CountingGenerator final : public PluginSlot {
+public:
+    explicit CountingGenerator(int out_ch) : info_(gen_info(out_ch)) {}
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue&, int n) override {
+        for (std::size_t c = 0; c < out.num_channels(); ++c) {
+            float* o = out.channel_ptr(c);
+            const float v = static_cast<float>((c + 1) * 10) + static_cast<float>(counter_);
+            for (int k = 0; k < n; ++k) o[static_cast<std::size_t>(k)] = v;
+        }
+        ++counter_;
+    }
+    std::vector<pulp::host::HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.0f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return true; }
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+private:
+    PluginInfo info_;
+    int counter_ = 0;
+};
+
+// gen(0/2) -> gain(2/2) -> out(2/0), stereo. Returns the nodes/connections.
+struct Graph {
+    std::vector<GraphNode> nodes;
+    std::vector<Connection> conns;
+    std::shared_ptr<CountingGenerator> gen;
+};
+
+Graph make_graph() {
+    Graph g;
+    g.gen = std::make_shared<CountingGenerator>(2);
+    GraphNode gen_node;
+    gen_node.id = 1;
+    gen_node.type = NodeType::Plugin;
+    gen_node.num_input_ports = 0;
+    gen_node.num_output_ports = 2;
+    gen_node.plugin = g.gen;
+    GraphNode gain_node;
+    gain_node.id = 2;
+    gain_node.type = NodeType::Gain;
+    gain_node.num_input_ports = 2;
+    gain_node.num_output_ports = 2;
+    GraphNode out_node;
+    out_node.id = 3;
+    out_node.type = NodeType::AudioOutput;
+    out_node.num_input_ports = 2;
+    out_node.num_output_ports = 0;
+    g.nodes = {gen_node, gain_node, out_node};
+    auto edge = [](NodeId s, PortIndex sp, NodeId d, PortIndex dp) {
+        Connection c;
+        c.source_node = s;
+        c.source_port = sp;
+        c.dest_node = d;
+        c.dest_port = dp;
+        return c;
+    };
+    g.conns = {edge(1, 0, 2, 0), edge(1, 1, 2, 1), edge(2, 0, 3, 0), edge(2, 1, 3, 1)};
+    return g;
+}
+
+AnticipationSubgraph subgraph_of(const Graph& g) {
+    const auto elig = analyze_anticipation_eligibility(g.nodes, g.conns);
+    const auto part = build_anticipation_partition(g.nodes, g.conns, elig);
+    return build_anticipation_subgraph(g.nodes, g.conns, part);
+}
+
+auto gain_for(std::atomic<float>* gain, NodeId gain_id) {
+    return [gain, gain_id](NodeId id) { return id == gain_id ? gain : nullptr; };
+}
+auto plugin_for(CountingGenerator* gen, NodeId gen_id) {
+    return [gen, gen_id](NodeId id) {
+        return id == gen_id ? static_cast<PluginSlot*>(gen) : nullptr;
+    };
+}
+
+// Render the sub-graph synchronously for `blocks` blocks, returning each channel's
+// concatenated output (state carries across blocks).
+std::vector<std::vector<float>> render_sync(const AnticipationSubgraph& sub,
+                                            CountingGenerator* gen,
+                                            std::atomic<float>* gain, int blocks) {
+    pulp::format::GraphRuntimeSnapshot snapshot;
+    std::vector<PluginBindingContext> ctx;
+    PluginRoutingScratch scratch;
+    REQUIRE(build_executor_snapshot(sub.nodes, sub.connections, gain_for(gain, 2),
+                                    plugin_for(gen, 1), ctx, scratch, snapshot));
+    pulp::format::GraphRuntimeBufferPool pool;
+    REQUIRE(pool.reset(snapshot.buffer_slot_count(), kFrames,
+                       snapshot.buffer_assignment().connection_delay_samples));
+    const std::size_t chs = sub.outputs.size();
+    std::vector<std::vector<float>> seq(chs);
+    for (int b = 0; b < blocks; ++b) {
+        std::vector<std::vector<float>> in_ch(2, std::vector<float>(kFrames, 0.0f));
+        std::vector<std::vector<float>> out_ch(chs, std::vector<float>(kFrames, 0.0f));
+        std::vector<const float*> inp;
+        std::vector<float*> outp;
+        for (auto& c : in_ch) inp.push_back(c.data());
+        for (auto& c : out_ch) outp.push_back(c.data());
+        pulp::audio::BufferView<const float> iv(inp.data(), inp.size(), kFrames);
+        pulp::audio::BufferView<float> ov(outp.data(), outp.size(), kFrames);
+        pulp::format::BusBufferSet buses;
+        REQUIRE(buses.add_input("main", iv, pulp::format::BusRole::Main));
+        REQUIRE(buses.add_output("main", ov, pulp::format::BusRole::Main));
+        pulp::format::ProcessBlock block;
+        block.sample_rate = kSr;
+        block.frame_count = kFrames;
+        block.buses = &buses;
+        REQUIRE(block.validate());
+        pulp::format::GraphRuntimeExecutor exec;
+        REQUIRE(exec.process_routed(block, snapshot, pool).ok());
+        for (std::size_t c = 0; c < chs; ++c)
+            seq[c].insert(seq[c].end(), out_ch[c].begin(), out_ch[c].end());
+    }
+    return seq;
+}
+
+}  // namespace
+
+TEST_CASE("AnticipationLane consumed output matches a synchronous render",
+          "[host][anticipation][lane]") {
+    constexpr int kBlocks = 12;
+
+    // Oracle: synchronous sub-graph render (its own generator instance).
+    auto og = make_graph();
+    const auto osub = subgraph_of(og);
+    REQUIRE(osub.outputs.size() == 2);
+    std::atomic<float> ogain{0.5f};
+    const auto expected = render_sync(osub, og.gen.get(), &ogain, kBlocks);
+
+    // Lane: render ahead + consume, interleaved like a real producer/consumer.
+    auto lg = make_graph();
+    const auto lsub = subgraph_of(lg);
+    std::atomic<float> lgain{0.5f};
+    AnticipationLane lane;
+    REQUIRE(lane.prepare(lsub, gain_for(&lgain, 2), plugin_for(lg.gen.get(), 1), kSr,
+                         kFrames, /*lead_blocks=*/4));
+    REQUIRE(lane.output_channels() == 2);
+
+    std::vector<std::vector<float>> got(2);
+    std::vector<float> ch0(kFrames), ch1(kFrames);
+    std::array<float*, 2> outp{ch0.data(), ch1.data()};
+    pulp::audio::BufferView<float> out(outp.data(), 2, kFrames);
+    for (int b = 0; b < kBlocks; ++b) {
+        lane.render_ahead(/*max_blocks=*/8);  // top the ring back up
+        REQUIRE(lane.consume(out));            // never underruns: lead >= 1
+        got[0].insert(got[0].end(), ch0.begin(), ch0.end());
+        got[1].insert(got[1].end(), ch1.begin(), ch1.end());
+    }
+
+    for (std::size_t c = 0; c < 2; ++c) {
+        REQUIRE(got[c].size() == expected[c].size());
+        for (std::size_t i = 0; i < got[c].size(); ++i) REQUIRE(got[c][i] == expected[c][i]);
+    }
+    // The two channels are genuinely distinct (gen ch0 != ch1), so the per-channel
+    // ring routing is exercised, not a degenerate all-same comparison.
+    CHECK(got[0][0] != got[1][0]);
+}
+
+TEST_CASE("AnticipationLane consume underruns cleanly on an empty ring",
+          "[host][anticipation][lane]") {
+    auto g = make_graph();
+    const auto sub = subgraph_of(g);
+    std::atomic<float> gain{0.5f};
+    AnticipationLane lane;
+    REQUIRE(lane.prepare(sub, gain_for(&gain, 2), plugin_for(g.gen.get(), 1), kSr,
+                         kFrames, 2));
+    std::vector<float> ch0(kFrames), ch1(kFrames);
+    std::array<float*, 2> outp{ch0.data(), ch1.data()};
+    pulp::audio::BufferView<float> out(outp.data(), 2, kFrames);
+    CHECK_FALSE(lane.consume(out));  // nothing rendered yet -> underrun
+    REQUIRE(lane.render_ahead(1) == 1);
+    CHECK(lane.consume(out));        // now a block is available
+    CHECK_FALSE(lane.consume(out));  // drained again
+}
+
+TEST_CASE("AnticipationLane consume does not allocate on the audio thread",
+          "[host][anticipation][lane][rt-safety]") {
+    auto g = make_graph();
+    const auto sub = subgraph_of(g);
+    std::atomic<float> gain{0.5f};
+    AnticipationLane lane;
+    REQUIRE(lane.prepare(sub, gain_for(&gain, 2), plugin_for(g.gen.get(), 1), kSr,
+                         kFrames, 4));
+    lane.render_ahead(4);
+    std::vector<float> ch0(kFrames), ch1(kFrames);
+    std::array<float*, 2> outp{ch0.data(), ch1.data()};
+    pulp::audio::BufferView<float> out(outp.data(), 2, kFrames);
+    lane.consume(out);  // warm up outside the probe
+    {
+        pulp::test::RtAllocationProbe probe;
+        lane.consume(out);
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
+}
+
+TEST_CASE("AnticipationLane producer and consumer run race-free",
+          "[host][anticipation][lane][threads][rt-safety]") {
+    // render_ahead on a background thread, consume on the audio thread — the
+    // ring's SPSC contract must hold. Surfaces a producer/consumer race under TSan.
+    auto g = make_graph();
+    const auto sub = subgraph_of(g);
+    std::atomic<float> gain{0.5f};
+    AnticipationLane lane;
+    REQUIRE(lane.prepare(sub, gain_for(&gain, 2), plugin_for(g.gen.get(), 1), kSr,
+                         kFrames, 8));
+
+    // Prime the ring on this thread (still single-producer: the producer thread
+    // is not spawned yet) so the consumer is guaranteed pre-rendered blocks
+    // regardless of how the producer thread is scheduled; the race coverage comes
+    // from the concurrent refill + drain below, not from the hit count.
+    REQUIRE(lane.render_ahead(8) > 0);
+
+    std::atomic<bool> stop{false};
+    std::atomic<std::uint64_t> hits{0};
+    std::thread producer([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            lane.render_ahead(4);
+            std::this_thread::yield();
+        }
+    });
+    std::vector<float> ch0(kFrames), ch1(kFrames);
+    std::array<float*, 2> outp{ch0.data(), ch1.data()};
+    pulp::audio::BufferView<float> out(outp.data(), 2, kFrames);
+    for (int i = 0; i < 4000; ++i) {
+        if (lane.consume(out)) hits.fetch_add(1, std::memory_order_relaxed);
+    }
+    stop.store(true, std::memory_order_relaxed);
+    producer.join();
+    CHECK(hits.load() > 0);  // the consumer saw pre-rendered blocks
+}


### PR DESCRIPTION
## Summary

The render-ahead **runtime** for masterwork Phase 6 anticipative rendering. `AnticipationLane` renders an eligible sub-graph AHEAD of the audio deadline into a `PlanarAudioRingBuffer`, so the live graph reads pre-computed boundary signals instead of paying the sub-graph's cost on the critical block.

Single-producer / single-consumer:
- `prepare()` (off-RT, quiescent) — builds the executor snapshot for the sub-graph, sizes the pool, sizes an output-channel ring for a **fixed** block size.
- `render_ahead()` (single background producer) — renders whole blocks via the executor (advancing the interior's plugin state) and pushes them to the ring.
- `consume()` (audio thread, **RT-safe, allocation-free**) — pops one pre-rendered block, or reports underrun so the caller falls back to a synchronous render.

The block size is **pinned at `prepare()`**, before any producer/consumer thread exists, so the two stay in lockstep with no cross-thread block-size field; the consumed sequence is **bit-identical** to rendering the sub-graph block by block. The interior's plugins are advanced only by `render_ahead` — a future live splice must not also process them.

Reuses the existing `PlanarAudioRingBuffer` (no new ring). **Default-OFF**: nothing wires it into `SignalGraph::process` yet — that's the final Phase 6 slice (6f).

## Tests

With a stateful counting generator (exposes any dropped/reordered block): consumed output matches a synchronous render; clean underrun on an empty ring; allocation-free `consume` (`RtAllocationProbe`); producer/consumer race-free under **TSan** (clean 3×).

Adversarial review: no MUST-FIX. Applied SHOULD-FIX — pinned the block size (kills a mismatched producer/consumer-`frames` determinism footgun) + bounded `consume`'s output (both via the fixed-block API), clean failure-state reset, and documented the single-producer + prepare-quiescence contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an anticipation lane that pre-renders an eligible sub-graph ahead of the audio deadline and feeds it to the audio thread via a ring buffer to reduce real-time work. Default-off; not yet wired into `SignalGraph::process`.

- **New Features**
  - Added `AnticipationLane` to render ahead into `PlanarAudioRingBuffer`: `prepare` (off-RT), `render_ahead` (single producer), `consume` (RT-safe, no alloc, underrun-aware).
  - Block size pinned at `prepare` for deterministic, bit-identical output vs synchronous render; interior plugins advance only via `render_ahead`.
  - Tests cover sync parity with a stateful generator, clean underrun, allocation-free `consume`, and race-free SPSC producer/consumer.

- **Dependencies**
  - Bump project version to `0.490.0`.
  - Bump `.claude-plugin` versions to `0.246.0` in `plugin.json` and `marketplace.json`.

<sup>Written for commit bc8c18957c625de3a7ab2ced83c2b73d75e39bd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

