### PR TITLE
docs(view): refresh design provenance breadcrumbs

### DIFF
--- a/assets/design-system/ink-signal/PROVENANCE.md
+++ b/assets/design-system/ink-signal/PROVENANCE.md
@@ -1,7 +1,7 @@
 # Ink & Signal — Provenance & License
 
 This directory vendors the **"Ink & Signal"** design language assets that seed
-Pulp's global design system (see `planning/Design-System-Import-Plan.md`, Phase 0).
+Pulp's global design system.
 It exists so the token foundation, Figma library, and fidelity baseline are
 reproducible from a clean clone — no external `~/Downloads` bundle required.
 
@@ -11,7 +11,7 @@ reproducible from a clean clone — no external `~/Downloads` bundle required.
 |---|---|---|
 | `tokens/pulp.tokens.json` | Tokens-Studio-format design tokens (`core` + `dark` + `light`) | Original Pulp work |
 | `tokens/css/*.css` | The same language as CSS custom properties (colors, semantic, themes, spacing, typography, elevation, motion, fonts) | Original Pulp work |
-| `reference/screenshots/*.png` | Per-component reference renders used as the fidelity-diff baseline (Phase 6) | Original Pulp work |
+| `reference/screenshots/*.png` | Per-component reference renders used as the fidelity-diff baseline | Original Pulp work |
 
 ## License determination (MIT-compatible)
 
@@ -27,7 +27,7 @@ was checked against that policy:
   Mono** (values/code) *by family name only*. No font binaries are vendored here.
   Both are SIL OFL 1.1 (MIT-compatible); if/when binaries are bundled for
   shipping, add an OFL `NOTICE.md` entry at that time.
