### PR TITLE
feat(host): wire anticipative rendering into SignalGraph::process (Phase 6 capstone)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -251,9 +251,24 @@ predictable output, no MIDI.
   ONLY by render_ahead — a live splice that uses a lane must not also process those
   nodes or their state double-advances; (2) render_ahead is SINGLE-producer (all
   calls, including priming, must be serialized — they share unsynchronized
-  executor/pool/scratch); only the ring mediates against the consumer. There is no
-  SignalGraph splice wiring this into the live path yet — that's the final Phase 6
-  slice.
+  executor/pool/scratch); only the ring mediates against the consumer.
+- **Anticipation splice (`set_anticipation_enabled`, default OFF; runs on the
+  canonical executor path).** When enabled + the routed snapshot is eligible + the
+  graph has an eligible latent interior, `compile_` builds an `AnticipationLane` +
+  a `skip_mask` over the routed plan (the interior nodes) + a prefill map (each
+  lane output channel → the interior boundary-source's `exec_pool` output slot).
+  The host drives `pump_anticipation()` from ONE background thread (the producer);
+  `process()` consumes a pre-rendered block, copies it into the prefill slots (or
+  zeros them on underrun / block-size mismatch), and runs `process_routed` with the
+  interior masked — bit-identical to the canonical interior-live render. GOTCHAS:
+  (1) the branch is TERMINAL once entered — on a routed failure it zeros the output
+  and returns rather than falling through to a path that would re-run (double-
+  advance) the producer-owned interior. (2) `pump_anticipation` pins the live
+  snapshot (RCU object-lifetime only) and is single-producer-guarded, but the host
+  MUST stop/join the pump before any `prepare()`/mutation — prepare reinitializes
+  the SAME plugin instances the pump renders (a data race otherwise; same rule as
+  "no `process()` during prepare"). (3) Host-clock-sensitive interiors aren't
+  detected — safe only because no transport reaches the routed render today.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.246.2",
+      "version": "0.247.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.246.2"
+  "version": "0.247.0"
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.246.0",
+      "version": "0.247.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.246.0"
+  "version": "0.247.0"
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.246.1",
+      "version": "0.247.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.246.1"
+  "version": "0.247.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.246.2",
+  "version": "0.247.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.246.0",
+  "version": "0.247.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.246.1",
+  "version": "0.247.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.491.0
+    VERSION 0.492.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -14,6 +14,7 @@
 //   graph.prepare(48000, 512);
 //   graph.process(output_buffer, input_buffer, num_samples);
 
+#include <pulp/host/anticipation_lane.hpp>
 #include <pulp/host/graph_types.hpp>
 #include <pulp/host/plugin_slot.hpp>
 #include <pulp/host/signal_graph_executor_routing.hpp>
@@ -480,6 +481,49 @@ public:
         return executor_.stats();
     }
 
