### PR TITLE
docs(test): refresh stale review severity labels

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -162,7 +162,7 @@ ctest --test-dir build-rtsan
 
 Currently annotated: the audio-thread `process()` paths in each format
 adapter. If RTSan reports an allocation in there, it's a real RT-safety
-bug (see #307 Codex P1 → PR #315 for a representative case).
+bug (see #307 → PR #315 for a representative case).
 
 ## Relation to #290
 

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -295,7 +295,7 @@ TEST_CASE("EditHistory window=0 disables time-window coalescing",
     REQUIRE(history.undo_count() == 2);
 }
 
-TEST_CASE("EditHistory undo resets coalesce window timestamp (Codex P1 regression)",
+TEST_CASE("EditHistory undo resets coalesce window timestamp (regression)",
           "[state][undo][time-coalesce][regression]") {
     EditHistory history;
     history.set_coalesce(false); // ensure only window coalescing matters

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -502,7 +502,7 @@ TEST_CASE("Environment: callback that drops its own token does not deadlock",
 }
 
 TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
-          "(#403 codex P1)",
+          "(#403)",
           "[environment][issue-403]") {
     Environment::reset_for_test();
 

--- a/test/test_raw_midi_parser.cpp
+++ b/test/test_raw_midi_parser.cpp
@@ -522,7 +522,7 @@ TEST_CASE("raw_midi_parser tolerates omitted callbacks",
     REQUIRE(state.sysex_buffer.empty());
 }
 
-TEST_CASE("raw_midi_parser recovers from aborted sysex (#406 codex P2)",
+TEST_CASE("raw_midi_parser recovers from aborted sysex (#406)",
           "[midi][raw_midi_parser][issue-406]") {
     // Device sends F0 7E <partial> then sends a Note On (0x90) without
     // ever emitting F7. Before the fix, the Note On + its data bytes

--- a/test/test_runtime_result.cpp
+++ b/test/test_runtime_result.cpp
@@ -120,7 +120,7 @@ struct Throwing {
 }  // namespace
 
 TEST_CASE("Result assignment preserves destination on throw",
-          "[runtime][result][codex-p2]") {
+          "[runtime][result]") {
     Result<Throwing, std::string> dst(Ok(Throwing(11)));
     Result<Throwing, std::string> src(Ok(Throwing(99)));
 

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1647,7 +1647,7 @@ TEST_CASE("Tokens survive StateStore destruction without crashing",
     REQUIRE_FALSE(static_cast<bool>(orphan));
 }
 
-TEST_CASE("Queued Main callback is cancelled by token reset (Codex P1 PR#2270)",
+TEST_CASE("Queued Main callback is cancelled by token reset (PR#2270)",
           "[state][listener][token][thread]") {
     // Regression for PR #2270: a Main listener dispatched through the
     // EventLoop must NOT fire if the token is destroyed/reset between

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -43,7 +43,7 @@ TEST_CASE("UndoManager coalesce_window=0 disables window coalescing",
     REQUIRE(um.undo_count() == 2);
 }
 
-TEST_CASE("UndoManager coalesced perform clears redo stack (Codex P1 regression)",
+TEST_CASE("UndoManager coalesced perform clears redo stack (regression)",
           "[state][undo][time-coalesce][regression]") {
     UndoManager um;
     um.set_coalesce_window(std::chrono::milliseconds(200));
@@ -61,7 +61,7 @@ TEST_CASE("UndoManager coalesced perform clears redo stack (Codex P1 regression)
     REQUIRE_FALSE(um.can_redo());
 }
 
-TEST_CASE("UndoManager undo resets coalesce window timestamp (Codex P1 regression)",
+TEST_CASE("UndoManager undo resets coalesce window timestamp (regression)",
           "[state][undo][time-coalesce][regression]") {
     UndoManager um;
     um.set_coalesce_window(std::chrono::milliseconds(200));

--- a/test/test_url.cpp
+++ b/test/test_url.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Url rejects malformed input", "[runtime][url]") {
 // Regression for non-numeric URL ports: strtol() alone accepted "80abc" as a
 // valid port-80 URL. After the fix the entire port_text must be all decimal
 // digits.
-TEST_CASE("Url rejects port with trailing junk", "[runtime][url][codex-p2]") {
+TEST_CASE("Url rejects port with trailing junk", "[runtime][url]") {
     REQUIRE_FALSE(Url::parse("http://example.com:80abc/path").has_value());
     REQUIRE_FALSE(Url::parse("http://example.com:8080x/").has_value());
     // Same fix on the IPv6 branch.

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1093,7 +1093,7 @@ TEST_CASE("View per-corner radii setters flip has_corner_radii",
 // Previously: set_border_radius(10); set_corner_radius_tl(2);
 // rendered as {2, 0, 0, 0}, silently discarding the uniform 10.
 TEST_CASE("set_border_radius + per-corner override seeds remaining corners",
-          "[view][border][issue-1171][codex-p2]") {
+          "[view][border][issue-1171]") {
     View v;
     v.set_border_radius(10.0f);
     REQUIRE_FALSE(v.has_corner_radii());
@@ -1108,7 +1108,7 @@ TEST_CASE("set_border_radius + per-corner override seeds remaining corners",
 }
 
 TEST_CASE("set_border_radius + multiple per-corner overrides — promote runs once",
-          "[view][border][issue-1171][codex-p2]") {
+          "[view][border][issue-1171]") {
     View v;
     v.set_border_radius(8.0f);
     v.set_corner_radius_tr(4.0f);
@@ -1124,7 +1124,7 @@ TEST_CASE("set_border_radius + multiple per-corner overrides — promote runs on
 }
 
 TEST_CASE("simulate_click bubble does NOT walk past `this` receiver",
-          "[view][simulate_click][issue-1171][codex-p2]") {
+          "[view][simulate_click][issue-1171]") {
     // Build: outer (PARENT) > root (this) > child.
     // outer has on_click set. root + child have no on_click.
     // Calling root->simulate_click(...) MUST NOT bubble up to outer —
@@ -1543,12 +1543,12 @@ TEST_CASE("View::last_paint_*_ns updates on every paint cycle",
 // override should still report non-zero last_paint_self_ns because
 // background_color painting + layer setup runs inside paint_all().
 TEST_CASE("View::last_paint_self_ns covers framework drawing on no-override views "
-          "(codex P2 #2338 regression)",
+          "(#2338 regression)",
           "[view][paint-timing][phase3d][regression]") {
     // Use the BASE pulp::view::View (no paint() override) but set a
     // background color so the framework's background fill runs in
-    // paint_all() between save() and the (no-op) paint() call. The
-    // Timing only the paint() override reports ~0ns for this case; timing the
+    // paint_all() between save() and the (no-op) paint() call. Timing
+    // only the paint() override reports ~0ns for this case; timing the
     // whole paint_all body should report > 0ns even for a no-override styled
     // View.
     auto v = std::make_unique<pulp::view::View>();


### PR DESCRIPTION
## Summary

- removes stale Codex review-severity labels from test/dev comments and tags
- preserves issue anchors, PR anchors, regression tags, and semantic Catch2 tags
- keeps this as one batched comment-hygiene PR after #4918 cleared

## Validation

- `git diff --check origin/main`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_consistency_check.py`
- residual scan: `rg -n "codex-p2|codex P2|Codex P1|codex P1" docs/dev/testing.md test/test_environment.cpp test/test_view.cpp test/test_runtime_result.cpp test/test_url.cpp test/test_raw_midi_parser.cpp test/test_state.cpp test/test_undo_manager.cpp test/test_edit_history.cpp || true`
- `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push -u origin HEAD` pre-push gates clean
- `autoreview --mode branch --base origin/main --reviewers codex,claude`: clean, `overall: patch is correct (0.95)`

RepoPrompt/rp-cli was used during the earlier classification pass; it identified the stale severity labels as safe only after checking for external `[codex-p2]` filter use.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale Codex review-severity labels from test names, tags, and docs to reduce noise while keeping issue anchors and regression context intact. No test behavior or logic changes.

- **Refactors**
  - Stripped “Codex P1/P2” and `[codex-p2]` from Catch2 test names/tags across test files.
  - Preserved issue/PR anchors (e.g., “#403”, “PR #2270”) and semantic tags (e.g., `[regression]`, `[state]`, `[view]`).
  - Updated one docs reference in `docs/dev/testing.md` to remove “Codex P1” wording.

<sup>Written for commit c58da653b0f57f16b76cb389d851ae6ae585d66a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

