### PR TITLE
refactor(host): harden the anticipation splice + prove determinism for harder graphs

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -272,7 +272,15 @@ predictable output, no MIDI.
   "no `process()` during prepare"). (3) Host-clock-sensitive interiors aren't
   detected — safe only because no transport reaches the routed render today.
   (A masked node must not be an `AudioOutput` or a feedback endpoint; the
-  partition guarantees this and `process_routed` debug-asserts it.)
+  partition guarantees this and `process_routed` debug-asserts it.) (4) The lane
+  uses a FIXED block size (the prepared max). A block of a different size — or a
+  ring underrun — silences the interior for that block (the interior is never
+  re-rendered live, so bit-identical-to-canonical holds only for fixed-size,
+  kept-up blocks); and an interior param/gain edit takes effect at render-ahead
+  time, a lead earlier than a live render. The anticipation branch is
+  STRUCTURALLY terminal once `anticipation_valid` — it never falls through to the
+  parallel/legacy paths (which would run the producer-owned interior live), even
+  if the pool can't fit the block (then: silence).
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -488,9 +488,16 @@ public:
     // interior into an AnticipationLane that is pre-rendered AHEAD of the deadline
     // off the audio thread; process() then consumes the pre-rendered boundary
     // signals and runs the rest of the graph with the interior masked, absorbing