+    // Opt into ANTICIPATIVE RENDERING for eligible graphs (default OFF). When
+    // enabled + the canonical-executor routing is eligible + the graph has an
+    // anticipation-eligible latent interior (no live input / feedback / sidechain
+    // dependency — see analyze_anticipation_eligibility), compile_ carves that
+    // interior into an AnticipationLane that is pre-rendered AHEAD of the deadline
+    // off the audio thread; process() then consumes the pre-rendered boundary
+    // signals and runs the rest of the graph with the interior masked, absorbing
+    // the interior's CPU cost off the critical block. Output is bit-identical to
+    // the canonical (interior-live) render. Requires the canonical executor path
+    // (set_canonical_executor_routing_enabled). Enable BEFORE prepare().
+    //
+    // The interior's plugin state is advanced ONLY by the anticipation producer
+    // (pump_anticipation), never by process() — so the interior is always masked
+    // on the live path; an underrun yields silence for that block, never a live
+    // re-render (which would double-advance the producer-owned state).
+    //
+    // SAFETY NOTE: the static eligibility (analyze_anticipation_eligibility) does
+    // NOT detect a host-clock-sensitive interior plugin (one whose output depends
+    // on the transport playhead). It is safe today only because process() does not
+    // propagate transport into the routed render, so the ahead-render and a live
+    // render see identical (absent) transport. When transport plumbing lands, such
+    // an interior must be excluded (a per-node opt-out) before enabling this.
+    void set_anticipation_enabled(bool enabled) noexcept {
+        anticipation_enabled_.store(enabled, std::memory_order_relaxed);
+    }
+    bool anticipation_enabled() const noexcept {
+        return anticipation_enabled_.load(std::memory_order_relaxed);
+    }
+    // Producer pump (OFF the audio thread): render the live graph's anticipation
+    // interior ahead into its ring, up to `max_blocks` blocks. The host calls this
+    // from a single background/idle thread (it is the lane's sole producer; a
+    // concurrent/reentrant call is a guarded no-op). A no-op when anticipation is
+    // disabled or the live graph has no eligible interior. Returns the number of
+    // blocks rendered ahead this call.
+    //
+    // CONTRACT: the host MUST stop calling pump_anticipation and JOIN its producer
+    // thread before any prepare()/graph mutation. The pump renders the interior's
+    // plugin instances, which prepare() reinitializes and re-binds; running them
+    // concurrently is a data race (the snapshot reader-pin protects object lifetime,
+    // not plugin-state exclusivity). Same discipline as "no process() during
+    // prepare()". Re-prepare also resets the lead buffer — expect a brief transient.
+    int pump_anticipation(int max_blocks = 8);
+
     RuntimeBudgetReport evaluate_optional_runtime_budget(
         runtime::RuntimeBudgetFrame& frame,
         runtime::RuntimeWorkLane lane = runtime::RuntimeWorkLane::Background,
@@ -745,6 +789,28 @@ private:
         graph::GraphRuntimeLevelization routing_levelization;
         std::vector<PluginBindingContext> routing_plugin_ctx_parallel;
         bool routing_parallel_valid = false;
+
+        // Anticipative rendering for this snapshot (built only when anticipation is
+        // enabled at compile time AND the routed plan has an eligible latent
+        // interior). The lane pre-renders the interior off the audio thread; the
+        // live path masks the interior in routing_snapshot's walk and feeds the
+        // lane's pre-rendered boundary signals into the interior boundary-source
+        // output slots of exec_pool. anticipation_skip_mask is indexed by
+        // routing_snapshot's dense node order; anticipation_prefill maps each lane
+        // output channel to the exec_pool slot carrying that boundary signal;
+        // anticipation_consume_scratch is the per-snapshot capture buffer consume()
+        // pops a block into before the prefill copy. The lane owns the interior
+        // plugin instances' state advancement — process() never runs them.
+        AnticipationLane anticipation_lane;
+        std::vector<std::uint8_t> anticipation_skip_mask;
+        struct AnticipationPrefill {
+            std::uint32_t out_channel = 0;  // lane output channel
+            std::uint32_t slot = 0;         // exec_pool mono slot to fill
+        };
+        std::vector<AnticipationPrefill> anticipation_prefill;
+        std::vector<std::vector<float>> anticipation_consume_scratch;
+        std::vector<float*> anticipation_consume_ptrs;
+        bool anticipation_valid = false;
     };
 
     std::vector<GraphNode> nodes_;
@@ -775,6 +841,11 @@ private:
     // parallel-safe snapshot + levelization + scratch pool ride the CompiledGraph
     // (see CompiledGraph::routing_*_parallel).
     std::atomic<bool> parallel_routing_enabled_{false};
+    std::atomic<bool> anticipation_enabled_{false};
+    // Guards the single-producer contract on pump_anticipation: a concurrent or
+    // reentrant call degrades to a no-op instead of corrupting the lane's
+    // unsynchronized executor/pool/scratch + interior plugin state.
+    std::atomic<bool> anticipation_pump_busy_{false};
     format::GraphRuntimeWorkerPool worker_pool_;
     std::atomic<std::uint32_t> active_process_readers_{0};
     std::atomic<int64_t> total_latency_samples_{0};  // reflected for const-query access

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -9,6 +9,9 @@
 // See signal_graph.hpp for the mutation protocol details.
 
 #include <pulp/host/signal_graph.hpp>
