### PR TITLE
feat(cli): pulp run --audio-capture-wav — dump the live output ring to a WAV

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -231,7 +231,16 @@ entry has a `check` (`not_silent`, `silent`, `no_nan_inf`, `peak_below`,
 tolerance (`min_rms_dbfs`, `ceiling_dbfs`, `expected_hz` + `tolerance_cents`,
 ...). The `/audio-harness` slash command documents these verbs.
 
-## Roadmap (planned — do NOT instruct using this until it lands)
+## Roadmap
 
-- **Live ring-capture-to-WAV** (`pulp audio validate` over a running plugin's
-  tapped output) and a scenario-driven `render` verb are later Phase-7 slices.
+- **Live capture-to-WAV — LANDED (earliest-window).** `pulp run
+  --audio-capture-wav <file>` taps the standalone's output-boundary probe ring
+  and dumps it to a WAV the offline `pulp audio validate` verbs read. It captures
+  the EARLIEST window after the stream starts (int16, drop-on-full FIFO), so it is
+  robust for `validate summarize` / `assert` (presence / level / clip / NaN) but
+  is the wrong window for steady-state `doctor` (THD/response) and is
+  quantization-limited for `compare`.
+- **Planned (do NOT instruct using these until they land):** the rolling-ring
+  capture variant (true last-N + float/24-bit WAV, lifting the doctor/compare
+  caveat above), and a scenario-driven `render` verb (`pulp audio render
+  --plugin <bundle> ...`) that renders a plugin offline from declarative flags.

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -56,7 +56,7 @@ sync with `tools/scripts/cli_sync_check.py` and
 **Commands that DO have slash commands** (list for cross-reference, not exhaustive — `ls .claude/commands/` is authoritative):
 build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, ci-host, upgrade, prototype-loop, motion, audio-harness, audio-inspect
 
-`audio-harness` is a workflow slash command (wraps the audio observability harness `ctest` targets + the `audio-harness` skill) — it is NOT a `pulp` CLI subcommand. Note the distinction from the `pulp audio` CLI: that command owns both the model/bundle tooling (model/excerpt-find/read-bundle) AND the offline `pulp audio validate <verb>` harness CLI (summarize/doctor/compare/assert, `tools/cli/cmd_audio_validate.cpp`, over captured WAVs / `audio-run/` bundles — no live plugin). `pulp audio` intentionally has no slash command of its own; the `/audio-harness` command documents the `validate` verbs. Keep the live/planned boundary in sync with the `audio-harness` skill: live Audio Inspector use is landed under `/audio-inspect` / `pulp run --audio-inspector`, while live ring-capture-to-WAV and a scenario-driven `render` verb remain planned. When adding a `validate` verb, update `cmd_audio_validate.cpp`, `docs/status/cli-commands.yaml` (nested under `audio`), `docs/reference/cli.md#audio`, and both the `audio-harness` and this skill.
+`audio-harness` is a workflow slash command (wraps the audio observability harness `ctest` targets + the `audio-harness` skill) — it is NOT a `pulp` CLI subcommand. Note the distinction from the `pulp audio` CLI: that command owns both the model/bundle tooling (model/excerpt-find/read-bundle) AND the offline `pulp audio validate <verb>` harness CLI (summarize/doctor/compare/assert, `tools/cli/cmd_audio_validate.cpp`, over captured WAVs / `audio-run/` bundles — no live plugin). `pulp audio` intentionally has no slash command of its own; the `/audio-harness` command documents the `validate` verbs. Keep the live/planned boundary in sync with the `audio-harness` skill: live Audio Inspector use is landed under `/audio-inspect` / `pulp run --audio-inspector`, and live ring-capture-to-WAV is landed under `pulp run --audio-capture-wav` (earliest-window int16 dump — good for `validate summarize`/`assert`; the rolling-ring variant for `doctor`/`compare`, and a scenario-driven `render` verb, remain planned). When adding a `validate` verb, update `cmd_audio_validate.cpp`, `docs/status/cli-commands.yaml` (nested under `audio`), `docs/reference/cli.md#audio`, and both the `audio-harness` and this skill.
 
 Not every slash command wraps a `pulp` CLI subcommand. A slash command may
 also document a developer-tool *surface* with no CLI backing — e.g.
@@ -475,10 +475,16 @@ to the `print_help` text plus the `pulp run --help` shellout assertion in
 `test_cli_shellout.cpp` and the parser test in `test_cli_run_options.cpp`.
 The Audio Inspector flags follow this shape: `--audio-inspector` →
 `PULP_AUDIO_INSPECTOR=1` (does NOT imply headless); `--audio-probe-json <path>`
-→ `PULP_AUDIO_PROBE_JSON=<path>` (implies headless, like `--screenshot`). A
-bare `--audio-probe-json` run is headless but must NOT auto-assign a default
-screenshot PNG path — guard the headless-default branch on an empty probe-json
-path. See `docs/guides/audio-inspector.md`.
+→ `PULP_AUDIO_PROBE_JSON=<path>` (implies headless, like `--screenshot`);
+`--audio-scope-json <path>` → `PULP_AUDIO_SCOPE_JSON=<path>` (+ window/trigger/
+channel); `--audio-capture-wav <file>` → `PULP_AUDIO_CAPTURE_WAV=<file>` (+
+`--audio-capture-frames` → `PULP_AUDIO_CAPTURE_WAV_FRAMES`), which dumps the live
+output ring to a WAV for `pulp audio validate`, implies headless, and shares the
+single capture FIFO with `--audio-inspector` / `--audio-scope-json` (the three
+are mutually exclusive at parse time). A bare `--audio-probe-json` /
+`--audio-scope-json` / `--audio-capture-wav` run is headless but must NOT
+auto-assign a default screenshot PNG path — guard the headless-default branch on
+all three being empty. See `docs/guides/audio-inspector.md`.
 
 The live window also reads display-only waveform env vars:
 `PULP_AUDIO_INSPECTOR_TRIGGER=rising-zero`, `PULP_AUDIO_INSPECTOR_GRID=0`, and

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.252.1",
+      "version": "0.253.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.252.1"
+  "version": "0.253.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.252.1",
+  "version": "0.253.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.498.0
+    VERSION 0.499.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_audio_capture_wav.hpp
+++ b/core/format/include/pulp/format/detail/standalone_audio_capture_wav.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <pulp/audio/audio_file.hpp>
+#include <pulp/audio/audio_probe.hpp>
+#include <pulp/audio/buffer.hpp>
+#include <pulp/format/standalone.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace pulp::format::detail {
+
+// Cap on the capture-to-WAV ring window, shared between the writer (clamp) and
+// the start()-time ring sizing so the two can never silently diverge into a
+// short read. Matches the scope path's window cap.
+constexpr int kMaxCaptureWindowSamples = 16384;
+
+// Drain the standalone output probe's capture ring into a WAV file so the
+// already-shipped offline `pulp audio validate summarize|assert` verbs can read
+// it. Off the realtime thread (called from the one-shot delayed action, like the
+// scope-json dump); the producer side (AudioProbe::analyze_output) stays
+// allocation/lock-free. Empty path → no-op.
+//
+// SCOPE CAVEAT (matches the underlying AudioProbe FIFO): the capture ring is
+// drop-on-full, so this holds the EARLIEST ~window samples after the stream
+// starts, not a rolling "last N", and `write_wav_file` quantizes to int16. That
+// is robust for `summarize`/`assert` (presence / level / clip / NaN), but it is
+// the wrong window for steady-state `doctor` (THD/response) and is
+// quantization-limited for `compare` — those wait on the rolling-ring follow-up.
+inline bool write_audio_capture_wav_file(const std::string& path,
+                                         audio::AudioProbe& probe,
+                                         const StandaloneConfig& config) {
+    if (path.empty()) return false;
+
+    // 0 (the config default) means "as much as the ring holds" → the shared cap.
+    int requested = config.audio_capture_wav_frames > 0
+                        ? config.audio_capture_wav_frames
+                        : kMaxCaptureWindowSamples;
+    requested = std::clamp(requested, 1, kMaxCaptureWindowSamples);
+
+    const auto snapshot = probe.latest();
+    const std::size_t channels =
+        std::max<std::size_t>(1, static_cast<std::size_t>(snapshot.channel_count));
+
+    audio::Buffer<float> samples(channels, static_cast<std::size_t>(requested));
+    const int frames = probe.read_capture(samples.view(), requested);
+    if (frames <= 0) return false;  // nothing captured yet — surface as a failure
+
+    audio::AudioFileData data;
+    data.sample_rate =
+        static_cast<std::uint32_t>(std::max(0.0, snapshot.sample_rate));
+    data.channels.resize(channels);
+    const auto view = samples.view();
+    for (std::size_t c = 0; c < channels; ++c) {
+        const float* src = view.channel_ptr(c);
+        data.channels[c].assign(src, src + frames);
+    }
+    return audio::write_wav_file(path, data);
+}
+
+}  // namespace pulp::format::detail

