### PR TITLE
feat(format): optional skip-mask in process_routed for pre-filled nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.490.0
+    VERSION 0.491.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.489.0
+    VERSION 0.490.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -506,7 +506,21 @@ public:
         std::span<const graph::GraphTimedCommand> commands = {},
         std::span<GraphRuntimeCommandDecision> command_results = {},
         GraphRuntimeCommandHandler command_handler = {},
-        GraphRuntimeEventSink event_sink = {}) noexcept;
+        GraphRuntimeEventSink event_sink = {},
+        std::span<const std::uint8_t> skip_mask = {}) noexcept;
+
+    // `skip_mask` (optional, indexed by dense node index; empty = run everything):
+    // a non-zero entry means "do not run this node — its output slots are already
+    // filled by the caller". Used by anticipative rendering, where a pre-rendered
+    // sub-graph's boundary outputs are written into the skipped interior nodes'
+    // output slots before the call so the rest of the graph reads them instead of
+    // re-running the interior (which advances plugin state that the anticipation
+    // producer already owns). A masked node must NOT be a feedback endpoint (source
+    // or destination — the post-walk feedback capture would read its prefilled slot
+    // and feed stale history) nor an AudioOutput (skipping it drops its accumulate
+    // into the shared output bus, which no pool prefill can restore). The
+    // anticipation interior satisfies both — 6a excludes feedback endpoints and the
+    // interior never contains a live sink. Debug builds assert the contract.
 
     // Levelized PARALLEL routing path: same per-node work as process_routed, but
     // each topological level's independent nodes are dispatched across `workers`

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <span>
 #include <utility>
 
@@ -854,7 +855,8 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     std::span<const graph::GraphTimedCommand> commands,
     std::span<GraphRuntimeCommandDecision> command_results,
     GraphRuntimeCommandHandler command_handler,
-    GraphRuntimeEventSink event_sink) noexcept {
+    GraphRuntimeEventSink event_sink,
+    std::span<const std::uint8_t> skip_mask) noexcept {
     if (!block.validate()) return fail_invalid_block();
     if (!snapshot.valid()) return fail_invalid_snapshot();
 
@@ -905,9 +907,44 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
         }
     }
 
+#ifndef NDEBUG
+    // Contract for a skip_mask (caller-enforced; assert it so a future caller
+    // can't regress into silent-wrong audio): a masked node must be neither an
+    // AudioOutput (skipping it drops its += into the shared output bus, which no
+    // pool pre-fill can restore) nor a feedback endpoint (its pre-filled slot would
+    // feed stale history into capture_feedback / the next block). The anticipation
+    // interior satisfies this — live sinks are never interior and 6a excludes
+    // feedback endpoints.
+    if (!skip_mask.empty()) {
+        for (std::uint32_t i = 0; i < plan.nodes.size(); ++i) {
+            if (i < skip_mask.size() && skip_mask[i] != 0) {
+                assert(plan.nodes[i].kind != graph::GraphRuntimeNodeKind::AudioOutput &&
+                       "process_routed: a skipped node must not be an AudioOutput");
+            }
+        }
+        for (const auto& c : plan.connections) {
+            if (!c.feedback) continue;
+            const bool src_skipped =
+                c.source_index < skip_mask.size() && skip_mask[c.source_index] != 0;
+            const bool dst_skipped =
+                c.dest_index < skip_mask.size() && skip_mask[c.dest_index] != 0;
+            assert(!src_skipped && !dst_skipped &&
+                   "process_routed: a skipped node must not be a feedback endpoint");
+        }
+    }
+#endif
+
     const auto command_decisions = command_results.first(commands.size());
     for (const auto node_index : plan.processing_order_indices) {
         if (node_index >= bindings.size()) return fail_invalid_snapshot();
+
+        // Skipped nodes are not run: the caller has pre-filled their output slots
+        // (anticipative rendering pre-renders the interior off-thread). They are
+        // not counted as processed and their plugin state is left untouched.
+        if (!skip_mask.empty() && node_index < skip_mask.size() &&
+            skip_mask[node_index] != 0) {
+            continue;
+        }
 
         const auto error = run_routed_node(node_index, plan, bindings, assignment,
                                            pool, midi, automation, block, in_bus,

--- a/test/test_graph_executor_routing.cpp
+++ b/test/test_graph_executor_routing.cpp
@@ -829,3 +829,65 @@ TEST_CASE("Parallel routing cost gate: a sub-threshold level runs serially",
                 lo.outs[0][static_cast<std::size_t>(i)]);
     }
 }