+#include <pulp/host/anticipation_eligibility.hpp>
+#include <pulp/host/anticipation_partition.hpp>
+#include <pulp/host/anticipation_subgraph.hpp>
 #include <pulp/host/signal_graph_executor_routing.hpp>
 #include <pulp/runtime/log.hpp>
 #include <algorithm>
@@ -1273,8 +1276,108 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
             }
             cg->routing_parallel_valid = ok;
         }
+
+        // Anticipative rendering: carve an eligible latent interior out of the
+        // graph into a lane pre-rendered ahead of the deadline, and prepare the
+        // live-path splice (a skip mask over the routed plan + a map from each lane
+        // output channel to the interior boundary-source output slot it fills).
+        // Requires the canonical routed snapshot (the splice runs on that path).
+        if (cg->routing_valid &&
+            anticipation_enabled_.load(std::memory_order_relaxed) &&
+            max_block_size > 0) {
+            const auto eligibility =
+                analyze_anticipation_eligibility(nodes_, connections_);
+            const auto partition =
+                build_anticipation_partition(nodes_, connections_, eligibility);
+            const auto subgraph =
+                build_anticipation_subgraph(nodes_, connections_, partition);
+            if (subgraph.renders_anything()) {
+                CompiledGraph& cgr = *cg;
+                constexpr int kLeadBlocks = 4;
+                const bool prepared = cg->anticipation_lane.prepare(
+                    subgraph,
+                    [&cgr](NodeId id) -> std::atomic<float>* {
+                        auto it = cgr.runtime.find(id);
+                        return it == cgr.runtime.end() ? nullptr : it->second.gain.get();
+                    },
+                    [&cgr](NodeId id) -> PluginSlot* {
+                        auto it = cgr.plugins.find(id);
+                        return it == cgr.plugins.end() ? nullptr : it->second.get();
+                    },
+                    sample_rate, max_block_size, kLeadBlocks);
+                if (prepared) {
+                    // Map each interior node id -> its dense index in the ROUTED
+                    // plan, to build the skip mask and resolve boundary output slots.
+                    const auto& rplan = cg->routing_snapshot.plan();
+                    const auto& rassign = cg->routing_snapshot.buffer_assignment();
+                    auto routed_index = [&rplan](NodeId id) -> std::uint32_t {
+                        for (std::uint32_t i = 0; i < rplan.nodes.size(); ++i) {
+                            if (rplan.nodes[i].id == id) return i;
+                        }
+                        return 0xFFFFFFFFu;
+                    };
+                    cg->anticipation_skip_mask.assign(rplan.nodes.size(), 0);
+                    bool map_ok = true;
+                    for (const auto idx : partition.interior_nodes) {
+                        const std::uint32_t ri = routed_index(nodes_[idx].id);
+                        if (ri == 0xFFFFFFFFu) { map_ok = false; break; }
+                        cg->anticipation_skip_mask[ri] = 1;
+                    }
+                    cg->anticipation_prefill.clear();
+                    for (std::uint32_t ch = 0; map_ok && ch < subgraph.outputs.size();
+                         ++ch) {
+                        const auto& out = subgraph.outputs[ch];
+                        const std::uint32_t ri = routed_index(out.source_node);
+                        if (ri == 0xFFFFFFFFu) { map_ok = false; break; }
+                        const std::uint32_t slot =
+                            rassign.nodes[ri].output_base + out.source_port;
+                        cg->anticipation_prefill.push_back({ch, slot});
+                    }
+                    if (map_ok) {
+                        cg->anticipation_consume_scratch.assign(
+                            subgraph.outputs.size(),
+                            std::vector<float>(static_cast<std::size_t>(max_block_size),
+                                               0.0f));
+                        cg->anticipation_consume_ptrs.clear();
+                        for (auto& c : cg->anticipation_consume_scratch) {
+                            cg->anticipation_consume_ptrs.push_back(c.data());
+                        }
+                        cg->anticipation_valid = true;
+                    }
+                }
+            }
+        }
     }
     return cg;