--- a/core/format/include/pulp/format/detail/standalone_environment.hpp
+++ b/core/format/include/pulp/format/detail/standalone_environment.hpp
@@ -92,6 +92,18 @@ inline StandaloneConfig standalone_config_from_environment(StandaloneConfig conf
     if (!config.audio_scope_json_path.empty())
         config.headless = true;
 
+    if (auto capture_wav = runtime::get_env("PULP_AUDIO_CAPTURE_WAV");
+        capture_wav && config.audio_capture_wav_path.empty()) {
+        config.audio_capture_wav_path = *capture_wav;
+    }
+    if (auto frames = runtime::get_env("PULP_AUDIO_CAPTURE_WAV_FRAMES")) {
+        int parsed = 0;
+        if (parse_positive_frame_delay(*frames, parsed))
+            config.audio_capture_wav_frames = parsed;
+    }
+    if (!config.audio_capture_wav_path.empty())
+        config.headless = true;
+
     if (!config.screenshot_path.empty())
         config.headless = true;
 
@@ -104,6 +116,7 @@ inline bool standalone_headless_requires_screenshot(const StandaloneConfig& conf
 #if PULP_ENABLE_AUDIO_PROBES
     if (!config.audio_probe_json_path.empty()) return false;
     if (!config.audio_scope_json_path.empty()) return false;
+    if (!config.audio_capture_wav_path.empty()) return false;
 #endif
     return true;
 }
@@ -115,7 +128,8 @@ inline bool standalone_probe_json_requested_but_disabled(
     return false;
 #else
     return !config.audio_probe_json_path.empty()
-        || !config.audio_scope_json_path.empty();
+        || !config.audio_scope_json_path.empty()
+        || !config.audio_capture_wav_path.empty();
 #endif
 }
 

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -89,6 +89,14 @@ struct StandaloneConfig {
     std::string audio_scope_trigger = "rising-zero";
     int audio_scope_channel = 0;
 
+    // Programmatic live capture-to-WAV over the same output-boundary probe ring.
+    // Writes a WAV the offline `pulp audio validate` verbs can read, then the
+    // one-shot exits. Only meaningful when PULP_ENABLE_AUDIO_PROBES is ON.
+    // `audio_capture_wav_frames` is the ring window in samples (0 = as much as the
+    // ring holds, clamped to the capture cap). Captures all output channels.
+    std::string audio_capture_wav_path;
+    int audio_capture_wav_frames = 0;
+
     // Built-in tempo source. The standalone host has no DAW providing
     // transport, so it acts as one: it surfaces `tempo_bpm` / time signature on
     // every ProcessContext block, and advances `position_beats` from

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -39,6 +39,7 @@
 #endif
 #if PULP_ENABLE_AUDIO_PROBES
 #include <pulp/audio/audio_probe_json.hpp>
+#include <pulp/format/detail/standalone_audio_capture_wav.hpp>
 #include <pulp/format/detail/standalone_audio_probe_json.hpp>
 #include <pulp/format/detail/standalone_audio_scope_json.hpp>
 #include <pulp/view/audio_inspector_window.hpp>
@@ -196,8 +197,24 @@ bool StandaloneApp::start() {
     const int scope_capture_frames = config_.audio_scope_json_path.empty()
         ? 0
         : std::clamp(config_.audio_scope_window_samples, 1, kMaxScopeWindowSamples);
-    probe_capture.capture_frames = std::max(view::AudioWaveformView::kCapacity,
-                                            scope_capture_frames);
+    // capture-to-WAV shares the one probe ring; size it to whichever consumer
+    // (inspector display / scope / capture-wav) needs the most. A 0 capture-wav
+    // frame request means "as much as the ring holds" → the cap.
+    if (!config_.audio_capture_wav_path.empty()
+        && config_.audio_capture_wav_frames > detail::kMaxCaptureWindowSamples) {
+        runtime::log_info(
+            "Standalone: --audio-capture-frames {} exceeds the {}-sample cap; clamping",
+            config_.audio_capture_wav_frames, detail::kMaxCaptureWindowSamples);
+    }
+    const int capture_wav_frames = config_.audio_capture_wav_path.empty()
+        ? 0
+        : (config_.audio_capture_wav_frames > 0
+               ? std::clamp(config_.audio_capture_wav_frames, 1,
+                            detail::kMaxCaptureWindowSamples)
+               : detail::kMaxCaptureWindowSamples);
+    probe_capture.capture_frames = std::max({view::AudioWaveformView::kCapacity,
+                                             scope_capture_frames,
+                                             capture_wav_frames});
     output_probe_.prepare(config_.output_channels, max_callback_block_,
                           config_.sample_rate,
                           audio::AudioProbeStage::kStandaloneOutputBoundary,
@@ -735,6 +752,9 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     auto write_scope_json = [this, effective_config](const std::string& path) {
         detail::write_audio_scope_json_file(path, output_probe_, effective_config);
     };
+    auto write_capture_wav = [this, effective_config](const std::string& path) {
+        detail::write_audio_capture_wav_file(path, output_probe_, effective_config);
+    };
 #endif
 
     // ── Headless one-shot screenshot ────────────────────────────────────────
@@ -765,9 +785,10 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         cap.capture_fn = [host, editor_view, w, h
 #if PULP_ENABLE_AUDIO_PROBES
                           , audio_inspector_ptr, inspector_png_path,
-                          write_probe_json, write_scope_json,
+                          write_probe_json, write_scope_json, write_capture_wav,
                           probe_json_path = effective_config.audio_probe_json_path,
-                          scope_json_path = effective_config.audio_scope_json_path
+                          scope_json_path = effective_config.audio_scope_json_path,
+                          capture_wav_path = effective_config.audio_capture_wav_path
 #endif
         ] {
 #if PULP_ENABLE_AUDIO_PROBES
@@ -776,6 +797,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
             // --audio-probe-json in a single headless run). No-op when unset.
             write_probe_json(probe_json_path);
             write_scope_json(scope_json_path);
+            write_capture_wav(capture_wav_path);
             // Side-effect: capture the inspector window's own surface at the
             // same frame, before the main window closes. capture_png() returns
             // empty on hosts without GPU capture — skip the write in that case.
@@ -865,6 +887,25 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         runtime::log_info(
             "Standalone: audio-scope-json mode armed — will dump to {} after {} frames",
             effective_config.audio_scope_json_path, cap.delay);
+    }
+    else if (!effective_config.audio_capture_wav_path.empty()) {
+        auto* host = window.get();
+        detail::DelayedAction cap;
+        cap.delay = effective_config.screenshot_frame_delay > 0
+            ? effective_config.screenshot_frame_delay : 30;
+        cap.action_fn = [write_capture_wav,
+                         path = effective_config.audio_capture_wav_path]() {
+            write_capture_wav(path);
+        };
+        cap.close_fn = [host] { host->request_close(); };
+        auto prior = pre_screenshot_idle;
+        host->set_idle_callback([prior, cap = std::move(cap)]() mutable {
+            if (prior) prior();
+            cap();
+        });
+        runtime::log_info(
+            "Standalone: audio-capture-wav mode armed — will dump to {} after {} frames",
+            effective_config.audio_capture_wav_path, cap.delay);
     }
 #endif
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -294,6 +294,15 @@ dev-on/ship-off `PULP_ENABLE_AUDIO_PROBES` gating.
 - `--audio-scope-window <samples>` / `--audio-scope-trigger <none|raw|off|rising-zero>` /
   `--audio-scope-channel <index>` — acquisition controls for
   `--audio-scope-json`.
+- `--audio-capture-wav <file>` — capture the live output to a WAV after the frame
+  delay, then exit, so the offline `pulp audio validate` verbs can analyze it.
+  `--audio-capture-frames <n>` sets the ring window (0 = as much as the ring
+  holds). Implies `--headless` but still launches the live audio device, and
+  shares the single capture FIFO with `--audio-inspector` / `--audio-scope-json`
+  (the three are mutually exclusive). NOTE: this dumps the **earliest** window
+  after the stream starts (int16), which is robust for `validate summarize` /
+  `assert` (presence / level / clip / NaN); steady-state `doctor` (THD/response)
+  and `compare` want the rolling-ring follow-up.
 
 Display-only waveform controls:
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -504,6 +504,12 @@ commands:
       - name: --audio-scope-channel
         kind: option
         description: Source channel index for --audio-scope-json.
+      - name: --audio-capture-wav
+        kind: option
+        description: Capture the live output to a WAV at <file> after rendering, then exit, so `pulp audio validate` can analyze it; implies --headless for UI but still launches the live audio device. Forwarded as --audio-capture-wav <file> and PULP_AUDIO_CAPTURE_WAV=<file>. Shares the one capture FIFO with --audio-inspector and --audio-scope-json (mutually exclusive). Captures the earliest window (int16) — best for validate summarize/assert.
+      - name: --audio-capture-frames
+        kind: option
+        description: Ring window in samples for --audio-capture-wav (0 = as much as the ring holds, clamped). Forwarded as --audio-capture-frames <n> and PULP_AUDIO_CAPTURE_WAV_FRAMES=<n>.
       - name: PULP_RUN_AUDIO_NOTICE
         kind: environment
         description: Set to 0/false/off/no to suppress the pre-launch notice that pulp run may activate system audio output.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1934,6 +1934,7 @@ pulp_add_test_suite(pulp-test-standalone-editor-chrome LIBRARIES pulp::standalon
     PROPERTIES PROCESSORS 8)
 pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
+pulp_add_test_suite(pulp-test-standalone-audio-capture-wav LIBRARIES pulp::standalone pulp::audio PROPERTIES PROCESSORS 8)
 pulp_add_test_suite(pulp-test-standalone-transport-midi LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
 pulp_add_test_suite(pulp-test-standalone-audio-inspector
@@ -1943,7 +1944,6 @@ pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
 # STFT and audio visualization signal tests
 pulp_add_test_suite(pulp-test-stft LIBRARIES pulp::signal)
-
 # Visualization bridge and widget tests
 pulp_add_test_suite(pulp-test-visualization LIBRARIES pulp::view)
 

--- a/test/test_cli_run_options.cpp
+++ b/test/test_cli_run_options.cpp
@@ -469,6 +469,47 @@ TEST_CASE("pulp run rejects invalid audio scope options and inspector contention
     REQUIRE_FALSE(contention.error.empty());
 }
 
+TEST_CASE("pulp run --audio-capture-wav implies headless and forwards the path",
+          "[cli][run][audio-capture-wav]") {
+    auto r = parse_run_options({"--audio-capture-wav", "/tmp/cap.wav",
+                                "--audio-capture-frames", "1024"});
+    REQUIRE(r.error.empty());
+    REQUIRE(r.audio_capture_wav_path == "/tmp/cap.wav");
+    REQUIRE(r.audio_capture_frames == 1024);
+    REQUIRE(r.headless);
+    auto args = assemble_launch_args(r);
+    REQUIRE(std::find(args.begin(), args.end(), "--audio-capture-wav") != args.end());
+    REQUIRE(std::find(args.begin(), args.end(), "/tmp/cap.wav") != args.end());
+    REQUIRE(std::find(args.begin(), args.end(), "--audio-capture-frames") != args.end());
+    REQUIRE(std::find(args.begin(), args.end(), "1024") != args.end());
+
+    auto eq = parse_run_options({"--audio-capture-wav=/tmp/cap2.wav"});
+    REQUIRE(eq.error.empty());
+    REQUIRE(eq.audio_capture_wav_path == "/tmp/cap2.wav");
+    REQUIRE(eq.headless);
+    // Frames default to 0 (ring default) → not forwarded.
+    auto eq_args = assemble_launch_args(eq);
+    REQUIRE(std::find(eq_args.begin(), eq_args.end(), "--audio-capture-frames")
+            == eq_args.end());
+}
+
+TEST_CASE("pulp run rejects invalid audio-capture-wav options and FIFO contention",
+          "[cli][run][audio-capture-wav]") {
+    REQUIRE_FALSE(parse_run_options({"--audio-capture-wav"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--audio-capture-wav="}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--audio-capture-frames", "0",
+                                     "--audio-capture-wav", "/tmp/c.wav"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--audio-capture-frames=-1",
+                                     "--audio-capture-wav", "/tmp/c.wav"}).error.empty());
+    // --audio-capture-frames requires --audio-capture-wav.
+    REQUIRE_FALSE(parse_run_options({"--audio-capture-frames", "512"}).error.empty());
+    // Shares the one capture FIFO with inspector + scope-json.
+    REQUIRE_FALSE(parse_run_options({"--audio-inspector",
+                                     "--audio-capture-wav", "/tmp/c.wav"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--audio-scope-json", "/tmp/s.json",
+                                     "--audio-capture-wav", "/tmp/c.wav"}).error.empty());
+}
+
 TEST_CASE("pulp run treats negative-looking targets as pass-through flags",
           "[cli][run][coverage]") {
     auto r = parse_run_options({"--standalone", "demo"});

--- a/test/test_standalone_audio_capture_wav.cpp
+++ b/test/test_standalone_audio_capture_wav.cpp
@@ -1,0 +1,99 @@
+// Coverage for the standalone live capture-to-WAV writer: drain the output
+// probe's capture ring into a WAV the offline `pulp audio validate` verbs can
+// read. Exercises the real AudioProbe capture path (prepare → analyze_output →
+// read_capture) and the int16 WAV round-trip, plus the headless predicate that
+// keeps a capture-wav-only run from forcing a screenshot.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/audio/audio_file.hpp>
+#include <pulp/audio/audio_probe.hpp>
+#include <pulp/audio/buffer.hpp>
+#include <pulp/format/detail/standalone_audio_capture_wav.hpp>
+#include <pulp/format/detail/standalone_environment.hpp>
+#include <pulp/format/standalone.hpp>
+
+#include <cmath>
+#include <filesystem>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+TEST_CASE("write_audio_capture_wav_file dumps the probe ring to a readable WAV",
+          "[standalone][audio-capture-wav]") {
+    constexpr int kChannels = 2;
+    constexpr int kBlock = 128;
+    constexpr int kWindow = 256;  // two blocks fit exactly
+
+    pulp::audio::AudioProbe probe;
+    pulp::audio::AudioProbe::CaptureConfig cc;
+    cc.capture_frames = kWindow;
+    probe.prepare(kChannels, kBlock, 48000.0,
+                  pulp::audio::AudioProbeStage::kStandaloneOutputBoundary, cc);
+
+    // Feed two blocks of a per-channel ramp distinct across channels, so a
+    // channel swap or a wrong window would diverge. The FIFO is drop-on-full, so
+    // these two blocks (256 frames) are exactly the captured window.
+    auto sample = [](int ch, int frame) {
+        return static_cast<float>(ch + 1) * 0.1f + static_cast<float>(frame) * 0.0001f;
+    };
+    int global = 0;
+    for (int b = 0; b < 2; ++b) {
+        std::vector<std::vector<float>> blk(kChannels, std::vector<float>(kBlock, 0.0f));
+        std::vector<const float*> ptrs;
+        for (int ch = 0; ch < kChannels; ++ch) {
+            for (int i = 0; i < kBlock; ++i) blk[ch][i] = sample(ch, global + i);
+            ptrs.push_back(blk[ch].data());
+        }
+        global += kBlock;
+        pulp::audio::BufferView<const float> view(ptrs.data(), kChannels, kBlock);
+        probe.analyze_output(view);
+    }
+
+    pulp::format::StandaloneConfig cfg;
+    cfg.audio_capture_wav_frames = kWindow;
+    const auto path = (fs::temp_directory_path() / "pulp_capture_wav_test.wav").string();
+    fs::remove(path);
+
+    REQUIRE(pulp::format::detail::write_audio_capture_wav_file(path, probe, cfg));
+
+    const auto data = pulp::audio::read_audio_file(path);
+    REQUIRE(data.has_value());
+    CHECK(data->num_channels() == static_cast<std::uint32_t>(kChannels));
+    CHECK(data->num_frames() == static_cast<std::uint64_t>(kWindow));
+    CHECK(data->sample_rate == 48000u);
+
+    // int16 round-trip tolerance (~1/32768). The earliest-window contract means
+    // frame f holds sample(ch, f).
+    for (int ch = 0; ch < kChannels; ++ch) {
+        CHECK(std::abs(data->channels[ch][0] - sample(ch, 0)) < 1e-3f);
+        CHECK(std::abs(data->channels[ch][kWindow - 1] - sample(ch, kWindow - 1)) < 1e-3f);
+    }
+    // The two channels are genuinely distinct (not a degenerate all-equal dump).
+    CHECK(std::abs(data->channels[0][10] - data->channels[1][10]) > 1e-2f);
+
+    fs::remove(path);
+}
+
+TEST_CASE("write_audio_capture_wav_file with an empty path or empty ring is a no-op",
+          "[standalone][audio-capture-wav]") {
+    pulp::audio::AudioProbe probe;  // not prepared with capture → nothing to drain
+    pulp::format::StandaloneConfig cfg;
+    CHECK_FALSE(pulp::format::detail::write_audio_capture_wav_file("", probe, cfg));
+    CHECK_FALSE(pulp::format::detail::write_audio_capture_wav_file(
+        (fs::temp_directory_path() / "pulp_capture_empty.wav").string(), probe, cfg));
+}
+
+#if PULP_ENABLE_AUDIO_PROBES
+TEST_CASE("a capture-wav-only headless run does not require a screenshot",
+          "[standalone][audio-capture-wav]") {
+    pulp::format::StandaloneConfig cfg;
+    cfg.headless = true;
+    cfg.audio_capture_wav_path = "out.wav";
+    CHECK_FALSE(pulp::format::detail::standalone_headless_requires_screenshot(cfg));
+}
+#endif
+
+}  // namespace

--- a/tools/cli/cmd_run.cpp
+++ b/tools/cli/cmd_run.cpp
@@ -28,6 +28,8 @@ constexpr const char* kAudioScopeJsonEnv = "PULP_AUDIO_SCOPE_JSON";
 constexpr const char* kAudioScopeWindowEnv = "PULP_AUDIO_SCOPE_WINDOW";
 constexpr const char* kAudioScopeTriggerEnv = "PULP_AUDIO_SCOPE_TRIGGER";
 constexpr const char* kAudioScopeChannelEnv = "PULP_AUDIO_SCOPE_CHANNEL";
+constexpr const char* kAudioCaptureWavEnv = "PULP_AUDIO_CAPTURE_WAV";
+constexpr const char* kAudioCaptureWavFramesEnv = "PULP_AUDIO_CAPTURE_WAV_FRAMES";
 constexpr const char* kAudioNoticeEnv    = "PULP_RUN_AUDIO_NOTICE";
 
 void print_help() {
@@ -64,6 +66,14 @@ void print_help() {
            "                          --audio-scope-trigger, and --audio-scope-channel\n"
            "                          to control acquisition. Implies --headless but\n"
            "                          still uses the live audio device.\n"
+           "  --audio-capture-wav <file>\n"
+           "                          Capture the live output to a WAV file after\n"
+           "                          rendering, then exit, so `pulp audio validate` can\n"
+           "                          analyze it. --audio-capture-frames <n> sets the ring\n"
+           "                          window. Implies --headless but still uses the live\n"
+           "                          audio device. NOTE: captures the earliest window\n"
+           "                          after start (int16) — best for summarize/assert;\n"
+           "                          doctor/compare want the rolling-ring follow-up.\n"
            "  PULP_RUN_AUDIO_NOTICE=0\n"
            "                          Suppress the pre-launch notice that the\n"
            "                          standalone may activate system audio output.\n"
@@ -150,7 +160,8 @@ int cmd_run(const std::vector<std::string>& args) {
     // only wants the JSON dump, so don't force a PNG capture in that case.
     if (opts.headless && opts.screenshot_path.empty()
         && opts.audio_probe_json_path.empty()
-        && opts.audio_scope_json_path.empty()) {
+        && opts.audio_scope_json_path.empty()
+        && opts.audio_capture_wav_path.empty()) {
         std::string base = opts.target_name.empty() ? "pulp-run" : opts.target_name;
         opts.screenshot_path = (build_dir / (base + ".png")).string();
     }
@@ -285,6 +296,11 @@ int cmd_run(const std::vector<std::string>& args) {
         set_env(kAudioScopeWindowEnv, std::to_string(opts.audio_scope_window));
         set_env(kAudioScopeTriggerEnv, opts.audio_scope_trigger);
         set_env(kAudioScopeChannelEnv, std::to_string(opts.audio_scope_channel));
+    }
+    if (!opts.audio_capture_wav_path.empty()) {
+        set_env(kAudioCaptureWavEnv, opts.audio_capture_wav_path);
+        if (opts.audio_capture_frames > 0)
+            set_env(kAudioCaptureWavFramesEnv, std::to_string(opts.audio_capture_frames));
     }
 
     auto launch_args = assemble_launch_args(opts);

--- a/tools/cli/cmd_run.hpp
+++ b/tools/cli/cmd_run.hpp
@@ -31,6 +31,8 @@ struct ParseRunResult {
     int audio_scope_window = 2048;      ///< --audio-scope-window <samples>
     std::string audio_scope_trigger = "rising-zero"; ///< --audio-scope-trigger <mode>
     int audio_scope_channel = 0;        ///< --audio-scope-channel <index>
+    std::string audio_capture_wav_path; ///< --audio-capture-wav <file>; implies --headless
+    int audio_capture_frames = 0;       ///< --audio-capture-frames <n>, 0 = ring default
 
     /// Args explicitly forwarded by the user with `-- ...`, plus any
     /// unknown flags (legacy permissive behaviour).

--- a/tools/cli/cmd_run_parse.cpp
+++ b/tools/cli/cmd_run_parse.cpp
@@ -52,6 +52,7 @@ ParseRunResult parse_run_options(const std::vector<std::string>& args) {
     ParseRunResult r;
     bool after_separator = false;
     bool audio_scope_acquisition_option_seen = false;
+    bool audio_capture_frames_option_seen = false;
 
     for (size_t i = 0; i < args.size(); ++i) {
         const auto& a = args[i];
@@ -239,6 +240,45 @@ ParseRunResult parse_run_options(const std::vector<std::string>& args) {
             continue;
         }
 
+        if (a == "--audio-capture-wav") {
+            if (i + 1 >= args.size() || args[i + 1].empty()) {
+                r.error = "--audio-capture-wav requires a path argument";
+                return r;
+            }
+            r.audio_capture_wav_path = args[++i];
+            r.headless = true;
+            continue;
+        }
+        if (a.rfind("--audio-capture-wav=", 0) == 0) {
+            r.audio_capture_wav_path = a.substr(std::string("--audio-capture-wav=").size());
+            if (r.audio_capture_wav_path.empty()) {
+                r.error = "--audio-capture-wav= requires a non-empty path";
+                return r;
+            }
+            r.headless = true;
+            continue;
+        }
+        if (a == "--audio-capture-frames") {
+            audio_capture_frames_option_seen = true;
+            if (i + 1 >= args.size() || !parse_frame_count(args[i + 1], r.audio_capture_frames)
+                || r.audio_capture_frames <= 0) {
+                r.error = "--audio-capture-frames requires a positive integer";
+                return r;
+            }
+            ++i;
+            continue;
+        }
+        if (a.rfind("--audio-capture-frames=", 0) == 0) {
+            audio_capture_frames_option_seen = true;
+            if (!parse_frame_count(a.substr(std::string("--audio-capture-frames=").size()),
+                                   r.audio_capture_frames)
+                || r.audio_capture_frames <= 0) {
+                r.error = "--audio-capture-frames requires a positive integer";
+                return r;
+            }
+            continue;
+        }
+
         if (r.target_name.empty() && !a.empty() && a[0] != '-') {
             r.target_name = a;
             continue;
@@ -254,6 +294,15 @@ ParseRunResult parse_run_options(const std::vector<std::string>& args) {
     if (audio_scope_acquisition_option_seen && r.audio_scope_json_path.empty()) {
         r.error = "--audio-scope-window, --audio-scope-trigger, and "
                   "--audio-scope-channel require --audio-scope-json";
+    }
+    // --audio-capture-wav is the third single-consumer of the one probe FIFO.
+    if (!r.audio_capture_wav_path.empty()
+        && (r.audio_inspector || !r.audio_scope_json_path.empty())) {
+        r.error = "--audio-capture-wav cannot be combined with --audio-inspector or "
+                  "--audio-scope-json; they share the one live capture FIFO";
+    }
+    if (audio_capture_frames_option_seen && r.audio_capture_wav_path.empty()) {
+        r.error = "--audio-capture-frames requires --audio-capture-wav";
     }
 
     return r;
@@ -288,6 +337,14 @@ std::vector<std::string> assemble_launch_args(const ParseRunResult& opts) {
         out.push_back(opts.audio_scope_trigger);
         out.push_back("--audio-scope-channel");
         out.push_back(std::to_string(opts.audio_scope_channel));
+    }
+    if (!opts.audio_capture_wav_path.empty()) {
+        out.push_back("--audio-capture-wav");
+        out.push_back(opts.audio_capture_wav_path);
+        if (opts.audio_capture_frames > 0) {
+            out.push_back("--audio-capture-frames");
+            out.push_back(std::to_string(opts.audio_capture_frames));
+        }
     }
     for (const auto& a : opts.user_pass_through) {
         out.push_back(a);


### PR DESCRIPTION
## What

Adds `pulp run --audio-capture-wav <file>` (plus `--audio-capture-frames <n>`): a one-shot that, after the frame delay, drains the standalone output-boundary probe's existing capture ring to a WAV the offline `pulp audio validate` verbs can analyze, then exits — closing the live → offline debugging loop. Implements slice A1 of the audio-harness Phase 7 plan (`planning/2026-06-26-audio-harness-phase7-slices-plan.md`).

It reuses the proven `--audio-scope-json` one-shot machinery; **no new realtime code** (the producer side, `AudioProbe::analyze_output`, is unchanged and stays allocation/lock-free). The flag implies `--headless`, shares the single capture FIFO with `--audio-inspector` and `--audio-scope-json` (the three are mutually exclusive at parse time), and a bare `--audio-capture-wav` run is excluded from the headless-default-PNG branch.

## Honest caveat (documented in `--help`, `cli.md`, the audio-harness skill)

The capture FIFO is drop-on-full and the WAV is int16, so this dumps the **earliest** window after the stream starts — robust for `validate summarize`/`assert` (presence/level/clip/NaN), but the wrong window for steady-state `doctor` (THD/response) and quantization-limited for `compare`. Those wait on the rolling-ring follow-up (A2).

## Tests

- Writer round-trip: `prepare → analyze_output → read_capture → write_wav → read` (int16-tolerance match, per-channel distinctness, empty-ring → no-op).
- Parser: flag/env/forward, `=`-forms, three-way FIFO contention, frames-needs-wav, positive-int validation.
- The capture-wav-only headless predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pulp run --audio-capture-wav <file>` (+ `--audio-capture-frames <n>`) to dump the live standalone output ring to a WAV for offline `pulp audio validate`, then exit. Reuses the existing one-shot path; no new realtime code.

- **New Features**
  - `--audio-capture-wav` captures after the frame delay as a headless one-shot (still opens the audio device); `--audio-capture-frames` sets the ring window.
  - Mutually exclusive with `--audio-inspector` and `--audio-scope-json`; the shared capture FIFO is sized to the largest need and capped at 16384 samples.
  - Captures the earliest window (int16) — good for `validate summarize`/`assert`; `doctor`/`compare` await a rolling-ring follow-up.
  - CLI/env wiring: forwards `PULP_AUDIO_CAPTURE_WAV` and `PULP_AUDIO_CAPTURE_WAV_FRAMES`; prevents auto-adding a default PNG when only probe/scope/capture is set. Docs and tests included.

- **Dependencies**
  - Bump `project(Pulp)` to 0.499.0.
  - Bump plugin versions to 0.253.0 in `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`.

<sup>Written for commit 98705cc203b5fc3608cd9f4072f8e75098aab421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