-- **Icons** — vendored at Phase 3 under `icons/` (66 line-style 24×24 SVGs,
+- **Icons** — vendored under `icons/` (66 line-style 24×24 SVGs,
   signal-teal stroke). The generic glyphs are **Lucide**-derived (ISC); the
   audio glyphs (compressor, delay, distortion, eq, filter, fader, envelope,
   reverb, …) are original Pulp work. ISC is MIT-compatible; attribution is

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -1248,7 +1248,7 @@ struct DrawCommand {
         // legacy set_font command so existing tests that count set_font
         // continue to pass.
         set_font_full,
-        // ── Canvas2D API gaps ────────────────────────────────────────
+        // ── Canvas2D API coverage ────────────────────────────────────
         set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
         draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
         write_pixels,       ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -62,7 +62,7 @@ set(PULP_JS_PRELUDES
     # CanvasRenderingContext2D.getTransform() instantiates this lazily
     # at call time so embed order relative to canvas.js is flexible.
     ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-canvas-matrix.js
-    # Canvas2D API gap-closure methods:
+    # Canvas2D API coverage methods:
     # measureText / drawImage / setLineDash / getLineDash /
     # getImageData / putImageData. Loaded AFTER the parent so the
     # CanvasRenderingContext2D constructor is in scope.

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -112,7 +112,7 @@ struct CanvasDrawCmd {
         clip,                      // intersect clip with current path
         // Image
         draw_image,
-        // Canvas2D API gap closures
+        // Canvas2D API coverage
         set_line_dash,             ///< pattern in `gradient_positions`, phase in `extra`
         put_image_data,            ///< RGBA pixels in `text` (binary), int_val=width, x2=height (as int)
         // Canvas2D shadow* sticky state setters

--- a/core/view/include/pulp/view/recognition_resolver.hpp
+++ b/core/view/include/pulp/view/recognition_resolver.hpp
@@ -35,7 +35,7 @@
 /// (figma_rest_export.py) bake recognition for the BUILT-IN library at capture
 /// time; accepting a user manifest in those lanes too is a follow-up.
 ///
-/// ── Never-silent-knob contract (P7) ──────────────────────────────────────────
+/// ── Never-silent-knob contract ───────────────────────────────────────────────
 /// A component instance the resolver does NOT match is left exactly as parsed —
 /// it is never guessed into a wrong kind. `apply_to_figma_plugin_ir` reports the
 /// unmatched-but-present component instances so they surface in the import
@@ -161,7 +161,7 @@ int apply_recognition_resolver(IRNode& root,
                                const RecognitionResolver& resolver,
                                std::vector<UnmatchedComponent>* unmatched_out = nullptr);
 
-// ── Installed-package custom-control source (the P8 merge half) ───────────────
+// ── Installed-package custom-control source ───────────────────────────────────
 // Gather every installed package's `design_controls` fragments into recognition
 // sources the resolver consumes. A package declares custom controls in its
 // registry entry under `design_controls`: an array of
@@ -203,7 +203,7 @@ PackageDesignControlSources discover_package_design_controls(
 // `recognitionFactoryId` (see apply_recognition_resolver), append a
 // `kind=custom` IRInteractiveElement carrying that `factory_id` so the native
 // materializer builds the registered overlay — or renders inert + diagnoses
-// when the factory is unregistered (P7 Tier-3, never a silent knob). Geometry
+// when the factory is unregistered (never a silent knob). Geometry
 // is taken from the node's own box; `source_node_id` is carried so the
 // inspector can map the control back to its design node.
 //

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -137,7 +137,7 @@ static pulp::events::MainThreadDispatcher::Backend make_uikit_main_thread_backen
     me.is_down = isDown;
     me.modifiers = 0x8000; // Touch flag
 
-    // Stylus / pressure data (P3: Apple Pencil support)
+    // Stylus / pressure data (Apple Pencil support)
     if (touch.maximumPossibleForce > 0)
         me.pressure = static_cast<float>(touch.force / touch.maximumPossibleForce);
     if (touch.type == UITouchTypePencil) {
@@ -186,7 +186,7 @@ static pulp::events::MainThreadDispatcher::Backend make_uikit_main_thread_backen
     }
 }
 
-// ── iPadOS hover support (P6: trackpad/mouse connected) ─────────────────
+// ── iPadOS hover support (trackpad/mouse connected) ─────────────────────
 
 - (void)setupHoverIfAvailable {
     if (@available(iOS 13.0, *)) {

--- a/core/view/src/recognition_resolver.cpp
+++ b/core/view/src/recognition_resolver.cpp
@@ -251,7 +251,7 @@ int apply_recursive(IRNode& node,
                     ++wired;
                 }
             } else if (unmatched_out) {
-                // Never-silent-knob (P7): a present-but-unmatched component is
+                // Never-silent-knob: a present-but-unmatched component is
                 // surfaced, never guessed. Dedup by component_key when present,
                 // else by the identity name — a detached/local component carries
                 // only figmaMainComponentName, not a component_key, and must
@@ -280,7 +280,7 @@ int apply_recognition_resolver(IRNode& root,
     return apply_recursive(root, resolver, unmatched_out, unmatched_seen);
 }
 
-// ── Installed-package custom-control source (the P8 merge half) ───────────────
+// ── Installed-package custom-control source ───────────────────────────────────
 
 namespace {
 

--- a/core/view/src/widget_bridge/canvas2d_api.cpp
+++ b/core/view/src/widget_bridge/canvas2d_api.cpp
@@ -1034,7 +1034,7 @@ void WidgetBridge::register_canvas2d_api(std::function<canvas::Color(const std::
     });
 
     // ═══════════════════════════════════════════════════════════════════
-    // Final gap closure
+    // Final Canvas2D API coverage
     // ═══════════════════════════════════════════════════════════════════
 
     // Canvas drawImage(canvasId, imagePath, dx, dy, dw, dh)
@@ -1067,7 +1067,7 @@ void WidgetBridge::register_canvas2d_api(std::function<canvas::Color(const std::
     });
 
     // ═══════════════════════════════════════════════════════════════════
-    // Canvas2D API gap closures
+    // Canvas2D API coverage
     // ═══════════════════════════════════════════════════════════════════
 
     // canvasMeasureText(id, text, fontFamily, fontSize) →

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1671,7 +1671,7 @@ if(PULP_HAS_SKIA AND APPLE AND PULP_ENABLE_GPU)
     # PULP_GPU_TEST_DISCOVERY_ARGS block below isn't needed here.
     catch_discover_tests(pulp-test-font-rendering-goldens-gpu)
 
-    # GPU view-host-in-plugins (P1) — proves a Processor::create_view() editor
+    # GPU view-host-in-plugins — proves a Processor::create_view() editor
     # that sets requires_gpu_host() auto-selects the GPU host, mounts a real
     # (non-AutoUi) tree, and paints a nonblank offscreen Dawn/Skia frame.
     # Soft-skips on Dawn-init failure.

--- a/test/test_design_import_codegen.cpp
+++ b/test/test_design_import_codegen.cpp
@@ -232,44 +232,44 @@ TEST_CASE("generate_pulp_cpp emits all faithful overlay kinds and chunks a large
     step.options = {"x1", "x2"};
     ir.root.interactive_elements.push_back(step);
 
-    IRInteractiveElement fader;          // P1a: SVG-patch thumb over a track
+    IRInteractiveElement fader;          // SVG-patch thumb over a track
     fader.kind = InteractiveElementKind::fader;
     fader.x = 8.0f; fader.y = 120.0f; fader.w = 12.0f; fader.h = 80.0f;
     fader.svg_patch_d = "M14 200L14 190";
     fader.default_value = 0.4f;
     ir.root.interactive_elements.push_back(fader);
 
-    IRInteractiveElement flashToggle;    // P1a: press-flash command button
+    IRInteractiveElement flashToggle;    // press-flash command button
     flashToggle.kind = InteractiveElementKind::toggle;
     flashToggle.x = 8.0f; flashToggle.y = 220.0f; flashToggle.w = 40.0f; flashToggle.h = 20.0f;
     flashToggle.flash = true;
     ir.root.interactive_elements.push_back(flashToggle);
 
-    IRInteractiveElement swap;           // P1b: swap-link button
+    IRInteractiveElement swap;           // swap-link button
     swap.kind = InteractiveElementKind::swap;
     swap.x = 60.0f; swap.y = 120.0f; swap.w = 60.0f; swap.h = 20.0f;
     swap.target_frame = 2;
     ir.root.interactive_elements.push_back(swap);
 
-    IRInteractiveElement act;            // P1b: command button
+    IRInteractiveElement act;            // command button
     act.kind = InteractiveElementKind::action;
     act.x = 60.0f; act.y = 150.0f; act.w = 30.0f; act.h = 20.0f;
     act.action = "octave_up";
     ir.root.interactive_elements.push_back(act);
 
-    IRInteractiveElement pad;            // P1b: xy pad
+    IRInteractiveElement pad;            // xy pad
     pad.kind = InteractiveElementKind::xy_pad;
     pad.x = 60.0f; pad.y = 180.0f; pad.w = 80.0f; pad.h = 80.0f;
     pad.default_value = 0.3f; pad.default_value_y = 0.7f;
     ir.root.interactive_elements.push_back(pad);
 
-    IRInteractiveElement lbl;            // P1b: value readout
+    IRInteractiveElement lbl;            // value readout
     lbl.kind = InteractiveElementKind::value_label;
     lbl.x = 60.0f; lbl.y = 270.0f; lbl.w = 80.0f; lbl.h = 16.0f;
     lbl.text = "-6.0 dB"; lbl.value_left_align = true;
     ir.root.interactive_elements.push_back(lbl);
 
-    IRInteractiveElement cst;            // P7 Tier-3: registered custom control
+    IRInteractiveElement cst;            // registered custom control
     cst.kind = InteractiveElementKind::custom;
     cst.x = 160.0f; cst.y = 120.0f; cst.w = 60.0f; cst.h = 40.0f;
     cst.factory_id = "acme.spinner"; cst.custom_props = "{\"max\":11}";
@@ -1245,8 +1245,8 @@ TEST_CASE("parse_figma_json covers layout style and audio shape metadata edges",
 
 // ── Code generation ─────────────────────────────────────────────────────
 
-TEST_CASE("generate_pulp_js emits motion.setProvenance per vendor + root (Phase 9e)",
-          "[view][import][motion][provenance][issue-pulp-motion-phase9]") {
+TEST_CASE("generate_pulp_js emits motion.setProvenance per vendor + root",
+          "[view][import][motion][provenance]") {
     // Figma export with a recognizable root node name should emit
     // `motion.setProvenance('design-import', 'figma:<root-name>')` so
     // any animations the bundle drives self-attribute through the

--- a/test/test_motion_provenance.cpp
+++ b/test/test_motion_provenance.cpp
@@ -1,5 +1,5 @@
 /// @file test_motion_provenance.cpp
-/// Phase 9 — Provenance adapters: confirm that each animation surface
+/// Provenance adapters: confirm that each animation surface
 /// (Tween, AnimatorSet, CSS TransitionSpec, JS rAF via ambient slot)
 /// stamps an identifiable `motion::Provenance` envelope on the events
 /// it publishes. An offline reader of the fixture can answer
@@ -66,7 +66,7 @@ const SampleEvent* find_event_by_kind(const std::vector<SampleEvent>& events,
 // ── Tween + PULP_MOTION_TWEEN macro ─────────────────────────────────────
 
 TEST_CASE("Tween::set_motion_provenance stamps publishes",
-          "[motion][provenance][tween][issue-pulp-motion-phase9]") {
+          "[motion][provenance][tween]") {
     MotionCapture cap;
 
     Tween t(0.0f, 1.0f, 0.1f, easing::linear);
@@ -90,7 +90,7 @@ TEST_CASE("Tween::set_motion_provenance stamps publishes",
 }
 
 TEST_CASE("PULP_MOTION_TWEEN macro auto-fills source_file/source_line",
-          "[motion][provenance][tween][macro][issue-pulp-motion-phase9]") {
+          "[motion][provenance][tween][macro]") {
     MotionCapture cap;
 
     // Note the line number of the next statement — it'll be captured by
@@ -122,7 +122,7 @@ TEST_CASE("PULP_MOTION_TWEEN macro auto-fills source_file/source_line",
 // ── AnimatorSetBuilder::name() ──────────────────────────────────────────
 
 TEST_CASE("AnimatorSetBuilder::name() propagates as motion provenance",
-          "[motion][provenance][animator-set][issue-pulp-motion-phase9]") {
+          "[motion][provenance][animator-set]") {
     MotionCapture cap;
 
     float captured = 0.0f;
@@ -149,7 +149,7 @@ TEST_CASE("AnimatorSetBuilder::name() propagates as motion provenance",
 // ── CSS TransitionSpec source attribution ───────────────────────────────
 
 TEST_CASE("parse_transition_shorthand_with_provenance carries file/line",
-          "[motion][provenance][css-transition][issue-pulp-motion-phase9]") {
+          "[motion][provenance][css-transition]") {
     auto specs = parse_transition_shorthand_with_provenance(
         "opacity 200ms ease, transform 300ms ease-in 100ms",
         "/styles/card.css", 17);
@@ -163,7 +163,7 @@ TEST_CASE("parse_transition_shorthand_with_provenance carries file/line",
 }
 
 TEST_CASE("CssAnimation publish stamps css-transition provenance",
-          "[motion][provenance][css-transition][issue-pulp-motion-phase9]") {
+          "[motion][provenance][css-transition]") {
     MotionCapture cap;
 
     auto specs = parse_transition_shorthand_with_provenance(
@@ -193,7 +193,7 @@ TEST_CASE("CssAnimation publish stamps css-transition provenance",
 // ── Ambient provenance (rAF / design-import substrate) ──────────────────
 
 TEST_CASE("Ambient provenance fills in when PublishOptions::provenance empty",
-          "[motion][provenance][ambient][issue-pulp-motion-phase9]") {
+          "[motion][provenance][ambient]") {
     MotionCapture cap;
 
     Provenance p;
@@ -218,7 +218,7 @@ TEST_CASE("Ambient provenance fills in when PublishOptions::provenance empty",
 }
 
 TEST_CASE("Design-import provenance round-trips through publish channel",
-          "[motion][provenance][design-import][issue-pulp-motion-phase9]") {
+          "[motion][provenance][design-import]") {
     MotionCapture cap;
 
     // Simulate a generated JS bundle calling motion.set_provenance(...)
@@ -251,7 +251,7 @@ TEST_CASE("Design-import provenance round-trips through publish channel",
 // ── WidgetBridge::load_script(code, script_id) + JS motion bindings ───
 
 TEST_CASE("WidgetBridge load_script(code, script_id) tags rAF publishes",
-          "[motion][provenance][widget-bridge][raf][issue-pulp-motion-phase9]") {
+          "[motion][provenance][widget-bridge][raf]") {
     MotionCapture cap;
 
     ScriptEngine engine;
@@ -290,7 +290,7 @@ TEST_CASE("WidgetBridge load_script(code, script_id) tags rAF publishes",
 }
 
 TEST_CASE("motion.setProvenance + motion.publishValue round-trip from JS",
-          "[motion][provenance][widget-bridge][js][design-import][issue-pulp-motion-phase9]") {
+          "[motion][provenance][widget-bridge][js][design-import]") {
     MotionCapture cap;
 
     ScriptEngine engine;
@@ -320,10 +320,10 @@ TEST_CASE("motion.setProvenance + motion.publishValue round-trip from JS",
     REQUIRE(current_ambient_provenance().source_kind.empty());
 }
 
-// ── Backwards compat: pre-Phase-9 publishes still work unchanged ────────
+// ── Backwards compat: publishes without provenance still work unchanged ─
 
 TEST_CASE("Publishes without provenance still emit (backwards compatible)",
-          "[motion][provenance][backcompat][issue-pulp-motion-phase9]") {
+          "[motion][provenance][backcompat]") {
     MotionCapture cap;
 
     PublishOptions po{};  // empty provenance

--- a/tools/figma-plugin/test/faithful-vector.test.ts
+++ b/tools/figma-plugin/test/faithful-vector.test.ts
@@ -221,7 +221,7 @@ test("detectOverlayControls: finds a search text_field and a tab group", () => {
   assert.equal(tabs[0].selected_index, 2);  // the filled button
 });
 
-test("detectOverlayControls: emits swap / action / xy_pad / value_label from named nodes (P1b)", () => {
+test("detectOverlayControls: emits swap / action / xy_pad / value_label from named nodes", () => {
   const readout = baseNode({
     figma_type: "TEXT", name: "Cutoff Readout", figma_node_id: "v1", content: "1.2 kHz",
     absolute_bounds: { x: 10, y: 200, w: 80, h: 16 },
@@ -257,7 +257,7 @@ test("detectOverlayControls: emits swap / action / xy_pad / value_label from nam
   assert.equal(label!.source_node_id, "v1");
 });
 
-test("detectOverlayControls: P1b name gates do not fire on generic names", () => {
+test("detectOverlayControls: name gates do not fire on generic names", () => {
   // A plain panel with unrelated names must NOT sprout swap/action/xy_pad/
   // value_label overlays. Crucially a STATIC text layer literally named "Value"
   // or "Display" must stay static — the gate requires a deliberate readout
@@ -279,7 +279,7 @@ test("detectOverlayControls: P1b name gates do not fire on generic names", () =>
     ["swap", "action", "xy_pad", "value_label"].indexOf(e.kind) !== -1).length, 0);
 });
 
-test("detectOverlayControls: stamps the P7 resolution report on every control (F2)", () => {
+test("detectOverlayControls: stamps the resolution report on every control", () => {
   // A well-shaped xy_pad resolves cleanly; a deliberately mis-shaped one (named
   // 'XY Pad' but a wide strip) is CAUGHT as a conflict in the live pipeline — the
   // silent-knob stumble, surfaced.

--- a/tools/figma-plugin/test/serialize.test.ts
+++ b/tools/figma-plugin/test/serialize.test.ts
@@ -253,7 +253,7 @@ function ieErrors(el: any): string[] {
   return errors;
 }
 
-test("interactive_element schema accepts every producer-emitted kind (P1a)", () => {
+test("interactive_element schema accepts every producer-emitted kind", () => {
   const knob = { kind: "knob", cx: 50, cy: 50, hit_radius: 22, svg_patch_d: "M50 38L50 30", default_value: 0.5, source_node_id: "1:1" };
   const fader = { kind: "fader", x: 10, y: 10, w: 8, h: 80, svg_patch_d: "M14 80L14 70", default_value: 0.3, cx: 14, cy: 75, source_node_id: "1:2" };
   const toggle = { kind: "toggle", x: 10, y: 10, w: 40, h: 20, default_value: 1, flash: true, source_node_id: "1:3" };
@@ -273,14 +273,14 @@ test("interactive_element schema accepts every producer-emitted kind (P1a)", () 
   }
 });
 
-test("interactive_element schema requires factory_id for a custom control (P7 Tier-3)", () => {
+test("interactive_element schema requires factory_id for a custom control", () => {
   // A custom control with no factory_id can't be built — the schema must reject it.
   const errs = ieErrors({ kind: "custom", x: 0, y: 0, w: 60, h: 40 });
   assert.ok(errs.some((e) => e.includes("'factory_id'")),
     `custom must require factory_id, got:\n${errs.join("\n")}`);
 });
 
-test("interactive_element schema accepts the P7 import-report fields (F0)", () => {
+test("interactive_element schema accepts the import-report fields", () => {
   // A control carrying full resolution provenance validates against the schema.
   const conflicted = {
     kind: "knob", cx: 50, cy: 50, hit_radius: 20,
@@ -295,12 +295,12 @@ test("interactive_element schema accepts the P7 import-report fields (F0)", () =
     "conflict_signals must be an array");
 });
 
-test("interactive_element schema rejects an unknown kind (P1a)", () => {
+test("interactive_element schema rejects an unknown kind", () => {
   const errs = ieErrors({ kind: "wormhole", x: 0, y: 0, w: 10, h: 10 });
   assert.ok(errs.some((e) => e.includes("not in enum")), `expected enum rejection, got:\n${errs.join("\n")}`);
 });
 
-test("interactive_element schema enforces per-kind required fields (P1a)", () => {
+test("interactive_element schema enforces per-kind required fields", () => {
   // A knob missing its cx/cy/hit_radius fails (the knob allOf branch).
   const knobMissing = ieErrors({ kind: "knob" });
   assert.ok(knobMissing.some((e) => e.includes("'cx'")), `knob should require cx, got:\n${knobMissing.join("\n")}`);

--- a/tools/harness/tests/test_canvas2d_adapter_shim_files.py
+++ b/tools/harness/tests/test_canvas2d_adapter_shim_files.py
@@ -35,7 +35,7 @@ class Canvas2dShimFileUnionTests(unittest.TestCase):
         cls.adapter = Canvas2dAdapter(REPO_ROOT)
 
     def test_image_prelude_methods_resolve(self) -> None:
-        """The six API gap-closure methods from `web-compat-canvas-image.js`
+        """The six API coverage methods from `web-compat-canvas-image.js`
         must appear in the adapter's prototype-method set, otherwise the
         verifier reports `canvas2d/measureText` etc. as NOT-IMPL."""
         moved_to_image_prelude = {

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -174,7 +174,7 @@ def extract_style(n, ctx=None):
                 ih = f.get("imageRef") or f.get("imageHash")
                 if ih:
                     s["background_image"] = f"pending:{ih}"
-                    # P2: accumulate into the explicit context (no module global).
+                    # Accumulate into the explicit context (no module global).
                     # ctx is None only on direct extract_style() calls (unit tests
                     # that don't exercise image-fill resolution).
                     if ctx is not None:
@@ -332,7 +332,7 @@ def is_pure_vector_illustration(n):
 # with audio_widget set so the importer renders it NATIVELY (silver knob / fader /
 # meter — the figma-plugin lane default) at the node's own size, instead of
 # capturing its internal vectors as images (which suppresses recognition and
-# renders a misplaced raw sprite). Mirror this in the TS extractor (P2/P3).
+# renders a misplaced raw sprite). Mirror this in the TS extractor.
 def _tokenize_name(name):
     """Whole-word tokens mirroring the C++ tokenize_name (design_import.cpp):
     split on non-alphanumerics AND camelCase / acronym / digit boundaries,
@@ -484,7 +484,7 @@ def extract_layout(n):
     return l
 
 class ExtractContext:
-    """P2 — explicit accumulators for walk()'s side effects, replacing the old
+    """Explicit accumulators for walk()'s side effects, replacing the old
     module globals (ASSET_IDS / FONT_ASSETS / IMAGE_FILL_REFS). node_tree_to_ir()
     creates one, threads it through walk()/extract_style()/_record_font(), and
     returns it so the caller reads the outputs explicitly instead of reaching into
@@ -522,7 +522,7 @@ def _record_font(n, ctx):
 def node_tree_to_ir(root):
     """Walk a Figma node tree into the Pulp IR, returning (ir_node, ExtractContext)
     so the side effects (asset ids / fonts / image fills) are EXPLICIT outputs —
-    no module globals. The decomposed seam (P2 'the real refactor')."""
+    no module globals. The decomposed seam."""
     ctx = ExtractContext()
     ir = walk(root, None, 0, ctx)
     return ir, ctx

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -2445,7 +2445,7 @@ int main(int argc, char* argv[]) {
     // resolvable third-party keys leaves behavior exactly as before (the built-in
     // library path stays authoritative; an already-stamped audio_widget is never
     // overridden). Unmatched-but-present component instances are surfaced as an
-    // import diagnostic — never guessed into a wrong kind (P7).
+    // import diagnostic — never guessed into a wrong kind.
     if (*source == DesignSource::figma_plugin || *source == DesignSource::figma) {
         auto resolver = pulp::view::RecognitionResolver::with_builtin_library();
         if (!recognition_manifest_path.empty()) {
@@ -2466,7 +2466,7 @@ int main(int argc, char* argv[]) {
             resolver.add_source(std::move(*user_source));
         }
 
-        // Installed-package custom controls (P8): gather each installed
+        // Installed-package custom controls: gather each installed
         // package's `design_controls` fragment and add it as its own source,
         // MERGED OVER the built-in library and the user manifest. With no
         // custom-control package installed this contributes nothing, so behavior


### PR DESCRIPTION
## Summary
- remove stale phase/P-row planning breadcrumbs from view/design comments, markdown provenance, and display-only test names/tags
- align Canvas2D API comments on coverage wording
- preserve behavior notes, issue anchors, fixture IDs, schema literals, and generated-source/future-work gates

## Validation
- git diff --check origin/main
- python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh refs/remotes/origin/main
- npm test (tools/figma-plugin): 60/60 passed
- python3 -m unittest tools/harness/tests/test_canvas2d_adapter_shim_files.py: 2/2 passed
- RepoPrompt diff-backed review: safe comment/docstring/test-title-only after accepted sibling-title cleanup
- autoreview --mode branch --base origin/main --reviewers codex,claude: clean, 0 findings
- accidental full pre-push run reached CTest 9949/10634 with no failures before being stopped in low-CPU iOS configure test; retry push used intended comment-only gate path


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale planning breadcrumbs from view/design comments, provenance docs, and test names/tags, and updated Canvas2D comments to use “API coverage” wording. Behavior is unchanged; existing notes, anchors, IDs, schema literals, and gates are preserved.

<sup>Written for commit bcd20159911dac2c460cca908100156a90aa5c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