+}
+
+int SignalGraph::pump_anticipation(int max_blocks) {
+    if (!anticipation_enabled_.load(std::memory_order_relaxed)) return 0;
+    // Single-producer guard: a concurrent or reentrant pump degrades to a no-op
+    // rather than corrupting the lane's unsynchronized executor/pool/scratch.
+    if (anticipation_pump_busy_.exchange(true, std::memory_order_acquire)) return 0;
+    // Pin the live snapshot like a process() reader (the same RCU handshake
+    // prune_retired_snapshots_ waits on) so the CompiledGraph object can't be freed
+    // while we render its lane. render_ahead is bounded (<= max_blocks), so this
+    // never holds the reader count long enough to stall a re-prepare materially.
+    //
+    // CONTRACT (host-enforced, not provable here): the host MUST stop calling
+    // pump_anticipation AND join its producer thread before any prepare()/graph
+    // mutation. The reader-pin only keeps the CompiledGraph object alive — it does
+    // NOT make the shared PluginSlot instances exclusive, and prepare() reinitializes
+    // those same instances (n.plugin->prepare) and builds a new lane over them. A
+    // pump concurrent with prepare() would be a data race on the plugin state. This
+    // mirrors the existing "no process() concurrent with prepare()" contract.
+    active_process_readers_.fetch_add(1, std::memory_order_seq_cst);
+    int rendered = 0;
+    if (auto* cg = live_raw_.load(std::memory_order_seq_cst)) {
+        if (cg->anticipation_valid && max_blocks > 0) {
+            rendered = cg->anticipation_lane.render_ahead(max_blocks);
+        }
+    }
+    active_process_readers_.fetch_sub(1, std::memory_order_seq_cst);
+    anticipation_pump_busy_.store(false, std::memory_order_release);
+    return rendered;
 }
 
 bool SignalGraph::prepare(double sample_rate, int max_block_size) {
@@ -1658,6 +1761,59 @@ void SignalGraph::process(audio::BufferView<float>& output,
             // (a node failed, or it does not fit) can fall through to the serial
             // executor and then the legacy walk re-rendering the same block with
             // no double-consumed MIDI and no doubled output.
+            // Anticipative rendering (tried first): the lane has pre-rendered the
+            // interior off the audio thread. Consume one block, fill the interior
+            // boundary-source output slots with it (or zero them on an underrun /
+            // block-size mismatch — NEVER re-run the interior, whose plugin state
+            // the producer owns), then run the routed walk with the interior masked
+            // so only the exterior runs live. Uses the serial routed snapshot.
+            if (anticipation_enabled_.load(std::memory_order_relaxed) &&
+                cg->anticipation_valid &&
+                cg->anticipation_lane.output_channels() ==
+                    cg->anticipation_prefill.size() &&
+                cg->exec_pool.fits(cg->routing_snapshot, frames32)) {
+                const bool size_ok =
+                    frames32 == static_cast<std::uint32_t>(
+                                    cg->anticipation_lane.block_frames());
+                bool hit = false;
+                if (size_ok) {
+                    pulp::audio::BufferView<float> cap(
+                        cg->anticipation_consume_ptrs.data(),
+                        cg->anticipation_consume_ptrs.size(), frames32);
+                    hit = cg->anticipation_lane.consume(cap);
+                }
+                for (const auto& pf : cg->anticipation_prefill) {
+                    float* dst = cg->exec_pool.slot_data(pf.slot);
+                    if (dst == nullptr) continue;
+                    if (hit) {
+                        std::copy_n(cg->anticipation_consume_ptrs[pf.out_channel],
+                                    num_samples, dst);
+                    } else {
+                        std::fill_n(dst, num_samples, 0.0f);
+                    }
+                }
+                // Once entered, this branch is TERMINAL: consume() has already
+                // advanced the ring (the producer owns the interior's plugin
+                // state), so we must NOT fall through to a path that re-runs the
+                // interior live — that would double-advance it. A routed failure
+                // (a rare exterior node error) yields a silent block here, not a
+                // fallback re-render.
+                const bool ok = dispatch_routed([&] {
+                    return executor_.process_routed(
+                        block, cg->routing_snapshot, cg->exec_pool,
+                        has_midi ? &cg->routing_midi : nullptr,
+                        has_automation ? &cg->routing_automation : nullptr, {}, {}, {},
+                        {}, cg->anticipation_skip_mask);
+                });
+                if (!ok) {
+                    for (std::size_t c = 0; c < output.num_channels(); ++c) {
+                        std::memset(output.channel_ptr(c), 0,
+                                    sizeof(float) * static_cast<std::size_t>(num_samples));
+                    }
+                }
+                return;
+            }
+
             if (parallel_routing_enabled_.load(std::memory_order_relaxed) &&
                 cg->routing_parallel_valid && worker_pool_.running() &&
                 cg->exec_pool_parallel.fits(cg->routing_snapshot_parallel, frames32)) {

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -100,6 +100,12 @@ pulp_add_test_suite(pulp-test-anticipation-subgraph-render
 pulp_add_test_suite(pulp-test-anticipation-lane
     SOURCES test_anticipation_lane.cpp harness/rt_allocation_probe.cpp
     LIBRARIES pulp::host pulp::format pulp::graph pulp::audio)
+# Acceptance: anticipation wired into SignalGraph::process — the pre-rendered
+# interior splice is bit-identical to the canonical interior-live render, and the
+# interior is advanced exactly once per block (by the producer pump), never twice.
+pulp_add_test_suite(pulp-test-signal-graph-anticipation
+    SOURCES test_signal_graph_anticipation.cpp
+    LIBRARIES pulp::host pulp::format pulp::graph pulp::audio)
 
 # First sampler/looper storage primitives split by ownership so failures point
 # to the actual layer instead of a catch-all primitive bucket.

--- a/test/test_signal_graph_anticipation.cpp
+++ b/test/test_signal_graph_anticipation.cpp
@@ -1,0 +1,197 @@
+// Acceptance coverage for anticipative rendering wired into SignalGraph::process
+// (masterwork Phase 6): with anticipation enabled, the eligible latent interior is
+// pre-rendered ahead of the deadline off the audio thread and spliced into the
+// live graph, so the audio block never runs the interior itself. The result must
+// be bit-identical to the canonical (interior-live) executor render, and a
+// counting generator proves the interior is advanced exactly once per block (by
+// the producer pump), never twice (which a double-render would cause).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/audio/buffer.hpp>
+#include <pulp/host/signal_graph.hpp>
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace pulp::host;
+
+namespace {
+
+constexpr double kSr = 48000.0;
+constexpr int kFrames = 64;
+
+PluginInfo gen_info() {
+    PluginInfo info{};
+    info.name = "AnticipationCountingGen";
+    info.format = PluginFormat::CLAP;
+    info.num_inputs = 0;
+    info.num_outputs = 2;
+    info.category = "Generator";
+    return info;
+}
+
+// Stateful source: block n, channel c -> (c+1)*10 + n. Counts process() calls so a
+// test can prove how many times the interior was actually rendered.
+class CountingGen final : public PluginSlot {
+public:
+    CountingGen() : info_(gen_info()) {}
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue&, int n) override {
+        for (std::size_t c = 0; c < out.num_channels(); ++c) {
+            float* o = out.channel_ptr(c);
+            const float v = static_cast<float>((c + 1) * 10) + static_cast<float>(block_);
+            for (int k = 0; k < n; ++k) o[static_cast<std::size_t>(k)] = v;
+        }
+        ++block_;
+        calls.fetch_add(1, std::memory_order_relaxed);
+    }
+    std::vector<pulp::host::HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.0f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return true; }
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+    std::atomic<int> calls{0};
+
+private:
+    PluginInfo info_;
+    int block_ = 0;
+};
+
+// gen(0/2) -> gain(2/2) -> out(2/0). Interior = {gen, gain}; out is the live sink.
+// Returns the raw generator pointer (owned by the graph) for call-count checks.
+CountingGen* build(SignalGraph& g) {
+    auto gen = std::make_unique<CountingGen>();
+    CountingGen* raw = gen.get();
+    const auto gen_id = g.add_plugin_node(std::move(gen), 0, 2, "Gen");
+    const auto gain = g.add_gain_node("G");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(gen_id, c, gain, c));
+        REQUIRE(g.connect(gain, c, out, c));
+    }
+    REQUIRE(g.set_node_gain(gain, 0.5f));
+    return raw;
+}
+
+std::vector<std::vector<float>> render_block(SignalGraph& g) {
+    std::vector<float> l(kFrames, 0.0f), r(kFrames, 0.0f);
+    std::array<float*, 2> oc{l.data(), r.data()};
+    std::vector<float> zi(kFrames, 0.0f);
+    std::array<const float*, 2> ic{zi.data(), zi.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 2, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 2, kFrames);
+    g.process(ov, iv, kFrames);
+    return {std::move(l), std::move(r)};
+}
+
+}  // namespace
+
+TEST_CASE("SignalGraph anticipation matches the canonical interior-live render",
+          "[host][anticipation][signal-graph]") {
+    constexpr int kBlocks = 12;
+
+    // Oracle: canonical executor, interior rendered live each block.
+    SignalGraph oracle;
+    CountingGen* ogen = build(oracle);
+    oracle.set_canonical_executor_routing_enabled(true);
+    REQUIRE(oracle.prepare(kSr, kFrames));
+    std::vector<std::vector<float>> expected(2);
+    for (int b = 0; b < kBlocks; ++b) {
+        const auto blk = render_block(oracle);
+        for (int c = 0; c < 2; ++c)
+            expected[c].insert(expected[c].end(), blk[c].begin(), blk[c].end());
+    }
+    CHECK(ogen->calls.load() == kBlocks);  // interior ran once per block, live
+
+    // Anticipated: same graph, interior pre-rendered ahead and spliced.
+    SignalGraph antic;
+    CountingGen* agen = build(antic);
+    antic.set_canonical_executor_routing_enabled(true);
+    antic.set_anticipation_enabled(true);
+    REQUIRE(antic.prepare(kSr, kFrames));
+    std::vector<std::vector<float>> got(2);
+    for (int b = 0; b < kBlocks; ++b) {
+        antic.pump_anticipation(8);  // producer: render the interior ahead
+        const auto blk = render_block(antic);
+        for (int c = 0; c < 2; ++c)
+            got[c].insert(got[c].end(), blk[c].begin(), blk[c].end());
+    }
+
+    // Bit-identical to the live render — which also proves the interior advanced
+    // exactly once per block: a double-render (pump + live) would desync the
+    // counting generator and diverge.
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(got[c].size() == expected[c].size());
+        for (std::size_t i = 0; i < got[c].size(); ++i)
+            REQUIRE(got[c][i] == expected[c][i]);
+    }
+    // The interior generator was advanced only by the producer pump, which renders
+    // AHEAD — so it ran at least once per consumed block and at most a lead's worth
+    // beyond. (That process() never ran it is already proven by the bit-exact match
+    // above: a second, live render would desync the counting generator.)
+    CHECK(agen->calls.load() >= kBlocks);
+    CHECK(agen->calls.load() <= kBlocks + 4);  // + the lead the ring holds ahead
+    // Distinct per channel: real per-channel splice, not an all-same comparison.
+    CHECK(got[0][0] != got[1][0]);
+}
+
+TEST_CASE("SignalGraph anticipation producer pump and audio process are race-free",
+          "[host][anticipation][signal-graph][threads][rt-safety]") {
+    // pump_anticipation on a background thread (the producer) while process() runs
+    // on the audio thread (the consumer) — the lane's SPSC ring + the snapshot
+    // reader pin must hold. Surfaces a race under TSan.
+    SignalGraph g;
+    build(g);
+    g.set_canonical_executor_routing_enabled(true);
+    g.set_anticipation_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+
+    std::atomic<bool> stop{false};
+    std::thread producer([&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+            g.pump_anticipation(4);
+            std::this_thread::yield();
+        }
+    });
+    std::uint64_t blocks = 0;
+    for (int i = 0; i < 3000; ++i) {
+        (void)render_block(g);
+        ++blocks;
+    }
+    stop.store(true, std::memory_order_relaxed);
+    producer.join();
+    CHECK(blocks > 0);
+}
+
+TEST_CASE("SignalGraph anticipation off leaves the canonical render unchanged",
+          "[host][anticipation][signal-graph]") {
+    // Sanity: with anticipation disabled, process() takes the ordinary canonical
+    // path and pump_anticipation is a no-op.
+    SignalGraph g;
+    CountingGen* gen = build(g);
+    g.set_canonical_executor_routing_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+    CHECK(g.pump_anticipation(8) == 0);  // disabled -> no-op
+    const auto blk = render_block(g);
+    CHECK(gen->calls.load() == 1);  // interior ran live
+    CHECK(blk[0][0] == (10.0f + 0.0f) * 0.5f);
+    CHECK(blk[1][0] == (20.0f + 0.0f) * 0.5f);
+}