+
+TEST_CASE("process_routed skips a node and reads its pre-filled output slot",
+          "[format][graph][executor][routing][skip]") {
+    // in -> A -> B -> out. Skipping A and pre-filling A's output slot with exactly
+    // what A would have produced (x * gainA) must yield the same output as running
+    // A — the mechanism anticipative rendering uses to splice a pre-rendered
+    // interior into the live graph without re-running (and re-advancing) it.
+    constexpr int kFrames = 64;
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 1},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 1, 1},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::AudioOutput, 1, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},
+        GraphRuntimeConnectionSpec{2, 0, 3, 0},
+        GraphRuntimeConnectionSpec{3, 0, 4, 0},
+    };
+    GainState gA{2.0f}, gB{3.0f};
+    const std::array bindings = {
+        GraphRuntimeNodeBinding{1, nullptr, nullptr, false},
+        GraphRuntimeNodeBinding{2, routing_gain, &gA, true},
+        GraphRuntimeNodeBinding{3, routing_gain, &gB, true},
+        GraphRuntimeNodeBinding{4, nullptr, nullptr, false},
+    };
+    GraphRuntimeSnapshot snapshot;
+    REQUIRE(make_snapshot(snapshot, nodes, conns, bindings));
+    const auto x = test_signal(kFrames, 0.5f);
+
+    GraphRuntimeExecutor exec;
+    auto pool_full = make_pool(snapshot, kFrames);
+    RoutedHarness full(kSr, kFrames, {x}, 1);
+    REQUIRE(full.run(exec, snapshot, pool_full).ok());
+
+    // A's plan index + output slot.
+    const auto& plan = snapshot.plan();
+    std::uint32_t a_idx = 0;
+    for (std::uint32_t i = 0; i < plan.nodes.size(); ++i)
+        if (plan.nodes[i].id == 2) a_idx = i;
+    const std::uint32_t a_slot = snapshot.buffer_assignment().nodes[a_idx].output_base;
+
+    // Skip A; pre-fill its output slot with x * gainA.
+    auto pool_skip = make_pool(snapshot, kFrames);
+    float* slot = pool_skip.slot_data(a_slot);
+    REQUIRE(slot != nullptr);
+    for (int i = 0; i < kFrames; ++i) slot[i] = x[static_cast<std::size_t>(i)] * 2.0f;
+
+    std::vector<std::uint8_t> skip(plan.nodes.size(), 0);
+    skip[a_idx] = 1;
+    RoutedHarness skipped(kSr, kFrames, {x}, 1);
+    REQUIRE(exec.process_routed(skipped.block, snapshot, pool_skip, nullptr, nullptr,
+                                {}, {}, {}, {}, skip)
+                .ok());
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE(skipped.outs[0][static_cast<std::size_t>(i)] ==
+                full.outs[0][static_cast<std::size_t>(i)]);
+    }
+    // Guard against a vacuous all-zero match: the signal is actually non-trivial.
+    CHECK(full.outs[0][1] != 0.0f);
+}


### PR DESCRIPTION
## Summary

Adds an optional `skip_mask` to `GraphRuntimeExecutor::process_routed` (dense-node-indexed; **empty = run everything, byte-identical to before**). A masked node is not run; its output slots are assumed pre-filled by the caller, so the rest of the graph reads those instead.

This is the splice mechanism for masterwork Phase 6 anticipative rendering (6f): a sub-graph's interior is pre-rendered off the audio thread (#4833), its boundary-source output slots are written into the pool, and the interior nodes are masked so the live graph consumes the pre-rendered signal **without re-running the interior** (which would double-advance plugin state the anticipation producer owns).

A masked node must be neither a **feedback endpoint** (its pre-filled slot would feed stale history into the post-walk feedback capture) nor an **AudioOutput** (skipping it drops its accumulate into the shared output bus, which no pool pre-fill can restore). The anticipation interior satisfies both by construction; **debug builds assert the contract** (Release-free) so a future caller can't regress into silent-wrong audio.

## Tests

Skip a node, pre-fill its output slot with exactly what it would produce, and assert the output matches a full render — **bit-exact**. The default-empty path is covered by the existing 46-case parity suites (unchanged). Verified the debug asserts don't fire on the valid path (Debug build green).

Adversarial review: no MUST-FIX; the SHOULD-FIX (unenforced skip contract) is addressed by the debug asserts + header doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `skip_mask` to `GraphRuntimeExecutor::process_routed` to let callers skip executing specific nodes when their output slots are pre-filled, enabling anticipative rendering to splice pre-rendered interiors without double-advancing plugin state. Empty mask keeps behavior unchanged; debug asserts prevent masking `AudioOutput` nodes or feedback endpoints.

- New Features
  - Added `skip_mask` (dense node index). Non-zero entry skips the node; caller must pre-fill its output slots.
  - Skipped nodes are not run and their state is untouched; downstream nodes read the pre-filled slots.
  - Debug-only checks block masking `AudioOutput` nodes and feedback endpoints.
  - New test verifies a skipped, pre-filled node produces bit-exact output vs. a full render.

<sup>Written for commit 4ff58afd9df40c909705cf759e6006d99367945c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