-    // the interior's CPU cost off the critical block. Output is bit-identical to
-    // the canonical (interior-live) render. Requires the canonical executor path
-    // (set_canonical_executor_routing_enabled). Enable BEFORE prepare().
+    // the interior's CPU cost off the critical block. Requires the canonical
+    // executor path (set_canonical_executor_routing_enabled). Enable BEFORE prepare().
+    //
+    // Output is bit-identical to the canonical (interior-live) render WHEN the host
+    // pumps enough and uses a fixed block size equal to the prepared max block. Two
+    // intrinsic exceptions: (1) a block whose size differs from the prepared max, or
+    // a ring underrun, silences the interior for that block (it is never re-rendered
+    // live — see the producer-ownership note below); (2) a parameter/gain change on
+    // an interior node takes effect at render-ahead time, i.e. up to a lead's-worth
+    // of blocks earlier than in a live render.
     //
     // The interior's plugin state is advanced ONLY by the anticipation producer
     // (pump_anticipation), never by process() — so the interior is always masked

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1770,41 +1770,46 @@ void SignalGraph::process(audio::BufferView<float>& output,
             if (anticipation_enabled_.load(std::memory_order_relaxed) &&
                 cg->anticipation_valid &&
                 cg->anticipation_lane.output_channels() ==
-                    cg->anticipation_prefill.size() &&
-                cg->exec_pool.fits(cg->routing_snapshot, frames32)) {
-                const bool size_ok =
-                    frames32 == static_cast<std::uint32_t>(
-                                    cg->anticipation_lane.block_frames());
-                bool hit = false;
-                if (size_ok) {
-                    pulp::audio::BufferView<float> cap(
-                        cg->anticipation_consume_ptrs.data(),
-                        cg->anticipation_consume_ptrs.size(), frames32);
-                    hit = cg->anticipation_lane.consume(cap);
-                }
-                for (const auto& pf : cg->anticipation_prefill) {
-                    float* dst = cg->exec_pool.slot_data(pf.slot);
-                    if (dst == nullptr) continue;
-                    if (hit) {
-                        std::copy_n(cg->anticipation_consume_ptrs[pf.out_channel],
-                                    num_samples, dst);
-                    } else {
-                        std::fill_n(dst, num_samples, 0.0f);
+                    cg->anticipation_prefill.size()) {
+                // STRUCTURALLY TERMINAL once anticipation is valid: the interior's
+                // plugin state is advanced solely by the producer (pump_anticipation),
+                // so the live path must NEVER run the interior — not via a fallback,
+                // and not even when the pool can't fit the block. The fits() check is
+                // INSIDE the branch (not an entry gate) precisely so a future change
+                // that made it false could not let control fall through to the
+                // parallel/legacy paths below, which would run the masked interior
+                // live and double-advance producer-owned state. Worst case here is a
+                // silent block, never a double-render.
+                bool ok = false;
+                if (cg->exec_pool.fits(cg->routing_snapshot, frames32)) {
+                    const bool size_ok =
+                        frames32 == static_cast<std::uint32_t>(
+                                        cg->anticipation_lane.block_frames());
+                    bool hit = false;
+                    if (size_ok) {
+                        pulp::audio::BufferView<float> cap(
+                            cg->anticipation_consume_ptrs.data(),
+                            cg->anticipation_consume_ptrs.size(), frames32);
+                        hit = cg->anticipation_lane.consume(cap);
                     }
+                    for (const auto& pf : cg->anticipation_prefill) {
+                        float* dst = cg->exec_pool.slot_data(pf.slot);
+                        if (dst == nullptr) continue;
+                        if (hit) {
+                            std::copy_n(cg->anticipation_consume_ptrs[pf.out_channel],
+                                        num_samples, dst);
+                        } else {
+                            std::fill_n(dst, num_samples, 0.0f);
+                        }
+                    }
+                    ok = dispatch_routed([&] {
+                        return executor_.process_routed(
+                            block, cg->routing_snapshot, cg->exec_pool,
+                            has_midi ? &cg->routing_midi : nullptr,
+                            has_automation ? &cg->routing_automation : nullptr, {}, {},
+                            {}, {}, cg->anticipation_skip_mask);
+                    });
                 }
-                // Once entered, this branch is TERMINAL: consume() has already
-                // advanced the ring (the producer owns the interior's plugin
-                // state), so we must NOT fall through to a path that re-runs the
-                // interior live — that would double-advance it. A routed failure
-                // (a rare exterior node error) yields a silent block here, not a
-                // fallback re-render.
-                const bool ok = dispatch_routed([&] {
-                    return executor_.process_routed(
-                        block, cg->routing_snapshot, cg->exec_pool,
-                        has_midi ? &cg->routing_midi : nullptr,
-                        has_automation ? &cg->routing_automation : nullptr, {}, {}, {},
-                        {}, cg->anticipation_skip_mask);
-                });
                 if (!ok) {
                     for (std::size_t c = 0; c < output.num_channels(); ++c) {
                         std::memset(output.channel_ptr(c), 0,
@@ -1814,6 +1819,10 @@ void SignalGraph::process(audio::BufferView<float>& output,
                 return;
             }
 
+            // Reached only when anticipation is NOT valid (the branch above is
+            // terminal whenever it is) — REQUIRED for safety: the parallel and
+            // legacy paths run every node, including any interior the producer
+            // owns, so they must never execute while anticipation is active.
             if (parallel_routing_enabled_.load(std::memory_order_relaxed) &&
                 cg->routing_parallel_valid && worker_pool_.running() &&
                 cg->exec_pool_parallel.fits(cg->routing_snapshot_parallel, frames32)) {

--- a/test/test_signal_graph_anticipation.cpp
+++ b/test/test_signal_graph_anticipation.cpp
@@ -38,7 +38,7 @@ PluginInfo gen_info() {
 // test can prove how many times the interior was actually rendered.
 class CountingGen final : public PluginSlot {
 public:
-    CountingGen() : info_(gen_info()) {}
+    explicit CountingGen(int latency = 0) : info_(gen_info()), latency_(latency) {}
     const PluginInfo& info() const override { return info_; }
     bool is_loaded() const override { return true; }
     bool prepare(double, int) override { return true; }
@@ -62,7 +62,7 @@ public:
     bool is_bypassed() const override { return false; }
     std::vector<uint8_t> save_state() const override { return {}; }
     bool restore_state(const std::vector<uint8_t>&) override { return true; }
-    int latency_samples() const override { return 0; }
+    int latency_samples() const override { return latency_; }
     int tail_samples() const override { return 0; }
     bool has_editor() const override { return false; }
     void* create_editor_view() override { return nullptr; }
@@ -72,6 +72,7 @@ public:
 
 private:
     PluginInfo info_;
+    int latency_ = 0;
     int block_ = 0;
 };
 
@@ -194,4 +195,140 @@ TEST_CASE("SignalGraph anticipation off leaves the canonical render unchanged",
     CHECK(gen->calls.load() == 1);  // interior ran live
     CHECK(blk[0][0] == (10.0f + 0.0f) * 0.5f);
     CHECK(blk[1][0] == (20.0f + 0.0f) * 0.5f);
+}
+
+namespace {
+
+// Drive `g` for `blocks` blocks, pumping the producer first when `anticipated`.
+// Returns each channel's concatenated output.
+std::vector<std::vector<float>> run_session(SignalGraph& g, int blocks,
+                                            bool anticipated, int out_channels) {
+    std::vector<std::vector<float>> seq(static_cast<std::size_t>(out_channels));
+    for (int b = 0; b < blocks; ++b) {
+        if (anticipated) g.pump_anticipation(8);
+        std::vector<std::vector<float>> oc(static_cast<std::size_t>(out_channels),
+                                           std::vector<float>(kFrames, 0.0f));
+        std::vector<float> zi(kFrames, 0.0f);
+        std::vector<float*> op;
+        std::vector<const float*> ip(2, zi.data());
+        for (auto& c : oc) op.push_back(c.data());
+        pulp::audio::BufferView<const float> iv(ip.data(), 2, kFrames);
+        pulp::audio::BufferView<float> ov(op.data(), op.size(), kFrames);
+        g.process(ov, iv, kFrames);
+        for (int c = 0; c < out_channels; ++c)
+            seq[static_cast<std::size_t>(c)].insert(
+                seq[static_cast<std::size_t>(c)].end(), oc[static_cast<std::size_t>(c)].begin(),
+                oc[static_cast<std::size_t>(c)].end());
+    }
+    return seq;
+}
+
+// Build `wire` into both a canonical graph and an anticipated graph, render
+// `blocks`, and assert bit-identical output. `wire` returns nothing; it adds nodes
+// + connections + gains to the passed graph (fresh plugin instances each call).
+template <typename Wire>
+void expect_anticipation_bit_exact(Wire&& wire, int blocks, int out_channels) {
+    SignalGraph oracle;
+    wire(oracle);
+    oracle.set_canonical_executor_routing_enabled(true);
+    REQUIRE(oracle.prepare(kSr, kFrames));
+    const auto expected = run_session(oracle, blocks, /*anticipated=*/false, out_channels);
+
+    SignalGraph antic;
+    wire(antic);
+    antic.set_canonical_executor_routing_enabled(true);
+    antic.set_anticipation_enabled(true);
+    REQUIRE(antic.prepare(kSr, kFrames));
+    const auto got = run_session(antic, blocks, /*anticipated=*/true, out_channels);
+
+    for (int c = 0; c < out_channels; ++c) {
+        const auto cc = static_cast<std::size_t>(c);
+        REQUIRE(got[cc].size() == expected[cc].size());
+        for (std::size_t i = 0; i < got[cc].size(); ++i)
+            REQUIRE(got[cc][i] == expected[cc][i]);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("SignalGraph anticipation: interior internal fan-in stays bit-exact",
+          "[host][anticipation][signal-graph]") {
+    // gen1, gen2 -> gain(2-in summing) -> out. Interior = {gen1, gen2, gain}.
+    expect_anticipation_bit_exact(
+        [](SignalGraph& g) {
+            const auto a = g.add_plugin_node(std::make_unique<CountingGen>(), 0, 2, "G1");
+            const auto b = g.add_plugin_node(std::make_unique<CountingGen>(), 0, 2, "G2");
+            const auto mix = g.add_gain_node("Mix");
+            const auto out = g.add_output_node(2, "Out");
+            for (int c = 0; c < 2; ++c) {
+                REQUIRE(g.connect(a, c, mix, c));
+                REQUIRE(g.connect(b, c, mix, c));
+                REQUIRE(g.connect(mix, c, out, c));
+            }
+            REQUIRE(g.set_node_gain(mix, 0.25f));
+        },
+        10, 2);
+}
+
+TEST_CASE("SignalGraph anticipation: one interior port feeding two sinks stays bit-exact",
+          "[host][anticipation][signal-graph]") {
+    // gen -> gain, gain feeds out1 AND out2 (same source ports, two consumers).
+    expect_anticipation_bit_exact(
+        [](SignalGraph& g) {
+            const auto gen = g.add_plugin_node(std::make_unique<CountingGen>(), 0, 2, "Gen");
+            const auto gain = g.add_gain_node("G");
+            const auto out1 = g.add_output_node(2, "Out1");
+            const auto out2 = g.add_output_node(2, "Out2");
+            for (int c = 0; c < 2; ++c) {
+                REQUIRE(g.connect(gen, c, gain, c));
+                REQUIRE(g.connect(gain, c, out1, c));
+                REQUIRE(g.connect(gain, c, out2, c));
+            }
+            REQUIRE(g.set_node_gain(gain, 0.5f));
+        },
+        10, 2);  // both AudioOutputs sum into the one main output bus
+}
+
+TEST_CASE("SignalGraph anticipation: a latency-reporting interior plugin stays bit-exact",
+          "[host][anticipation][signal-graph]") {
+    // gen(latency 16) -> gain -> out. Exercises per-connection PDC across the
+    // anticipation boundary: the lane must not double-apply the interior latency
+    // that the live splice's delay compensation also accounts for.
+    expect_anticipation_bit_exact(
+        [](SignalGraph& g) {
+            const auto gen =
+                g.add_plugin_node(std::make_unique<CountingGen>(/*latency=*/16), 0, 2, "Gen");
+            const auto gain = g.add_gain_node("G");
+            const auto out = g.add_output_node(2, "Out");
+            for (int c = 0; c < 2; ++c) {
+                REQUIRE(g.connect(gen, c, gain, c));
+                REQUIRE(g.connect(gain, c, out, c));
+            }
+            REQUIRE(g.set_node_gain(gain, 0.5f));
+        },
+        16, 2);
+}
+
+TEST_CASE("SignalGraph anticipation: a short block silences the interior safely",
+          "[host][anticipation][signal-graph]") {
+    // A block smaller than the prepared max can't be served by the fixed-block
+    // lane; the interior is silenced (never re-run live), not garbage/crash.
+    SignalGraph g;
+    build(g);
+    g.set_canonical_executor_routing_enabled(true);
+    g.set_anticipation_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+    g.pump_anticipation(8);
+    const int kShort = kFrames / 2;
+    std::vector<float> l(kFrames, 9.0f), r(kFrames, 9.0f);  // pre-fill non-zero
+    std::array<float*, 2> oc{l.data(), r.data()};
+    std::vector<float> zi(kFrames, 0.0f);
+    std::array<const float*, 2> ic{zi.data(), zi.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 2, kShort);
+    pulp::audio::BufferView<float> ov(oc.data(), 2, kShort);
+    g.process(ov, iv, kShort);
+    for (int i = 0; i < kShort; ++i) {
+        CHECK(l[static_cast<std::size_t>(i)] == 0.0f);  // interior silenced, not garbage
+        CHECK(r[static_cast<std::size_t>(i)] == 0.0f);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up from a **holistic adversarial review** of the assembled anticipative-rendering subsystem (Phase 6) — **no MUST-FIX found**; this closes the flagged follow-ups.

- **Structural terminal guard (S1):** the `process()` anticipation branch is now terminal once `anticipation_valid` — the `exec_pool.fits()` check moved *inside* the branch rather than gating entry, so a non-fitting block yields silence and returns instead of falling through to the parallel/legacy paths (which would run the masked interior live and double-advance the producer-owned plugin state). The no-double-advance guarantee no longer rests on `fits()` always being true.
- **Docs (S2/A1/A2):** noted the parallel/legacy precedence is safety-required; tightened the `set_anticipation_enabled` contract — bit-identical-to-canonical holds only for fixed-size, kept-up blocks (a short/odd block or ring underrun silences the interior, never re-renders it), and interior param/gain edits take effect at render-ahead time.
- **Determinism tests (A3):** proved the splice stays **bit-exact** for the harder topologies the per-slice tests didn't cover — interior internal **fan-in**, **one interior port feeding two sinks**, and a **latency-reporting (PDC) interior** (confirming the interior latency is *not* double-applied across the splice boundary) — plus a **short-block safe-silence** test.

Behavior-preserving on all reachable paths (parity suite unchanged, single-backend governance clean), TSan-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the anticipation splice: the `process()` anticipation path is now structurally terminal and never falls through, preventing live re-runs and double-advancing state. Added determinism tests for harder graphs and clarified that anticipation is bit-exact only for fixed-size, kept-up blocks; non-fitting or short blocks now silence the interior.

- **Refactors**
  - Moved `exec_pool.fits()` inside the anticipation branch; on size mismatch or pool not fitting, consume/silence and return — no live fallback.
  - Documented precedence: when anticipation is valid, parallel/legacy paths are skipped; tightened `set_anticipation_enabled` contract (fixed block size, underruns silence; param/gain edits apply at render-ahead time).
  - Added integration tests: internal fan-in, one interior port feeding two sinks, latency-reporting interiors (no double PDC), plus a short-block safe-silence test.

<sup>Written for commit 92102649b5a49290b520595ad82d4c409d2b056a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