### PR DESCRIPTION
## Summary

The **capstone of masterwork Phase 6**. With `set_anticipation_enabled` (default OFF), an eligible **latent interior** is pre-rendered ahead of the audio deadline off the thread and spliced into the live graph, absorbing the interior's CPU cost off the critical block.

- `compile_` (when enabled + the canonical routed snapshot is eligible + an anticipation-eligible latent interior exists) carves the interior into an `AnticipationLane` and prepares the splice: a `skip_mask` over the routed plan + a map from each lane output channel → the interior boundary-source's `exec_pool` output slot.
- `pump_anticipation()` (host-driven, single background producer, RCU-pinned, single-producer-guarded) renders the interior ahead.
- `process()` consumes a pre-rendered block, copies it into the prefill slots (or zeros on underrun / block-size mismatch), and runs `process_routed` with the interior **masked** — the live block never runs the interior. Output is **bit-identical** to the canonical interior-live render.

**Plugin-state ownership (settled):** the interior's plugin state is advanced *only* by the producer, so the live path always masks it. The anticipation branch is **terminal** once entered — a routed failure zeros the output and returns rather than falling through to a path that would re-run (double-advance) the interior; an underrun yields silence, not a live re-render. The host must stop+join the pump before any `prepare()`/mutation (documented; same rule as no-process-during-prepare). Host-clock-sensitive interiors aren't detected — safe only because no transport reaches the routed render today.

## Tests

Anticipated render bit-exact vs the canonical interior-live render (a stateful counting generator proves the interior advances exactly once per block, via the pump, never twice); anticipation-off leaves the canonical render unchanged; producer-pump and audio-process are **race-free under TSan**. Default-OFF path unchanged (46-case parity suite still passes).

Adversarial review: **2 MUST-FIX, both applied** — (M1) the branch is now terminal once entered; (M2) added a single-producer guard + documented the pump-quiesce-before-prepare contract. S2 (host-time) documented.

**This completes Phase 6** (eligibility → partition → sub-graph → render proof → lane → executor skip-mask → live splice), and with it the realtime-audio masterwork (Phases 4–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds anticipative rendering to `SignalGraph::process`: eligible interiors are pre-rendered off the audio thread and spliced into the live routed path to move their CPU cost off the critical block. Output is bit-identical to the canonical live render; feature is OFF by default.

- **New Features**
  - `compile_` builds an `AnticipationLane` (when eligible) plus a routed-plan skip mask and prefill map; requires the canonical executor routing path.
  - `pump_anticipation(max_blocks)` renders the interior ahead on a single background producer thread; RCU reader-pins the live snapshot and is single-producer guarded; returns blocks rendered.
  - `process()` consumes one pre-rendered block, fills boundary prefill slots (zeros on underrun or block-size mismatch), and runs the routed walk with the interior masked; the branch is terminal to avoid double-advancing producer-owned plugin state.
  - Acceptance test covers bit-identical splice and pump/process race-freedom; docs updated in hosting skill guide. Version bumps: SDK `0.492.0`, `pulp` plugin `0.247.0`.

- **Migration**
  - Enable before prepare: call `set_canonical_executor_routing_enabled(true)`, then `set_anticipation_enabled(true)`, then `prepare(...)`.
  - Drive `pump_anticipation(...)` from exactly one background thread; stop and join it before any `prepare()` or graph mutation.

<sup>Written for commit db789fa413f678c14686587e9868f940e9d5a51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

