### PR TITLE
docs(test): refresh runtime selector tags

### DIFF
--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Binding normalized", "[binding]") {
 }
 
 TEST_CASE("Binding unknown parameter operations stay inert",
-          "[binding][coverage][issue-646]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store,999);
     int call_count = 0;
@@ -82,7 +82,7 @@ TEST_CASE("Binding unknown parameter operations stay inert",
 }
 
 TEST_CASE("Binding set_normalized clamps and quantizes through store",
-          "[binding][coverage][issue-646]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store,1); // range -60..24, step 0.1
 
@@ -124,7 +124,7 @@ TEST_CASE("Binding on_change fires", "[binding]") {
 }
 
 TEST_CASE("Binding on_change callbacks fire in registration order",
-          "[binding][coverage][issue-646]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store,1);
     std::vector<int> calls;
@@ -163,7 +163,7 @@ TEST_CASE("Binding on_change does not fire for same value", "[binding]") {
 }
 
 TEST_CASE("Binding skips empty change callbacks and reports clamped values",
-          "[binding][codecov]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 1);
 
@@ -183,7 +183,7 @@ TEST_CASE("Binding skips empty change callbacks and reports clamped values",
 }
 
 TEST_CASE("Binding to unknown parameter is inert but remains store-bound",
-          "[binding][codecov]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 999);
 
@@ -234,7 +234,7 @@ TEST_CASE("Binding poll reports non-zero default once", "[binding]") {
 }
 
 TEST_CASE("create_bindings preserves parameter order and metadata",
-          "[binding][codecov]") {
+          "[binding]") {
     auto store = make_store();
     auto bindings = create_bindings(*store);
 
@@ -359,7 +359,7 @@ TEST_CASE("create_bindings for all params", "[binding]") {
 }
 
 TEST_CASE("create_bindings returns empty for an empty store",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     StateStore store;
 
     auto bindings = create_bindings(store);
@@ -368,7 +368,7 @@ TEST_CASE("create_bindings returns empty for an empty store",
 }
 
 TEST_CASE("Binding edit history can be detached before gesture end",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 1);
     EditHistory history;
@@ -385,7 +385,7 @@ TEST_CASE("Binding edit history can be detached before gesture end",
 }
 
 TEST_CASE("Binding set suppresses notifications within epsilon",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 1);
     int call_count = 0;
@@ -398,7 +398,7 @@ TEST_CASE("Binding set suppresses notifications within epsilon",
 }
 
 TEST_CASE("Binding set after clamping compares against clamped store value",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 1);
     int call_count = 0;
@@ -412,7 +412,7 @@ TEST_CASE("Binding set after clamping compares against clamped store value",
 }
 
 TEST_CASE("Binding poll updates baseline after the first notification",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     auto store = make_store();
     Binding b(*store, 1);
     int call_count = 0;
@@ -429,7 +429,7 @@ TEST_CASE("Binding poll updates baseline after the first notification",
 }
 
 TEST_CASE("Binding move construction preserves store and callbacks",
-          "[binding][coverage][phase3-github]") {
+          "[binding]") {
     auto store = make_store();
     Binding original(*store, 1);
     std::vector<float> values;
@@ -446,7 +446,7 @@ TEST_CASE("Binding move construction preserves store and callbacks",
 }
 
 TEST_CASE("Binding move assignment replaces destination binding",
-          "[binding][coverage][phase3-github]") {
+          "[binding]") {
     auto store = make_store();
     Binding destination(*store, 2);
     Binding source(*store, 1);
@@ -462,7 +462,7 @@ TEST_CASE("Binding move assignment replaces destination binding",
 }
 
 TEST_CASE("Binding copies retain store identity and callback state",
-          "[binding][coverage][phase3-large]") {
+          "[binding]") {
     auto store = make_store();
     Binding original(*store, 1);
     std::vector<float> original_values;

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -134,7 +134,7 @@ TEST_CASE("EditHistory empty undo/redo returns false", "[state][undo]") {
 }
 
 TEST_CASE("EditHistory lowering max depth trims existing undo stack",
-          "[state][undo][codecov]") {
+          "[state][undo]") {
     EditHistory history(5);
     int v = 0;
 
@@ -161,7 +161,7 @@ TEST_CASE("EditHistory lowering max depth trims existing undo stack",
 }
 
 TEST_CASE("EditHistory zero max depth performs actions without retaining history",
-          "[state][undo][codecov]") {
+          "[state][undo]") {
     EditHistory history(0);
     int v = 0;
 
@@ -175,7 +175,7 @@ TEST_CASE("EditHistory zero max depth performs actions without retaining history
 }
 
 TEST_CASE("EditHistory clear also drops redo history",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     EditHistory history;
     int v = 0;
 
@@ -195,7 +195,7 @@ TEST_CASE("EditHistory clear also drops redo history",
 }
 
 TEST_CASE("EditHistory increasing max depth preserves existing undo stack",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     EditHistory history(2);
     int v = 0;
 
@@ -214,7 +214,7 @@ TEST_CASE("EditHistory increasing max depth preserves existing undo stack",
 }
 
 TEST_CASE("EditHistory re-enabling coalescing affects subsequent actions only",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     EditHistory history;
     int v = 0;
 
@@ -235,7 +235,7 @@ TEST_CASE("EditHistory re-enabling coalescing affects subsequent actions only",
 }
 
 TEST_CASE("LambdaEdit tolerates empty callbacks and preserves description",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     LambdaEdit action({}, {}, "empty");
 
     action.redo();
@@ -245,7 +245,7 @@ TEST_CASE("LambdaEdit tolerates empty callbacks and preserves description",
 }
 
 TEST_CASE("EditHistory coalesced replacement controls undo and redo values",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     EditHistory history;
     int v = 0;
 

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environme
 }
 
 TEST_CASE("Environment: empty listener subscription is inert",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
 
     auto token = Environment::instance().subscribe({});
@@ -55,7 +55,7 @@ TEST_CASE("Environment: empty listener subscription is inert",
 }
 
 TEST_CASE("EnvironmentChange: any reflects individual flags",
-          "[environment][issue-640]") {
+          "[environment]") {
     EnvironmentChange change;
     REQUIRE_FALSE(change.any());
 
@@ -88,7 +88,7 @@ TEST_CASE("EnvironmentChange: any reflects individual flags",
 }
 
 TEST_CASE("SafeAreaInsets zero detection checks all edges",
-          "[environment][coverage][issue-640]") {
+          "[environment]") {
     SafeAreaInsets insets;
     REQUIRE(insets.is_zero());
 
@@ -151,7 +151,7 @@ TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
 }
 
 TEST_CASE("Environment: reset clears listeners held by live tokens",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     int calls = 0;
     auto token = Environment::instance().subscribe(
@@ -170,7 +170,7 @@ TEST_CASE("Environment: reset clears listeners held by live tokens",
 }
 
 TEST_CASE("Environment: token reset is idempotent and preserves other listeners",
-          "[environment][coverage][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     int first_calls = 0;
     int second_calls = 0;
@@ -210,8 +210,8 @@ TEST_CASE("Environment: token move transfers ownership", "[environment]") {
     REQUIRE(calls == 1);
 }
 
-TEST_CASE("Environment: publish without listeners still updates snapshot",
-          "[environment][coverage][issue-649]") {
+TEST_CASE("Environment: publish updates snapshot without listeners",
+          "[environment]") {
     Environment::reset_for_test();
 
     auto state = make_state(ColorScheme::light, 1.25f, 48.0f);
@@ -228,7 +228,7 @@ TEST_CASE("Environment: publish without listeners still updates snapshot",
 }
 
 TEST_CASE("Environment: token reset and self-move assignment are idempotent",
-          "[environment][coverage][issue-649]") {
+          "[environment]") {
     Environment::reset_for_test();
     int calls = 0;
 
@@ -251,7 +251,7 @@ TEST_CASE("Environment: token reset and self-move assignment are idempotent",
 }
 
 TEST_CASE("Environment: token move assignment replaces prior subscription",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     int first_calls = 0;
     int second_calls = 0;
@@ -275,8 +275,8 @@ TEST_CASE("Environment: token move assignment replaces prior subscription",
     REQUIRE(second_calls == 1);
 }
 
-TEST_CASE("Environment: token self move assignment preserves subscription",
-          "[environment][issue-640]") {
+TEST_CASE("Environment: token self-move via reference preserves subscription",
+          "[environment]") {
     Environment::reset_for_test();
     int calls = 0;
     auto token = Environment::instance().subscribe(
@@ -306,7 +306,7 @@ TEST_CASE("Environment: keyboard inset change propagates separately",
 }
 
 TEST_CASE("Environment: keyboard animation duration diffs separately",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     EnvironmentChange last;
     EnvironmentState last_state;
@@ -366,7 +366,7 @@ TEST_CASE("Environment: safe-area diff detection across all four edges",
 }
 
 TEST_CASE("Environment: display metadata changes are display-only",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     EnvironmentChange last;
     EnvironmentState last_state;
@@ -400,7 +400,7 @@ TEST_CASE("Environment: display metadata changes are display-only",
 }
 
 TEST_CASE("Environment: orientation and lifecycle emit isolated diffs",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
     EnvironmentChange last;
     EnvironmentState last_state;
@@ -462,7 +462,7 @@ TEST_CASE("Environment: memory pressure transitions", "[environment]") {
 // core/platform/platform/mac/environment_mac.mm — see #466 follow-up
 // for the layered coverage decision.
 TEST_CASE("Environment: memory pressure recovery to normal fires diff",
-          "[environment][issue-404]") {
+          "[environment]") {
     Environment::reset_for_test();
     EnvironmentChange last_change{};
     EnvironmentState  last_state{};
@@ -503,7 +503,7 @@ TEST_CASE("Environment: callback that drops its own token does not deadlock",
 
 TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
           "(#403)",
-          "[environment][issue-403]") {
+          "[environment]") {
     Environment::reset_for_test();
 
     int a_calls = 0;
@@ -541,7 +541,7 @@ TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
 }
 
 TEST_CASE("Environment: listener removed before its dispatch turn is skipped",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
 
     int victim_calls = 0;
@@ -565,7 +565,7 @@ TEST_CASE("Environment: listener removed before its dispatch turn is skipped",
 }
 
 TEST_CASE("Environment: reset during dispatch clears later callbacks",
-          "[environment][issue-640]") {
+          "[environment]") {
     Environment::reset_for_test();
 
     int resetter_calls = 0;
@@ -613,8 +613,8 @@ TEST_CASE("Environment: snapshot is consistent with last publish",
     REQUIRE(got.safe_area.top   == 22.0f);
 }
 
-TEST_CASE("Environment: publish without listeners still updates snapshot",
-          "[environment][coverage]") {
+TEST_CASE("Environment: inject_for_test updates snapshot without listeners",
+          "[environment]") {
     Environment::reset_for_test();
     auto state = make_state(ColorScheme::dark, 1.25f, 48.0f);
     state.lifecycle = LifecycleState::background;
@@ -629,7 +629,7 @@ TEST_CASE("Environment: publish without listeners still updates snapshot",
 }
 
 TEST_CASE("Environment: multiple listeners receive the same change snapshot",
-          "[environment][coverage]") {
+          "[environment]") {
     Environment::reset_for_test();
     int first_calls = 0;
     int second_calls = 0;
@@ -665,7 +665,7 @@ TEST_CASE("Environment: multiple listeners receive the same change snapshot",
 }
 
 TEST_CASE("Environment: default token reset is inert",
-          "[environment][coverage]") {
+          "[environment]") {
     Environment::reset_for_test();
     Environment::Token token;
     REQUIRE_FALSE(token.valid());
@@ -677,8 +677,8 @@ TEST_CASE("Environment: default token reset is inert",
     REQUIRE(Environment::instance().snapshot().color_scheme == ColorScheme::dark);
 }
 
-TEST_CASE("Environment: token self move assignment preserves subscription",
-          "[environment][coverage]") {
+TEST_CASE("Environment: token self-move via pointer preserves subscription",
+          "[environment]") {
     Environment::reset_for_test();
     int calls = 0;
     auto token = Environment::instance().subscribe(
@@ -694,7 +694,7 @@ TEST_CASE("Environment: token self move assignment preserves subscription",
 }
 
 TEST_CASE("Environment: move assigning an empty token unsubscribes existing listener",
-          "[environment][coverage]") {
+          "[environment]") {
     Environment::reset_for_test();
     int calls = 0;
     auto token = Environment::instance().subscribe(
@@ -711,7 +711,7 @@ TEST_CASE("Environment: move assigning an empty token unsubscribes existing list
 }
 
 TEST_CASE("Environment: listener subscribed during dispatch waits for next publish",
-          "[environment][coverage]") {
+          "[environment]") {
     Environment::reset_for_test();
     int first_calls = 0;
     int late_calls = 0;
@@ -741,7 +741,7 @@ TEST_CASE("Environment: listener subscribed during dispatch waits for next publi
 }
 
 TEST_CASE("Environment: reset restores defaults after published state",
-          "[environment][coverage]") {
+          "[environment]") {
     Environment::reset_for_test();
     auto state = make_state(ColorScheme::dark, 3.0f, 240.0f);
     state.safe_area.bottom = 12.0f;

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -64,7 +64,7 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
 }
 
-TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][coverage]") {
+TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("mode", "old");
     strings.add("mode", "new");
@@ -72,7 +72,7 @@ TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][cove
     REQUIRE(strings.translate("mode") == "new");
 }
 
-TEST_CASE("i18n accepts empty in-memory keys", "[runtime][i18n][coverage]") {
+TEST_CASE("i18n accepts empty in-memory keys", "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("", "metadata");
     strings.add("normal", "value");
@@ -117,28 +117,28 @@ TEST_CASE("i18n argument substitution also applies to missing-key fallback",
 }
 
 TEST_CASE("i18n argument substitution handles adjacent placeholders",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     LocalisedStrings strings;
     strings.add("compact", "{0}{1}{0}");
     REQUIRE(strings.translate("compact", {"A", "B"}) == "ABA");
 }
 
 TEST_CASE("i18n argument substitution treats double braces as literal text",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     LocalisedStrings strings;
     strings.add("template", "{{0}} {0}");
     REQUIRE(strings.translate("template", {"value"}) == "{value} value");
 }
 
 TEST_CASE("i18n argument substitution applies later indexes after earlier replacements",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     LocalisedStrings strings;
     strings.add("nested", "{0} {1}");
     REQUIRE(strings.translate("nested", {"{1}", "done"}) == "done done");
 }
 
 TEST_CASE("i18n argument substitution handles multi-digit indexes literally",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("many", "{9}:{10}:{0}");
     std::vector<std::string> args = {
@@ -159,7 +159,7 @@ TEST_CASE("i18n clear removes all translations", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n clear leaves selected locale intact",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.set_locale("ja");
     strings.add("hello", "konnichiwa");
@@ -217,7 +217,7 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -234,7 +234,7 @@ TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
 }
 
 TEST_CASE("i18n .strings parser accepts keys and values with spaces",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -249,7 +249,7 @@ TEST_CASE("i18n .strings parser accepts keys and values with spaces",
 }
 
 TEST_CASE("i18n .strings parser keeps entries without semicolons",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -262,7 +262,7 @@ TEST_CASE("i18n .strings parser keeps entries without semicolons",
 }
 
 TEST_CASE("i18n .strings parser permits empty keys",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -277,7 +277,7 @@ TEST_CASE("i18n .strings parser permits empty keys",
 }
 
 TEST_CASE("i18n .strings load failure leaves existing translations intact",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("existing", "kept");
 
@@ -350,7 +350,7 @@ TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
 }
 
 TEST_CASE("i18n .po parser replaces duplicate msgids",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -367,7 +367,7 @@ TEST_CASE("i18n .po parser replaces duplicate msgids",
 }
 
 TEST_CASE("i18n .po parser ignores msgids without translations",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -383,7 +383,7 @@ TEST_CASE("i18n .po parser ignores msgids without translations",
 }
 
 TEST_CASE("i18n .po parser accepts empty msgid continuations",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -399,7 +399,7 @@ TEST_CASE("i18n .po parser accepts empty msgid continuations",
 }
 
 TEST_CASE("i18n .po load failure leaves translations intact",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("existing", "kept");
 
@@ -409,7 +409,7 @@ TEST_CASE("i18n .po load failure leaves translations intact",
 }
 
 TEST_CASE("i18n .po parser ignores orphan msgstr lines",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -469,7 +469,7 @@ TEST_CASE("i18n JSON parser handles escapes and keyless entries", "[runtime][i18
 }
 
 TEST_CASE("i18n JSON parser handles standard control escapes",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -487,7 +487,7 @@ TEST_CASE("i18n JSON parser handles standard control escapes",
     REQUIRE(strings.translate("formfeed") == "page\fbreak");
 }
 
-TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage]") {
+TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -527,7 +527,7 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n JSON load failure preserves existing translations",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -543,7 +543,7 @@ TEST_CASE("i18n JSON load failure preserves existing translations",
 }
 
 TEST_CASE("i18n JSON parser accepts empty objects",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -578,7 +578,7 @@ TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
 }
 
 TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -592,7 +592,7 @@ TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
 }
 
 TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -606,7 +606,7 @@ TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
 }
 
 TEST_CASE("i18n JSON parser tolerates missing closing brace after entries",
-          "[runtime][i18n][coverage][large]") {
+          "[runtime][i18n][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -619,7 +619,7 @@ TEST_CASE("i18n JSON parser tolerates missing closing brace after entries",
 }
 
 TEST_CASE("i18n JSON parser accepts whitespace separated key value pairs",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -673,7 +673,7 @@ TEST_CASE("i18n system_locale returns non-empty", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n system_locale normalizes LANG where supported",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     ScopedLang lang("fr_CA.UTF-8");
 
 #if defined(_WIN32)
@@ -684,7 +684,7 @@ TEST_CASE("i18n system_locale normalizes LANG where supported",
 }
 
 TEST_CASE("i18n system_locale falls back when LANG is absent",
-          "[runtime][i18n][coverage]") {
+          "[runtime][i18n]") {
     ScopedLang lang(nullptr);
     REQUIRE(LocalisedStrings::system_locale() == "en");
 }

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -94,7 +94,7 @@ TEST_CASE("PropertiesFile numeric getters reject invalid stored strings", "[stat
 }
 
 TEST_CASE("PropertiesFile numeric getters reject partially parsed strings",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("count_suffix", "12items");
     props.set_string("count_prefix", "id12");
@@ -112,7 +112,7 @@ TEST_CASE("PropertiesFile numeric getters reject partially parsed strings",
 }
 
 TEST_CASE("PropertiesFile numeric getters reject trailing text",
-          "[state][properties][coverage][phase3]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("count", "12abc");
     props.set_string("gain", "3.5ms");
@@ -131,7 +131,7 @@ TEST_CASE("PropertiesFile numeric getters reject trailing text",
 }
 
 TEST_CASE("PropertiesFile numeric getters reject out-of-range strings",
-          "[state][properties][coverage][phase3]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("count", "999999999999999999999999999999999999");
     props.set_string("gain", "1e9999");
@@ -141,7 +141,7 @@ TEST_CASE("PropertiesFile numeric getters reject out-of-range strings",
 }
 
 TEST_CASE("PropertiesFile numeric getters reject partial parses",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("count_suffix", "512junk");
     props.set_string("count_decimal", "512.5");
@@ -160,7 +160,7 @@ TEST_CASE("PropertiesFile numeric getters reject partial parses",
 }
 
 TEST_CASE("PropertiesFile bool getter treats stored false-like values as false",
-          "[state][properties][issue-641]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("word_false", "false");
     props.set_string("zero", "0");
@@ -204,7 +204,7 @@ TEST_CASE("PropertiesFile set and get bool", "[state][properties]") {
 }
 
 TEST_CASE("PropertiesFile typed setters store retrievable string values",
-          "[state][properties][coverage][phase3]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_int("voices", 16);
     props.set_double("gain", -3.25);
@@ -216,7 +216,7 @@ TEST_CASE("PropertiesFile typed setters store retrievable string values",
 }
 
 TEST_CASE("PropertiesFile bool getter accepts true and numeric-one strings",
-          "[state][properties][codecov]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("true_text", "true");
     props.set_string("one_text", "1");
@@ -230,7 +230,7 @@ TEST_CASE("PropertiesFile bool getter accepts true and numeric-one strings",
 }
 
 TEST_CASE("PropertiesFile bool getter requires exact true tokens",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("upper_true", "TRUE");
     props.set_string("title_true", "True");
@@ -336,7 +336,7 @@ TEST_CASE("PropertiesFile load invalid JSON returns false", "[state][properties]
 }
 
 TEST_CASE("PropertiesFile load non-object JSON leaves existing values intact",
-          "[state][properties][issue-641]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -351,7 +351,7 @@ TEST_CASE("PropertiesFile load non-object JSON leaves existing values intact",
 }
 
 TEST_CASE("PropertiesFile load rejects non-object JSON without clearing values",
-          "[state][properties][codecov]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -367,7 +367,7 @@ TEST_CASE("PropertiesFile load rejects non-object JSON without clearing values",
 }
 
 TEST_CASE("PropertiesFile load coerces scalar JSON members and skips nested values",
-          "[state][properties][codecov]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -409,7 +409,7 @@ TEST_CASE("PropertiesFile load empty file clears existing values", "[state][prop
 }
 
 TEST_CASE("PropertiesFile load skips unsupported JSON member types",
-          "[state][properties][json][issue-641]") {
+          "[state][properties][json]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -504,7 +504,7 @@ TEST_CASE("PropertiesFile save without path returns false", "[state][properties]
 }
 
 TEST_CASE("PropertiesFile save fails when destination is a directory",
-          "[state][properties][issue-641]") {
+          "[state][properties]") {
     auto dir = std::filesystem::temp_directory_path() /
                ("pulp_props_dir_dest_" + std::to_string(std::random_device{}()));
     std::filesystem::create_directories(dir);
@@ -549,7 +549,7 @@ TEST_CASE("PropertiesFile save and reload preserves path", "[state][properties]"
 }
 
 TEST_CASE("PropertiesFile remove missing key and clear empty file are no-ops",
-          "[state][properties][issue-641]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.remove("missing");
     REQUIRE(props.size() == 0);
@@ -564,7 +564,7 @@ TEST_CASE("PropertiesFile remove missing key and clear empty file are no-ops",
 }
 
 TEST_CASE("PropertiesFile save and reload preserves escaped string values",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
 
     PropertiesFile props;
@@ -579,7 +579,7 @@ TEST_CASE("PropertiesFile save and reload preserves escaped string values",
 }
 
 TEST_CASE("PropertiesFile save and reload preserves tab and carriage escapes",
-          "[state][properties][coverage][phase3-github]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
 
     PropertiesFile props;
@@ -592,7 +592,7 @@ TEST_CASE("PropertiesFile save and reload preserves tab and carriage escapes",
 }
 
 TEST_CASE("PropertiesFile round-trips mixed JSON string escapes",
-          "[state][properties][coverage]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     const std::string value = "path\\\\plugin\t\"quoted\"\nnext line";
 
@@ -606,7 +606,7 @@ TEST_CASE("PropertiesFile round-trips mixed JSON string escapes",
 }
 
 TEST_CASE("PropertiesFile set_path can clear the implicit save destination",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     PropertiesFile props;
     props.set_string("key", "value");
@@ -619,7 +619,7 @@ TEST_CASE("PropertiesFile set_path can clear the implicit save destination",
 }
 
 TEST_CASE("PropertiesFile successful load replaces stale values",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -638,7 +638,7 @@ TEST_CASE("PropertiesFile successful load replaces stale values",
 }
 
 TEST_CASE("PropertiesFile load coerces false and numeric JSON scalars",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -656,7 +656,7 @@ TEST_CASE("PropertiesFile load coerces false and numeric JSON scalars",
 }
 
 TEST_CASE("PropertiesFile can save to a path without a parent directory",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     const std::filesystem::path path("properties_file_parentless_unit.json");
     std::filesystem::remove(path);
 
@@ -674,7 +674,7 @@ TEST_CASE("PropertiesFile can save to a path without a parent directory",
 }
 
 TEST_CASE("PropertiesFile setters copy string-view keys and values",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     std::string key = "dynamic_key";
     std::string value = "dynamic_value";
 
@@ -689,7 +689,7 @@ TEST_CASE("PropertiesFile setters copy string-view keys and values",
 }
 
 TEST_CASE("PropertiesFile remove and reinsert keeps sorted key enumeration",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("b", "2");
     props.set_string("a", "1");
@@ -702,7 +702,7 @@ TEST_CASE("PropertiesFile remove and reinsert keeps sorted key enumeration",
 }
 
 TEST_CASE("PropertiesFile empty string values remain present",
-          "[state][properties][coverage][phase3-github]") {
+          "[state][properties]") {
     PropertiesFile props;
     props.set_string("empty", "");
 
@@ -716,7 +716,7 @@ TEST_CASE("PropertiesFile empty string values remain present",
 }
 
 TEST_CASE("PropertiesFile contains tracks string-view keys across mutation",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     PropertiesFile props;
     std::string key = "dynamic";
 
@@ -734,7 +734,7 @@ TEST_CASE("PropertiesFile contains tracks string-view keys across mutation",
 // ── ApplicationProperties ───────────────────────────────────────────────
 
 TEST_CASE("ApplicationProperties exposes independent user and common stores",
-          "[state][properties][coverage][phase3]") {
+          "[state][properties]") {
     ApplicationProperties app("PulpUnit");
     REQUIRE(app.app_name() == "PulpUnit");
 
@@ -764,7 +764,7 @@ TEST_CASE("ApplicationProperties paths are platform-appropriate", "[state][prope
 }
 
 TEST_CASE("ApplicationProperties load reads user settings from the platform path",
-          "[state][properties][coverage][phase3-large]") {
+          "[state][properties]") {
     TemporaryFile home_marker(".home");
     const auto home_dir = std::filesystem::path(home_marker.path_string() + "_dir");
     std::filesystem::create_directories(home_dir);

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -75,7 +75,7 @@ private:
 } // namespace
 
 TEST_CASE("RuntimeBudgetPolicy keeps critical audio running",
-          "[runtime][budget-policy][phase4]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetRequest request;
     request.lane = RuntimeWorkLane::CriticalAudio;
     request.estimated_cost = 100;
@@ -91,7 +91,7 @@ TEST_CASE("RuntimeBudgetPolicy keeps critical audio running",
 }
 
 TEST_CASE("RuntimeBudgetPolicy preserves reserve for interactive work",
-          "[runtime][budget-policy][phase4]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetPolicy policy;
     policy.critical_audio_reserve = 128;
 
@@ -112,7 +112,7 @@ TEST_CASE("RuntimeBudgetPolicy preserves reserve for interactive work",
 }
 
 TEST_CASE("RuntimeBudgetPolicy sheds opportunistic work under pressure",
-          "[runtime][budget-policy][phase4]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetRequest request;
     request.lane = RuntimeWorkLane::Opportunistic;
     request.estimated_cost = 8;
@@ -128,7 +128,7 @@ TEST_CASE("RuntimeBudgetPolicy sheds opportunistic work under pressure",
 }
 
 TEST_CASE("RuntimeBudgetPolicy makes background degradation explicit",
-          "[runtime][budget-policy][phase4]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetRequest request;
     request.lane = RuntimeWorkLane::Background;
     request.estimated_cost = 200;
@@ -156,7 +156,7 @@ TEST_CASE("RuntimeBudgetPolicy makes background degradation explicit",
 }
 
 TEST_CASE("RuntimeBudgetFrame consumes budget and records degradation",
-          "[runtime][budget-policy][phase4][consumer]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetPolicy policy;
     policy.critical_audio_reserve = 32;
 
@@ -186,7 +186,7 @@ TEST_CASE("RuntimeBudgetFrame consumes budget and records degradation",
 }
 
 TEST_CASE("RuntimeBudgetFrame supports overload and refill hooks",
-          "[runtime][budget-policy][phase4][consumer]") {
+          "[runtime][budget-policy]") {
     RuntimeBudgetPolicy policy;
     policy.shed_background_on_overload = true;
 
@@ -214,7 +214,7 @@ TEST_CASE("RuntimeBudgetFrame supports overload and refill hooks",
 }
 
 TEST_CASE("RuntimeBudgetFrame hot path is allocation-free",
-          "[runtime][budget-policy][phase4][consumer][rt]") {
+          "[runtime][budget-policy][rt]") {
     RuntimeBudgetPolicy policy;
     policy.critical_audio_reserve = 16;
     RuntimeBudgetFrame frame(512, policy);
@@ -271,7 +271,7 @@ TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
 }
 
 TEST_CASE("BackgroundJobService runs higher priority queued work first",
-          "[runtime][background-job][phase2]") {
+          "[runtime][background-job]") {
     BackgroundJobService service;
     std::mutex mutex;
     std::condition_variable cv;
@@ -327,7 +327,7 @@ TEST_CASE("BackgroundJobService runs higher priority queued work first",
 }
 
 TEST_CASE("BackgroundJobService publishes progress and observes cancellation",
-          "[runtime][background-job][cancel][phase2]") {
+          "[runtime][background-job][cancel]") {
     BackgroundJobService service;
     std::atomic<bool> job_started{false};
     std::atomic<bool> saw_cancel{false};
@@ -363,7 +363,7 @@ TEST_CASE("BackgroundJobService publishes progress and observes cancellation",
 }
 
 TEST_CASE("BackgroundJobService cancels and drains queued work on teardown",
-          "[runtime][background-job][cancel][lifetime][phase2]") {
+          "[runtime][background-job][cancel][lifetime]") {
     BackgroundJobService service;
     std::mutex mutex;
     std::condition_variable cv;
@@ -419,7 +419,7 @@ TEST_CASE("BackgroundJobService cancels and drains queued work on teardown",
 }
 
 TEST_CASE("RealtimeResourceSlot publishes prepared resources with deferred reclaim",
-          "[runtime][background-job][rt-handoff][phase2]") {
+          "[runtime][background-job][rt-handoff]") {
     struct PreparedResource {
         int value = 0;
     };
@@ -440,7 +440,7 @@ TEST_CASE("RealtimeResourceSlot publishes prepared resources with deferred recla
 }
 
 TEST_CASE("RealtimeResourceSlot reports retire queue pressure",
-          "[runtime][background-job][rt-handoff][telemetry][phase2]") {
+          "[runtime][background-job][rt-handoff][telemetry]") {
     struct PreparedResource {
         int value = 0;
     };
@@ -466,7 +466,7 @@ TEST_CASE("RealtimeResourceSlot reports retire queue pressure",
 }
 
 TEST_CASE("RealtimeResourceSlot audio read path allocates zero times",
-          "[runtime][background-job][rt-handoff][rt-safety][phase2]") {
+          "[runtime][background-job][rt-handoff][rt-safety]") {
     struct PreparedResource {
         int value = 0;
     };
@@ -486,7 +486,7 @@ TEST_CASE("RealtimeResourceSlot audio read path allocates zero times",
 }
 
 TEST_CASE("Background resource job publishes immutable audio resource",
-          "[runtime][background-job][resource-recipe][phase2]") {
+          "[runtime][background-job][resource-recipe]") {
     struct PreparedResource {
         std::array<float, 4> values{};
         std::string source_id;
@@ -535,7 +535,7 @@ TEST_CASE("Background resource job publishes immutable audio resource",
 }
 
 TEST_CASE("Cancelled background resource job does not publish stale resource",
-          "[runtime][background-job][resource-recipe][cancel][phase2]") {
+          "[runtime][background-job][resource-recipe][cancel]") {
     struct PreparedResource {
         int revision = 0;
     };
@@ -577,7 +577,7 @@ TEST_CASE("Cancelled background resource job does not publish stale resource",
 }
 
 TEST_CASE("SpscQueue reuses slots after wrap-around",
-          "[runtime][spsc][coverage][issue-641]") {
+          "[runtime][spsc]") {
     SpscQueue<int, 4> q;
     REQUIRE(q.capacity() == 4);
 
@@ -632,7 +632,7 @@ TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
     REQUIRE(sum.load() == expected);
 }
 
-TEST_CASE("SpscQueue accepts rvalue pushes", "[runtime][spsc][coverage]") {
+TEST_CASE("SpscQueue accepts rvalue pushes", "[runtime][spsc]") {
     SpscQueue<std::string, 2> q;
 
     REQUIRE(q.try_push(std::string("alpha")));
@@ -645,7 +645,7 @@ TEST_CASE("SpscQueue accepts rvalue pushes", "[runtime][spsc][coverage]") {
 }
 
 TEST_CASE("SpscQueue preserves moved string payload order",
-          "[runtime][spsc][coverage]") {
+          "[runtime][spsc]") {
     SpscQueue<std::string, 3> q;
 
     std::string alpha = "alpha";
@@ -663,7 +663,7 @@ TEST_CASE("SpscQueue preserves moved string payload order",
 }
 
 TEST_CASE("SpscQueue exposes producer overflow telemetry",
-          "[runtime][spsc][telemetry][phase2]") {
+          "[runtime][spsc][telemetry]") {
     SpscQueue<int, 2> q;
     REQUIRE(q.overflow_count() == 0);
 
@@ -691,7 +691,7 @@ TEST_CASE("SpscQueue exposes producer overflow telemetry",
 }
 
 TEST_CASE("SpscQueue telemetry hot path allocates zero times",
-          "[runtime][spsc][telemetry][rt-safety][phase2]") {
+          "[runtime][spsc][telemetry][rt-safety]") {
     SpscQueue<int, 2> q;
 
     pulp::test::RtAllocationProbe probe;
@@ -736,7 +736,7 @@ TEST_CASE("ScopeGuard move transfers cleanup ownership", "[runtime][scope_guard]
 }
 
 TEST_CASE("ScopeGuard dismiss after move suppresses transferred cleanup",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -747,7 +747,7 @@ TEST_CASE("ScopeGuard dismiss after move suppresses transferred cleanup",
 }
 
 TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
-          "[runtime][scope_guard][coverage][issue-641]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         PULP_ON_SCOPE_EXIT(++calls);
@@ -757,7 +757,7 @@ TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
 }
 
 TEST_CASE("ScopeGuard move preserves dismissed state",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -770,7 +770,7 @@ TEST_CASE("ScopeGuard move preserves dismissed state",
 }
 
 TEST_CASE("Range reports containment intersections and empty spans",
-          "[runtime][range][codecov]") {
+          "[runtime][range]") {
     const IntRange range{10, 20};
 
     REQUIRE(range.length() == 10);
@@ -792,7 +792,7 @@ TEST_CASE("Range reports containment intersections and empty spans",
 }
 
 TEST_CASE("Range union constrain and expansion handle edge inputs",
-          "[runtime][range][codecov]") {
+          "[runtime][range]") {
     REQUIRE(IntRange{5, 5}.enclosing_union(IntRange{2, 4}) == IntRange{2, 4});
     REQUIRE(IntRange{2, 4}.enclosing_union(IntRange{8, 10}) == IntRange{2, 10});
 
@@ -828,7 +828,7 @@ TEST_CASE("Runtime environment helpers", "[runtime][system]") {
 }
 
 TEST_CASE("Runtime environment helpers treat unset and empty as missing",
-          "[runtime][system][codecov]") {
+          "[runtime][system]") {
     ScopedEnvVar env("PULP_RUNTIME_TEST_EMPTY_ENV");
 
     env.unset();
@@ -839,7 +839,7 @@ TEST_CASE("Runtime environment helpers treat unset and empty as missing",
 }
 
 TEST_CASE("Runtime environment helpers preserve non-empty values verbatim",
-          "[runtime][system][codecov]") {
+          "[runtime][system]") {
     ScopedEnvVar env("PULP_RUNTIME_TEST_VERBATIM_ENV");
 
     env.set(" value with spaces = yes ");
@@ -862,7 +862,7 @@ TEST_CASE("Runtime GMT helper returns UTC tm", "[runtime][system]") {
 }
 
 TEST_CASE("Runtime GMT helper handles leap-day timestamps",
-          "[runtime][system][codecov]") {
+          "[runtime][system]") {
     auto tm = gmtime_utc(static_cast<std::time_t>(951827696)); // 2000-02-29 12:34:56 UTC
     REQUIRE(tm.tm_year == 100);
     REQUIRE(tm.tm_mon == 1);
@@ -872,7 +872,7 @@ TEST_CASE("Runtime GMT helper handles leap-day timestamps",
     REQUIRE(tm.tm_sec == 56);
 }
 
-TEST_CASE("Runtime localtime helper returns a normalized tm", "[runtime][system][coverage]") {
+TEST_CASE("Runtime localtime helper returns a normalized tm", "[runtime][system]") {
     auto tm = localtime_local(static_cast<std::time_t>(0));
     REQUIRE(tm.tm_mon >= 0);
     REQUIRE(tm.tm_mon <= 11);
@@ -893,7 +893,7 @@ TEST_CASE("Runtime C string copy truncates safely", "[runtime][system]") {
 }
 
 TEST_CASE("Runtime C string copy handles exact fits and leaves tail bytes alone",
-          "[runtime][system][codecov]") {
+          "[runtime][system]") {
     char exact[4]{};
     copy_c_string(exact, "abc");
     REQUIRE(exact[0] == 'a');
@@ -912,7 +912,7 @@ TEST_CASE("Runtime C string copy handles exact fits and leaves tail bytes alone"
 }
 
 TEST_CASE("Runtime C string copy writes terminator for empty sources",
-          "[runtime][system][coverage]") {
+          "[runtime][system]") {
     std::array<char, 4> buffer{'x', 'y', 'z', 'w'};
 
     copy_c_string(buffer.data(), buffer.size(), "");
@@ -924,7 +924,7 @@ TEST_CASE("Runtime C string copy writes terminator for empty sources",
 }
 
 TEST_CASE("Runtime C string copy respects string_view length with embedded nulls",
-          "[runtime][system][codecov]") {
+          "[runtime][system]") {
     std::array<char, 5> buffer{'?', '?', '?', '?', '?'};
     constexpr char source[] = {'a', '\0', 'b'};
 
@@ -950,7 +950,7 @@ TEST_CASE("Runtime C string copy handles degenerate buffers", "[runtime][system]
 }
 
 TEST_CASE("Runtime system info convenience helpers mirror cached info",
-          "[runtime][system][coverage]") {
+          "[runtime][system]") {
     const auto& info = get_system_info();
     REQUIRE_FALSE(info.os_name.empty());
     REQUIRE_FALSE(info.arch.empty());
@@ -1014,7 +1014,7 @@ TEST_CASE("TemporaryFile move assignment cleans previous file", "[runtime][tempo
 }
 
 TEST_CASE("TemporaryFile self move assignment leaves file ownership intact",
-          "[runtime][temporary_file][coverage]") {
+          "[runtime][temporary_file]") {
     std::filesystem::path path;
     {
         TemporaryFile file(".self");
@@ -1066,7 +1066,7 @@ TEST_CASE("DynamicLibrary move keeps failed handles closed", "[runtime][dynamic_
     REQUIRE_FALSE(second.error().empty());
 }
 
-TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_library][coverage]") {
+TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_library]") {
     DynamicLibrary original;
 #ifdef __APPLE__
     REQUIRE(original.open("/usr/lib/libSystem.B.dylib"));
@@ -1093,7 +1093,7 @@ TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_lib
 }
 
 TEST_CASE("DynamicLibrary failed reopen closes the previous handle",
-          "[runtime][dynamic_library][coverage]") {
+          "[runtime][dynamic_library]") {
     DynamicLibrary library;
 #ifdef __APPLE__
     REQUIRE(library.open("/usr/lib/libSystem.B.dylib"));
@@ -1133,7 +1133,7 @@ TEST_CASE("DynamicLibrary failed reopen closes the previous handle",
 }
 
 TEST_CASE("HighResolutionTimer starts stops and reports running state",
-          "[runtime][timer][coverage]") {
+          "[runtime][timer]") {
     HighResolutionTimer timer;
     std::atomic<int> calls{0};
 
@@ -1160,7 +1160,7 @@ TEST_CASE("HighResolutionTimer starts stops and reports running state",
 }
 
 TEST_CASE("HighResolutionTimer restart replaces callback",
-          "[runtime][timer][coverage]") {
+          "[runtime][timer]") {
     HighResolutionTimer timer;
     std::atomic<int> first{0};
     std::atomic<int> second{0};
@@ -1187,7 +1187,7 @@ TEST_CASE("HighResolutionTimer restart replaces callback",
 }
 
 TEST_CASE("HighResolutionTimer can stop from its own callback",
-          "[runtime][timer][coverage]") {
+          "[runtime][timer]") {
     HighResolutionTimer timer;
     std::atomic<int> calls{0};
 
@@ -1208,7 +1208,7 @@ TEST_CASE("HighResolutionTimer can stop from its own callback",
 }
 
 TEST_CASE("runtime logging wrappers accept formatted payloads",
-          "[runtime][log][coverage]") {
+          "[runtime][log]") {
     REQUIRE_NOTHROW(log_info("info {} {}", "message", 1));
     REQUIRE_NOTHROW(log_warn("warn {}", 2));
     REQUIRE_NOTHROW(log_error("error {}", 3));

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -152,7 +152,7 @@ bool wait_for_predicate(Predicate&& predicate, std::chrono::milliseconds timeout
 // ── HighResolutionTimer ─────────────────────────────────────────────────
 
 TEST_CASE("HighResolutionTimer self-stop remains joinable for destruction",
-          "[runtime][timer][coverage]") {
+          "[runtime][timer]") {
     std::atomic<bool> stop_returned{false};
 
     {
@@ -173,7 +173,7 @@ TEST_CASE("HighResolutionTimer self-stop remains joinable for destruction",
 }
 
 TEST_CASE("HighResolutionTimer self-stop supports callback-owned destruction",
-          "[runtime][timer][coverage]") {
+          "[runtime][timer]") {
     std::atomic<bool> destroyed{false};
     auto timer = std::make_unique<HighResolutionTimer>();
 
@@ -192,7 +192,7 @@ TEST_CASE("HighResolutionTimer self-stop supports callback-owned destruction",
 // ── Identity ────────────────────────────────────────────────────────────
 
 TEST_CASE("Uuid parses canonical and compact forms",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     const auto canonical = std::string("12345678-90ab-4def-8123-456789abcdef");
     const auto compact = std::string("1234567890ab4def8123456789abcdef");
 
@@ -206,7 +206,7 @@ TEST_CASE("Uuid parses canonical and compact forms",
 }
 
 TEST_CASE("Uuid parser rejects malformed hex and dash placement",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     REQUIRE(Uuid::from_string("").is_nil());
     REQUIRE(Uuid::from_string("1234567890ab4def8123456789abcdez").is_nil());
     REQUIRE(Uuid::from_string("12345678-90ab-4def-8123-456789abcdez").is_nil());
@@ -217,7 +217,7 @@ TEST_CASE("Uuid parser rejects malformed hex and dash placement",
 // ── ScopeGuard ─────────────────────────────────────────────────────────
 
 TEST_CASE("ScopeGuard runs once on scope exit and can be dismissed",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -233,7 +233,7 @@ TEST_CASE("ScopeGuard runs once on scope exit and can be dismissed",
 }
 
 TEST_CASE("ScopeGuard move transfers ownership and disables source",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto first = make_scope_guard([&] { ++calls; });
@@ -247,7 +247,7 @@ TEST_CASE("ScopeGuard move transfers ownership and disables source",
 }
 
 TEST_CASE("ScopeGuard move transfers the active cleanup",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -258,7 +258,7 @@ TEST_CASE("ScopeGuard move transfers the active cleanup",
 }
 
 TEST_CASE("PULP_ON_SCOPE_EXIT macro creates independent guards",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         PULP_ON_SCOPE_EXIT(++calls;);
@@ -269,7 +269,7 @@ TEST_CASE("PULP_ON_SCOPE_EXIT macro creates independent guards",
 }
 
 TEST_CASE("PULP_ON_SCOPE_EXIT macro captures local state",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int value = 0;
     {
         PULP_ON_SCOPE_EXIT(value += 7;);
@@ -281,7 +281,7 @@ TEST_CASE("PULP_ON_SCOPE_EXIT macro captures local state",
 // ── ScopedNoAlloc ───────────────────────────────────────────────────────
 
 TEST_CASE("ScopedNoAlloc tracks nested scope depth on the current thread",
-          "[runtime][scoped_no_alloc][coverage]") {
+          "[runtime][scoped_no_alloc]") {
     REQUIRE(no_alloc_scope_depth() == 0);
     REQUIRE_FALSE(is_in_no_alloc_scope());
 
@@ -320,7 +320,7 @@ TEST_CASE("ScopedNoAlloc tracks nested scope depth on the current thread",
 }
 
 TEST_CASE("ScopedNoAlloc state is thread-local",
-          "[runtime][scoped_no_alloc][coverage]") {
+          "[runtime][scoped_no_alloc]") {
     ScopedNoAlloc main_scope;
 
     int worker_initial_depth = -1;
@@ -393,7 +393,7 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
 }
 
 TEST_CASE("TemporaryFile normalizes extensions without leading dots",
-          "[runtime][temp_file][issue-641]") {
+          "[runtime][temp_file]") {
     TemporaryFile tmp("raw");
     REQUIRE(tmp.path().extension() == ".raw");
     REQUIRE(tmp.path_string() == tmp.path().string());
@@ -401,7 +401,7 @@ TEST_CASE("TemporaryFile normalizes extensions without leading dots",
 }
 
 TEST_CASE("TemporaryFile supports extensionless paths",
-          "[runtime][temp_file][coverage]") {
+          "[runtime][temp_file]") {
     std::filesystem::path path;
     {
         TemporaryFile tmp;
@@ -415,7 +415,7 @@ TEST_CASE("TemporaryFile supports extensionless paths",
 }
 
 TEST_CASE("TemporaryFile treats separator characters as extension text",
-          "[runtime][temp_file][coverage]") {
+          "[runtime][temp_file]") {
     TemporaryFile tmp("nested/name\\raw");
 
     REQUIRE(tmp.path().filename().string().find('/') == std::string::npos);
@@ -425,7 +425,7 @@ TEST_CASE("TemporaryFile treats separator characters as extension text",
 }
 
 TEST_CASE("TemporaryFile move assignment removes the previous active file",
-          "[runtime][temp_file][issue-641]") {
+          "[runtime][temp_file]") {
     std::filesystem::path old_path;
     std::filesystem::path new_path;
     {
@@ -444,7 +444,7 @@ TEST_CASE("TemporaryFile move assignment removes the previous active file",
 }
 
 TEST_CASE("TemporaryFile self move assignment preserves ownership",
-          "[runtime][temp_file][issue-641]") {
+          "[runtime][temp_file]") {
     std::filesystem::path path;
     {
         TemporaryFile tmp(".self");
@@ -459,7 +459,7 @@ TEST_CASE("TemporaryFile self move assignment preserves ownership",
 }
 
 TEST_CASE("ScopeGuard dismiss and move control destructor execution",
-          "[runtime][scope_guard][coverage]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -517,7 +517,7 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
 }
 
 TEST_CASE("MemoryMappedFile reopen closes the previous mapping",
-          "[runtime][mmap][issue-641]") {
+          "[runtime][mmap]") {
     TemporaryFile first(".bin");
     TemporaryFile second(".bin");
     {
@@ -539,7 +539,7 @@ TEST_CASE("MemoryMappedFile reopen closes the previous mapping",
 }
 
 TEST_CASE("MemoryMappedFile ReadWrite mode persists byte edits",
-          "[runtime][mmap][coverage][issue-641]") {
+          "[runtime][mmap]") {
     TemporaryFile tmp(".bin");
     {
         std::ofstream f(tmp.path(), std::ios::binary);
@@ -564,7 +564,7 @@ TEST_CASE("MemoryMappedFile ReadWrite mode persists byte edits",
 }
 
 TEST_CASE("MemoryMappedFile open failure clears an existing mapping",
-          "[runtime][mmap][coverage][issue-641]") {
+          "[runtime][mmap]") {
     TemporaryFile mapped(".bin");
     {
         std::ofstream f(mapped.path(), std::ios::binary);
@@ -585,7 +585,7 @@ TEST_CASE("MemoryMappedFile open failure clears an existing mapping",
 }
 
 TEST_CASE("MemoryMappedFile read-write maps persist and move assignment closes old map",
-          "[runtime][mmap][coverage][issue-656]") {
+          "[runtime][mmap]") {
     TemporaryFile first(".bin");
     TemporaryFile second(".bin");
     {
@@ -620,7 +620,7 @@ TEST_CASE("MemoryMappedFile read-write maps persist and move assignment closes o
 }
 
 TEST_CASE("MemoryMappedFile self move assignment preserves the active map",
-          "[runtime][mmap][coverage]") {
+          "[runtime][mmap]") {
     TemporaryFile tmp(".bin");
     {
         std::ofstream f(tmp.path(), std::ios::binary);
@@ -642,7 +642,7 @@ TEST_CASE("MemoryMappedFile self move assignment preserves the active map",
 }
 
 TEST_CASE("MemoryMappedFile rejects empty files and close is idempotent",
-          "[runtime][mmap][coverage][issue-656]") {
+          "[runtime][mmap]") {
     TemporaryFile tmp(".bin");
 
     MemoryMappedFile mmap;
@@ -656,7 +656,7 @@ TEST_CASE("MemoryMappedFile rejects empty files and close is idempotent",
 }
 
 TEST_CASE("MemoryMappedFile self move assignment preserves mapping",
-          "[runtime][mmap][coverage]") {
+          "[runtime][mmap]") {
     TemporaryFile tmp(".bin");
     {
         std::ofstream f(tmp.path(), std::ios::binary);
@@ -675,7 +675,7 @@ TEST_CASE("MemoryMappedFile self move assignment preserves mapping",
 
 #ifndef _WIN32
 TEST_CASE("MemoryMappedFile rejects directory paths after opening",
-          "[runtime][mmap][coverage]") {
+          "[runtime][mmap]") {
     TemporaryFile marker(".dir");
     const auto dir = marker.path();
     marker.release();
@@ -721,7 +721,7 @@ TEST_CASE("DynamicLibrary fails on nonexistent", "[runtime][dynlib]") {
 }
 
 TEST_CASE("DynamicLibrary closed lookup is null and close is idempotent",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE_FALSE(lib.is_open());
     REQUIRE(lib.find_symbol(system_library_symbol()) == nullptr);
@@ -730,7 +730,7 @@ TEST_CASE("DynamicLibrary closed lookup is null and close is idempotent",
 }
 
 TEST_CASE("DynamicLibrary missing symbol lookup records an error",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE(lib.open(system_library_path()));
 
@@ -739,7 +739,7 @@ TEST_CASE("DynamicLibrary missing symbol lookup records an error",
 }
 
 TEST_CASE("DynamicLibrary move construction transfers the handle",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE(lib.open(system_library_path()));
     REQUIRE(lib.find_symbol(system_library_symbol()) != nullptr);
@@ -751,7 +751,7 @@ TEST_CASE("DynamicLibrary move construction transfers the handle",
 }
 
 TEST_CASE("DynamicLibrary move assignment closes target and transfers source",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary target;
     DynamicLibrary source;
     REQUIRE(target.open(system_library_path()));
@@ -765,7 +765,7 @@ TEST_CASE("DynamicLibrary move assignment closes target and transfers source",
 }
 
 TEST_CASE("DynamicLibrary self move assignment preserves open handle",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE(lib.open(system_library_path()));
     REQUIRE(lib.is_open());
@@ -779,7 +779,7 @@ TEST_CASE("DynamicLibrary self move assignment preserves open handle",
 }
 
 TEST_CASE("DynamicLibrary failed reopen clears a previously loaded handle",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE(lib.open(system_library_path()));
     REQUIRE(lib.is_open());
@@ -790,7 +790,7 @@ TEST_CASE("DynamicLibrary failed reopen clears a previously loaded handle",
 }
 
 TEST_CASE("DynamicLibrary missing symbol records an error while staying open",
-          "[runtime][dynlib][coverage]") {
+          "[runtime][dynlib]") {
     DynamicLibrary lib;
     REQUIRE(lib.open(system_library_path()));
     REQUIRE(lib.is_open());
@@ -820,7 +820,7 @@ TEST_CASE("InterProcessLock double lock succeeds", "[runtime][ipc_lock]") {
 }
 
 TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
-          "[runtime][ipc_lock][coverage][issue-641]") {
+          "[runtime][ipc_lock]") {
     InterProcessLock lock("test_lock_reacquire");
     REQUIRE_FALSE(lock.is_locked());
 
@@ -839,7 +839,7 @@ TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
 }
 
 TEST_CASE("InterProcessLock competing instance waits for release",
-          "[runtime][ipc_lock][coverage]") {
+          "[runtime][ipc_lock]") {
     const auto name = "test_lock_competing";
     InterProcessLock first(name);
     InterProcessLock second(name);
@@ -853,7 +853,7 @@ TEST_CASE("InterProcessLock competing instance waits for release",
 }
 
 TEST_CASE("InterProcessLock reports open failure for missing parent paths",
-          "[runtime][ipc_lock][coverage]") {
+          "[runtime][ipc_lock]") {
     TemporaryFile marker(".lock-parent");
     const auto unique = marker.path().filename().string();
     marker.release();
@@ -899,7 +899,7 @@ TEST_CASE("run_process captures exit code", "[runtime][child_process]") {
 }
 
 TEST_CASE("run_process captures stderr separately",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("powershell", {"-NoProfile", "-Command", "[Console]::Error.WriteLine('bad-news'); exit 7"});
 #else
@@ -911,7 +911,7 @@ TEST_CASE("run_process captures stderr separately",
 }
 
 TEST_CASE("run_process captures stdout and stderr from one child",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("powershell",
         {"-NoProfile", "-Command",
@@ -927,7 +927,7 @@ TEST_CASE("run_process captures stdout and stderr from one child",
 }
 
 TEST_CASE("run_process preserves output beyond the platform child default cap",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
     constexpr auto expected_size = (1u << 20) + 4096u;
 
 #ifdef _WIN32
@@ -949,7 +949,7 @@ TEST_CASE("run_process preserves output beyond the platform child default cap",
 }
 
 TEST_CASE("run_process honors working directory and preserves spaced arguments",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
     TemporaryFile marker(".cwd");
     const auto dir = marker.path();
     marker.release();
@@ -981,7 +981,7 @@ TEST_CASE("run_process honors working directory and preserves spaced arguments",
 }
 
 TEST_CASE("run_process rejects missing working directories",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
     TemporaryFile marker(".missing-working-dir");
     const auto missing_path = marker.path();
@@ -1014,7 +1014,7 @@ TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 }
 
 TEST_CASE("run_process terminates POSIX children on timeout",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
 #if defined(_WIN32) || defined(__ANDROID__)
     SUCCEED("POSIX timeout termination is covered on macOS/Linux");
 #else
@@ -1030,7 +1030,7 @@ TEST_CASE("run_process terminates POSIX children on timeout",
 }
 
 TEST_CASE("run_process preserves POSIX output captured before timeout",
-          "[runtime][child_process][coverage]") {
+          "[runtime][child_process]") {
 #if defined(_WIN32) || defined(__ANDROID__)
     SUCCEED("POSIX timeout output preservation is covered on macOS/Linux");
 #else
@@ -1046,7 +1046,7 @@ TEST_CASE("run_process preserves POSIX output captured before timeout",
 // ── Stream ──────────────────────────────────────────────────────────────
 
 TEST_CASE("MemoryStream rejects nonzero null buffers",
-          "[runtime][stream][coverage]") {
+          "[runtime][stream]") {
     MemoryStream stream({1, 2, 3});
 
     auto read_result = stream.read(nullptr, 1);
@@ -1064,7 +1064,7 @@ TEST_CASE("MemoryStream rejects nonzero null buffers",
 }
 
 TEST_CASE("FileStream rejects nonzero null buffers",
-          "[runtime][stream][coverage]") {
+          "[runtime][stream]") {
     TemporaryFile tmp(".bin");
 
     FileStream writer(tmp.path_string(), FileStream::Mode::Write);
@@ -1111,7 +1111,7 @@ TEST_CASE("base64 decode invalid", "[runtime][base64]") {
     REQUIRE_FALSE(result.has_value());
 }
 
-TEST_CASE("base64 decode rejects malformed padding", "[runtime][base64][issue-641]") {
+TEST_CASE("base64 decode rejects malformed padding", "[runtime][base64]") {
     REQUIRE_FALSE(base64_decode("A").has_value());
     REQUIRE_FALSE(base64_decode("YQ=").has_value());
     REQUIRE_FALSE(base64_decode("Y=Q=").has_value());
@@ -1120,13 +1120,13 @@ TEST_CASE("base64 decode rejects malformed padding", "[runtime][base64][issue-64
     REQUIRE_FALSE(base64_decode("====").has_value());
 }
 
-TEST_CASE("base64 decode permits whitespace around terminal padding", "[runtime][base64][issue-641]") {
+TEST_CASE("base64 decode permits whitespace around terminal padding", "[runtime][base64]") {
     auto decoded = base64_decode(" YQ = = \n");
     REQUIRE(decoded.has_value());
     REQUIRE(std::string(decoded->begin(), decoded->end()) == "a");
 }
 
-TEST_CASE("base64 decode handles whitespace and unpadded tail groups", "[runtime][base64][issue-641]") {
+TEST_CASE("base64 decode handles whitespace and unpadded tail groups", "[runtime][base64]") {
     auto empty = base64_decode(" \n\r\t");
     REQUIRE(empty.has_value());
     REQUIRE(empty->empty());
@@ -1144,7 +1144,7 @@ TEST_CASE("base64 decode handles whitespace and unpadded tail groups", "[runtime
     REQUIRE(std::string(with_whitespace->begin(), with_whitespace->end()) == "Hello");
 }
 
-TEST_CASE("base64 decode rejects non-ascii bytes", "[runtime][base64][issue-641]") {
+TEST_CASE("base64 decode rejects non-ascii bytes", "[runtime][base64]") {
     std::string encoded = "YQ";
     encoded.push_back(static_cast<char>(0x80));
     REQUIRE_FALSE(base64_decode(encoded).has_value());
@@ -1159,7 +1159,7 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
 }
 
 TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
-          "[runtime][base64][coverage][issue-641]") {
+          "[runtime][base64]") {
     REQUIRE(base64_encode(nullptr, 0) == "");
     REQUIRE(base64_encode(nullptr, 3) == "");
 
@@ -1178,7 +1178,7 @@ TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
 }
 
 TEST_CASE("base64 rejects URL-safe alphabet and misplaced padding across whitespace",
-          "[runtime][base64][coverage][large]") {
+          "[runtime][base64][large]") {
     REQUIRE_FALSE(base64_decode("SGVsbG8-").has_value());
     REQUIRE_FALSE(base64_decode("SGVsbG8_").has_value());
     REQUIRE_FALSE(base64_decode("YQ=\n=Z").has_value());
@@ -1192,7 +1192,7 @@ TEST_CASE("base64 rejects URL-safe alphabet and misplaced padding across whitesp
 // ── IP address helpers ─────────────────────────────────────────────────
 
 TEST_CASE("IPv4 validation accepts boundary octets",
-          "[runtime][ip][coverage]") {
+          "[runtime][ip]") {
     REQUIRE(is_valid_ipv4("0.0.0.0"));
     REQUIRE(is_valid_ipv4("127.0.0.1"));
     REQUIRE(is_valid_ipv4("192.168.1.20"));
@@ -1200,7 +1200,7 @@ TEST_CASE("IPv4 validation accepts boundary octets",
 }
 
 TEST_CASE("IPv4 validation rejects malformed octet counts",
-          "[runtime][ip][coverage]") {
+          "[runtime][ip]") {
     REQUIRE_FALSE(is_valid_ipv4(""));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1.2"));
@@ -1208,7 +1208,7 @@ TEST_CASE("IPv4 validation rejects malformed octet counts",
 }
 
 TEST_CASE("IPv4 validation rejects out-of-range and signed octets",
-          "[runtime][ip][coverage]") {
+          "[runtime][ip]") {
     REQUIRE_FALSE(is_valid_ipv4("256.0.0.1"));
     REQUIRE_FALSE(is_valid_ipv4("1.2.3.-4"));
     REQUIRE_FALSE(is_valid_ipv4("+1.2.3.4"));
@@ -1216,7 +1216,7 @@ TEST_CASE("IPv4 validation rejects out-of-range and signed octets",
 }
 
 TEST_CASE("IPv4 validation rejects whitespace-padded addresses",
-          "[runtime][ip][coverage]") {
+          "[runtime][ip]") {
     REQUIRE_FALSE(is_valid_ipv4(" 127.0.0.1"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1 "));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1\n"));
@@ -1224,7 +1224,7 @@ TEST_CASE("IPv4 validation rejects whitespace-padded addresses",
 }
 
 TEST_CASE("base64 decodes final quantum without padding",
-          "[runtime][base64][coverage]") {
+          "[runtime][base64]") {
     auto one = base64_decode("TQ");
     REQUIRE(one.has_value());
     REQUIRE(*one == std::vector<uint8_t>{'M'});
@@ -1235,7 +1235,7 @@ TEST_CASE("base64 decodes final quantum without padding",
 }
 
 TEST_CASE("base64 decodes mixed full quartets and unpadded tails",
-          "[runtime][base64][coverage]") {
+          "[runtime][base64]") {
     auto one_tail = base64_decode("TWFuYQ");
     REQUIRE(one_tail.has_value());
     REQUIRE(std::string(one_tail->begin(), one_tail->end()) == "Mana");
@@ -1246,7 +1246,7 @@ TEST_CASE("base64 decodes mixed full quartets and unpadded tails",
 }
 
 TEST_CASE("base64 covers full alphabet and padded binary tails",
-          "[runtime][base64][coverage][large]") {
+          "[runtime][base64][large]") {
     const uint8_t alphabet_bytes[] = {
         0x00, 0x10, 0x83, 0x10, 0x51, 0x87, 0x20, 0x92,
         0x8b, 0x30, 0xd3, 0x8f, 0x41, 0x14, 0x93, 0x51,
@@ -1270,7 +1270,7 @@ TEST_CASE("base64 covers full alphabet and padded binary tails",
 }
 
 TEST_CASE("base64 decode tolerates whitespace inside unpadded input",
-          "[runtime][base64][coverage][large]") {
+          "[runtime][base64][large]") {
     auto decoded = base64_decode("\n Y W J \t j Z A \r");
     REQUIRE(decoded.has_value());
     REQUIRE(std::string(decoded->begin(), decoded->end()) == "abcd");
@@ -1279,7 +1279,7 @@ TEST_CASE("base64 decode tolerates whitespace inside unpadded input",
 // ── Expression ─────────────────────────────────────────────────────────
 
 TEST_CASE("Expression evaluator handles precedence and exponent edge cases",
-          "[runtime][expression][coverage][issue-641]") {
+          "[runtime][expression]") {
     auto value = evaluate("2 + 3 * 4 ^ 2");
     REQUIRE(value.has_value());
     REQUIRE(*value == Catch::Approx(50.0));
@@ -1294,7 +1294,7 @@ TEST_CASE("Expression evaluator handles precedence and exponent edge cases",
 }
 
 TEST_CASE("Expression evaluator handles constants, functions, and scientific notation",
-          "[runtime][expression][coverage][issue-641]") {
+          "[runtime][expression]") {
     auto trig = evaluate("sin(pi / 2) + cos(0)");
     REQUIRE(trig.has_value());
     REQUIRE(*trig == Catch::Approx(2.0));
@@ -1309,7 +1309,7 @@ TEST_CASE("Expression evaluator handles constants, functions, and scientific not
 }
 
 TEST_CASE("Expression evaluator covers remaining built-in math functions",
-          "[runtime][expression][codecov]") {
+          "[runtime][expression]") {
     auto builtins = evaluate("tan(0) + sqrt(9) + abs(-4) + log(e) + log10(100) + exp(0) + floor(2.9) + ceil(2.1) + round(2.5)");
     REQUIRE(builtins.has_value());
     REQUIRE(*builtins == Catch::Approx(19.0));
@@ -1332,7 +1332,7 @@ TEST_CASE("Expression evaluator covers remaining built-in math functions",
 }
 
 TEST_CASE("Expression evaluator covers built-in math function variants",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto value = evaluate("abs(-3) + floor(1.9) + ceil(2.1) + round(2.6)");
     REQUIRE(value.has_value());
     REQUIRE(*value == Catch::Approx(10.0));
@@ -1347,7 +1347,7 @@ TEST_CASE("Expression evaluator covers built-in math function variants",
 }
 
 TEST_CASE("Expression evaluator treats division by zero as silent zero",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto direct = evaluate("12 / 0");
     REQUIRE(direct.has_value());
     REQUIRE(*direct == Catch::Approx(0.0));
@@ -1358,7 +1358,7 @@ TEST_CASE("Expression evaluator treats division by zero as silent zero",
 }
 
 TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs",
-          "[runtime][expression][coverage][issue-641]") {
+          "[runtime][expression]") {
     auto variable = evaluate("gain * 2 + offset", {{"gain", 0.75}, {"offset", 0.25}});
     REQUIRE(variable.has_value());
     REQUIRE(*variable == Catch::Approx(1.75));
@@ -1376,7 +1376,7 @@ TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs"
 }
 
 TEST_CASE("Expression evaluator rejects malformed decimal tokens",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     REQUIRE_FALSE(evaluate(".").has_value());
     REQUIRE_FALSE(evaluate("1..2").has_value());
     REQUIRE_FALSE(evaluate("1.2.3").has_value());
@@ -1384,7 +1384,7 @@ TEST_CASE("Expression evaluator rejects malformed decimal tokens",
 }
 
 TEST_CASE("Expression evaluator handles unary plus division by zero and identifiers",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto value = evaluate("+gain_1 / zero", {{"gain_1", 12.0}, {"zero", 0.0}});
     REQUIRE(value.has_value());
     REQUIRE(*value == Catch::Approx(0.0));
@@ -1394,7 +1394,7 @@ TEST_CASE("Expression evaluator handles unary plus division by zero and identifi
 }
 
 TEST_CASE("ExpressionEvaluator stores variables and clears them",
-          "[runtime][expression][coverage][issue-641]") {
+          "[runtime][expression]") {
     ExpressionEvaluator evaluator;
     evaluator.set("x", 4.0);
     evaluator.set("y", 2.5);
@@ -1412,7 +1412,7 @@ TEST_CASE("ExpressionEvaluator stores variables and clears them",
 }
 
 TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
-          "[runtime][expression][coverage][issue-641]") {
+          "[runtime][expression]") {
     ExpressionEvaluator evaluator;
     evaluator.register_function("db_to_gain", [](double db) {
         return std::pow(10.0, db / 20.0);
@@ -1426,7 +1426,7 @@ TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
 }
 
 TEST_CASE("ExpressionEvaluator rejects extra arguments for custom unary functions",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     ExpressionEvaluator evaluator;
     evaluator.register_function("double_it", [](double value) {
         return value * 2.0;
@@ -1440,7 +1440,7 @@ TEST_CASE("ExpressionEvaluator rejects extra arguments for custom unary function
 }
 
 TEST_CASE("Expression evaluator handles binary math functions",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto minimum = evaluate("min(9, 4)");
     REQUIRE(minimum.has_value());
     REQUIRE(*minimum == Catch::Approx(4.0));
@@ -1455,14 +1455,14 @@ TEST_CASE("Expression evaluator handles binary math functions",
 }
 
 TEST_CASE("Expression evaluator tolerates whitespace around tokens",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto value = evaluate("  ( 1 + 2 ) *\t3  ");
     REQUIRE(value.has_value());
     REQUIRE(*value == Catch::Approx(9.0));
 }
 
 TEST_CASE("ExpressionEvaluator replaces registered unary functions",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     ExpressionEvaluator evaluator;
     evaluator.register_function("shape", [](double x) { return x + 1.0; });
     REQUIRE(*evaluator.evaluate("shape(4)") == Catch::Approx(5.0));
@@ -1472,7 +1472,7 @@ TEST_CASE("ExpressionEvaluator replaces registered unary functions",
 }
 
 TEST_CASE("ExpressionEvaluator variables can be overwritten",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     ExpressionEvaluator evaluator;
     evaluator.set("amount", 1.5);
     REQUIRE(*evaluator.evaluate("amount + 1") == Catch::Approx(2.5));
@@ -1483,21 +1483,21 @@ TEST_CASE("ExpressionEvaluator variables can be overwritten",
 }
 
 TEST_CASE("Expression evaluator rejects trailing operators",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     REQUIRE_FALSE(evaluate("1 +").has_value());
     REQUIRE_FALSE(evaluate("2 *").has_value());
     REQUIRE_FALSE(evaluate("pow(2,)").has_value());
 }
 
 TEST_CASE("Expression evaluator handles nested function calls",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto value = evaluate("max(min(10, 4), abs(-7))");
     REQUIRE(value.has_value());
     REQUIRE(*value == Catch::Approx(7.0));
 }
 
 TEST_CASE("Expression evaluator covers multi-argument builtins",
-          "[runtime][expression][coverage][large]") {
+          "[runtime][expression][large]") {
     REQUIRE(evaluate("min(5, 3)") == Catch::Approx(3.0));
     REQUIRE(evaluate("max(5, 3)") == Catch::Approx(5.0));
     REQUIRE(evaluate("pow(2, 5)") == Catch::Approx(32.0));
@@ -1506,7 +1506,7 @@ TEST_CASE("Expression evaluator covers multi-argument builtins",
 }
 
 TEST_CASE("Expression evaluator rejects incomplete multi-argument calls",
-          "[runtime][expression][coverage][large]") {
+          "[runtime][expression][large]") {
     REQUIRE_FALSE(evaluate("min(1)").has_value());
     REQUIRE_FALSE(evaluate("max(1)").has_value());
     REQUIRE_FALSE(evaluate("pow(2)").has_value());
@@ -1516,7 +1516,7 @@ TEST_CASE("Expression evaluator rejects incomplete multi-argument calls",
 // ── ScopeGuard ─────────────────────────────────────────────────────────
 
 TEST_CASE("ScopeGuard dismiss and move transfer ownership",
-          "[runtime][scope_guard][coverage][large]") {
+          "[runtime][scope_guard][large]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -1533,7 +1533,7 @@ TEST_CASE("ScopeGuard dismiss and move transfer ownership",
 }
 
 TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
-          "[runtime][scope_guard][coverage][large]") {
+          "[runtime][scope_guard][large]") {
     int value = 0;
     {
         PULP_ON_SCOPE_EXIT(value = 42);
@@ -1543,7 +1543,7 @@ TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
 }
 
 TEST_CASE("Expression evaluator treats chained powers as right associative",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto chained = evaluate("2 ^ 3 ^ 2");
     REQUIRE(chained.has_value());
     REQUIRE(*chained == Catch::Approx(512.0));
@@ -1558,7 +1558,7 @@ TEST_CASE("Expression evaluator treats chained powers as right associative",
 }
 
 TEST_CASE("Expression evaluator handles unary plus and division by zero",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     auto positive = evaluate(" \t +e + +2 ");
     REQUIRE(positive.has_value());
     REQUIRE(*positive == Catch::Approx(4.718281828459045));
@@ -1571,7 +1571,7 @@ TEST_CASE("Expression evaluator handles unary plus and division by zero",
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",
-          "[runtime][http][url][issue-641]") {
+          "[runtime][http][url]") {
     const auto get_response = http_get("ftp://example.com/file", 1);
     REQUIRE(get_response.status_code == 0);
     REQUIRE(get_response.error == "Invalid URL");
@@ -1584,7 +1584,7 @@ TEST_CASE("HTTP helpers reject malformed URLs without transport work",
 }
 
 TEST_CASE("HTTP helpers reject invalid numeric URL ports",
-          "[runtime][http][url][issue-641]") {
+          "[runtime][http][url]") {
     const auto zero_port = http_get("http://example.com:0/path", 1);
     REQUIRE(zero_port.status_code == 0);
     REQUIRE(zero_port.error == "Invalid URL");
@@ -1598,7 +1598,7 @@ TEST_CASE("HTTP helpers reject invalid numeric URL ports",
     REQUIRE(too_large_port.error == "Invalid URL");
 }
 
-TEST_CASE("HttpResponse ok covers status code boundaries", "[runtime][http][url][coverage][issue-656]") {
+TEST_CASE("HttpResponse ok covers status code boundaries", "[runtime][http][url]") {
     HttpResponse response;
     response.status_code = 199;
     REQUIRE_FALSE(response.ok());
@@ -1613,7 +1613,7 @@ TEST_CASE("HttpResponse ok covers status code boundaries", "[runtime][http][url]
 }
 
 TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
-          "[runtime][http][url][coverage][issue-656]") {
+          "[runtime][http][url]") {
     REQUIRE(http_get("https://:443/path", 1).error == "Invalid URL");
     REQUIRE(http_get("http://example.com:not-a-port/path", 1).error == "Invalid URL");
     REQUIRE(http_post("file://example.com/path", "body", "text/plain", 1).error == "Invalid URL");
@@ -1621,14 +1621,14 @@ TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
 }
 
 TEST_CASE("HTTP helpers accept case-insensitive URL schemes during parsing",
-          "[runtime][http][url][coverage]") {
+          "[runtime][http][url]") {
     const auto response = http_get("HTTP://127.0.0.1:1/path", 1);
     REQUIRE(response.status_code == 0);
     REQUIRE(response.error != "Invalid URL");
 }
 
 TEST_CASE("HTTP helpers report POST transport failures",
-          "[runtime][http][url][coverage]") {
+          "[runtime][http][url]") {
     const auto response = http_post("http://127.0.0.1:1/closed",
                                     "body",
                                     "text/plain",
@@ -1638,7 +1638,7 @@ TEST_CASE("HTTP helpers report POST transport failures",
 }
 
 TEST_CASE("HTTP helpers expose error responses without downloading bodies",
-          "[runtime][http][url][coverage]") {
+          "[runtime][http][url]") {
     httplib::Server server;
     server.Get("/missing", [](const httplib::Request&, httplib::Response& response) {
         response.status = 404;
@@ -1685,7 +1685,7 @@ TEST_CASE("HTTP helpers expose error responses without downloading bodies",
 }
 
 TEST_CASE("HTTP helpers round-trip against a loopback server",
-          "[runtime][http][url][coverage]") {
+          "[runtime][http][url]") {
     httplib::Server server;
     server.Get("/", [](const httplib::Request&, httplib::Response& response) {
         response.set_content("root", "text/plain");
@@ -1762,7 +1762,7 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
 }
 
 TEST_CASE("HTTP helpers copy successful GET status body and headers",
-          "[runtime][http][coverage]") {
+          "[runtime][http]") {
     auto exchange = serve_one_http_response("GET", "/status?ok=1");
 
     REQUIRE(exchange.accepted);
@@ -1776,7 +1776,7 @@ TEST_CASE("HTTP helpers copy successful GET status body and headers",
 }
 
 TEST_CASE("HTTP helpers copy successful POST request bodies",
-          "[runtime][http][coverage]") {
+          "[runtime][http]") {
     auto exchange = serve_one_http_response("POST", "/submit", R"({"value":7})");
 
     REQUIRE(exchange.accepted);
@@ -1789,7 +1789,7 @@ TEST_CASE("HTTP helpers copy successful POST request bodies",
 }
 
 TEST_CASE("HTTP download writes successful response bodies",
-          "[runtime][http][coverage]") {
+          "[runtime][http]") {
     TemporaryFile output(".http-body");
     auto exchange = serve_one_http_response("DOWNLOAD", "/artifact.bin", output.path_string());
 
@@ -1805,7 +1805,7 @@ TEST_CASE("HTTP download writes successful response bodies",
 }
 
 TEST_CASE("HTTP download reports unwritable output paths after successful fetch",
-          "[runtime][http][coverage]") {
+          "[runtime][http]") {
     TemporaryFile marker(".missing-http-dir");
     const auto missing_dir = marker.path();
     marker.release();
@@ -1826,7 +1826,7 @@ TEST_CASE("HTTP download reports unwritable output paths after successful fetch"
 }
 
 TEST_CASE("local IPv4 helpers return usable fallback values",
-          "[runtime][ip][coverage]") {
+          "[runtime][ip]") {
     const auto primary = local_ipv4_address();
     REQUIRE(is_valid_ipv4(primary));
 
@@ -1840,7 +1840,7 @@ TEST_CASE("local IPv4 helpers return usable fallback values",
 // ── Primes ──────────────────────────────────────────────────────────────
 
 TEST_CASE("prime helpers cover small values composites and sieve output",
-          "[runtime][primes][coverage]") {
+          "[runtime][primes]") {
     REQUIRE_FALSE(is_prime(0));
     REQUIRE_FALSE(is_prime(1));
     REQUIRE(is_prime(2));
@@ -1855,7 +1855,7 @@ TEST_CASE("prime helpers cover small values composites and sieve output",
 }
 
 TEST_CASE("generate_prime rejects impossible bit sizes and returns bounded primes",
-          "[runtime][primes][coverage]") {
+          "[runtime][primes]") {
     REQUIRE(generate_prime(0) == 0);
     REQUIRE(generate_prime(1) == 0);
     REQUIRE(generate_prime(63) == 0);
@@ -1868,14 +1868,14 @@ TEST_CASE("generate_prime rejects impossible bit sizes and returns bounded prime
 
 // ── Text Diff ────────────────────────────────────────────────────────────
 
-TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {
+TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff]") {
     auto diff = text_diff("", "");
     REQUIRE(diff.empty());
     REQUIRE(format_diff(diff).empty());
 }
 
 TEST_CASE("text_diff formats unchanged lines as context",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("alpha\nbeta", "alpha\nbeta");
 
     REQUIRE(diff.size() == 2);
@@ -1889,7 +1889,7 @@ TEST_CASE("text_diff formats unchanged lines as context",
 }
 
 TEST_CASE("text_diff reports pure inserts and deletes",
-          "[runtime][text-diff][issue-641]") {
+          "[runtime][text-diff]") {
     auto inserted = text_diff("", "one\ntwo");
     REQUIRE(inserted.size() == 2);
     REQUIRE(inserted[0].op == DiffOp::Insert);
@@ -1906,7 +1906,7 @@ TEST_CASE("text_diff reports pure inserts and deletes",
 }
 
 TEST_CASE("text_diff preserves equal lines across replacements and appends",
-          "[runtime][text-diff][issue-641]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("alpha\nbeta\ngamma\n",
                           "alpha\ndelta\ngamma\nomega");
 
@@ -1931,7 +1931,7 @@ TEST_CASE("text_diff preserves equal lines across replacements and appends",
 }
 
 TEST_CASE("text_diff keeps repeated-line matches stable",
-          "[runtime][text-diff][coverage][issue-641]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("same\nkeep\nsame\nremove\nsame",
                           "same\nkeep\nsame\ninsert\nsame");
 
@@ -1951,7 +1951,7 @@ TEST_CASE("text_diff keeps repeated-line matches stable",
 }
 
 TEST_CASE("text_diff treats identical multiline inputs as equal entries",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("one\ntwo\nthree", "one\ntwo\nthree");
     REQUIRE(diff.size() == 3);
     for (const auto& entry : diff) {
@@ -1961,7 +1961,7 @@ TEST_CASE("text_diff treats identical multiline inputs as equal entries",
 }
 
 TEST_CASE("text_diff preserves leading and trailing empty lines",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("\nbody\n", "\nbody\nnext\n");
     REQUIRE(diff.size() == 3);
     REQUIRE(diff[0].op == DiffOp::Equal);
@@ -1973,7 +1973,7 @@ TEST_CASE("text_diff preserves leading and trailing empty lines",
 }
 
 TEST_CASE("text_diff handles replacement ties and empty line formatting",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("old-a\n\nold-b", "new-a\nnew-b");
 
     REQUIRE(diff.size() == 5);
@@ -1997,7 +1997,7 @@ TEST_CASE("text_diff handles replacement ties and empty line formatting",
 }
 
 TEST_CASE("text_diff treats missing terminal newlines equivalently",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("one\ntwo", "one\ntwo\n");
 
     REQUIRE(diff.size() == 2);
@@ -2011,7 +2011,7 @@ TEST_CASE("text_diff treats missing terminal newlines equivalently",
 }
 
 TEST_CASE("format_diff handles manually constructed operation order",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     std::vector<DiffEntry> diff{
         {DiffOp::Equal, "context"},
         {DiffOp::Insert, "added"},
@@ -2025,7 +2025,7 @@ TEST_CASE("format_diff handles manually constructed operation order",
 }
 
 TEST_CASE("text_diff tie-breaks replacements as delete before insert",
-          "[runtime][text-diff][coverage][large]") {
+          "[runtime][text-diff][large]") {
     auto diff = text_diff("left\nmiddle\nright",
                           "left\ncenter\nright");
 
@@ -2041,7 +2041,7 @@ TEST_CASE("text_diff tie-breaks replacements as delete before insert",
 }
 
 TEST_CASE("text_diff preserves blank lines as diff entries",
-          "[runtime][text-diff][coverage][large]") {
+          "[runtime][text-diff][large]") {
     auto diff = text_diff("alpha\n\nomega",
                           "alpha\ninserted\n\nomega");
 
@@ -2057,7 +2057,7 @@ TEST_CASE("text_diff preserves blank lines as diff entries",
 }
 
 TEST_CASE("format_diff keeps empty inserted and deleted lines visible",
-          "[runtime][text-diff][coverage][large]") {
+          "[runtime][text-diff][large]") {
     const std::vector<DiffEntry> diff{
         {DiffOp::Equal, "context"},
         {DiffOp::Delete, ""},
@@ -2071,7 +2071,7 @@ TEST_CASE("format_diff keeps empty inserted and deleted lines visible",
 }
 
 TEST_CASE("text_diff treats trailing newline as no synthetic blank line",
-          "[runtime][text-diff][coverage][large]") {
+          "[runtime][text-diff][large]") {
     auto diff = text_diff("alpha\nbeta\n", "alpha\nbeta");
 
     REQUIRE(diff.size() == 2);
@@ -2085,7 +2085,7 @@ TEST_CASE("text_diff treats trailing newline as no synthetic blank line",
 }
 
 TEST_CASE("text_diff chooses deletions first for single-line replacements",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("left", "right");
 
     REQUIRE(diff.size() == 2);
@@ -2097,7 +2097,7 @@ TEST_CASE("text_diff chooses deletions first for single-line replacements",
 }
 
 TEST_CASE("text_diff ignores trailing empty line fragments",
-          "[runtime][text-diff][coverage]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("same\n", "same");
 
     REQUIRE(diff.size() == 1);
@@ -2148,7 +2148,7 @@ TEST_CASE("Range constrain", "[runtime][range]") {
 }
 
 TEST_CASE("Range constrain handles empty and reversed integer ranges",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     REQUIRE(IntRange(5, 5).constrain(100) == 5);
     REQUIRE(IntRange(10, 5).constrain(-100) == 10);
     REQUIRE(IntRange(-3, -1).constrain(9) == -2);
@@ -2162,7 +2162,7 @@ TEST_CASE("Range from_start_length", "[runtime][range]") {
 }
 
 TEST_CASE("Range covers containment and equality edge paths",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     IntRange outer(0, 10);
 
     REQUIRE(outer.contains(IntRange(0, 10)));
@@ -2176,7 +2176,7 @@ TEST_CASE("Range covers containment and equality edge paths",
 }
 
 TEST_CASE("Range expands empty and non-empty intervals",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     REQUIRE(IntRange(5, 5).expanded(8) == IntRange(8, 9));
     REQUIRE(IntRange(3, 7).expanded(10) == IntRange(3, 11));
     REQUIRE(IntRange(3, 7).expanded(-2) == IntRange(-2, 7));
@@ -2184,7 +2184,7 @@ TEST_CASE("Range expands empty and non-empty intervals",
 }
 
 TEST_CASE("Range union handles empty operands",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     REQUIRE(IntRange().enclosing_union(IntRange(4, 9)) == IntRange(4, 9));
     REQUIRE(IntRange(4, 9).enclosing_union(IntRange()) == IntRange(4, 9));
     REQUIRE(IntRange().enclosing_union(IntRange()) == IntRange());
@@ -2197,7 +2197,7 @@ TEST_CASE("FloatRange", "[runtime][range]") {
 }
 
 TEST_CASE("Range constrain preserves floating half-open upper bound",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     FloatRange floats(0.0f, 1.0f);
     auto constrained_float = floats.constrain(2.0f);
     REQUIRE(constrained_float < 1.0f);
@@ -2213,7 +2213,7 @@ TEST_CASE("Range constrain preserves floating half-open upper bound",
 }
 
 TEST_CASE("DoubleRange intersections and unions preserve fractional bounds",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     DoubleRange a(0.25, 2.75);
     DoubleRange b(1.5, 4.0);
 
@@ -2227,7 +2227,7 @@ TEST_CASE("DoubleRange intersections and unions preserve fractional bounds",
 }
 
 TEST_CASE("SizeRange and FloatRange cover containment and expansion helpers",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     SizeRange bytes = SizeRange::from_start_length(4u, 8u);
     REQUIRE(bytes.start == 4u);
     REQUIRE(bytes.end == 12u);
@@ -2249,7 +2249,7 @@ TEST_CASE("SizeRange and FloatRange cover containment and expansion helpers",
 }
 
 TEST_CASE("Floating Range constrain clamps to contained upper bound",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     FloatRange unit(0.0f, 1.0f);
     REQUIRE_THAT(unit.constrain(-2.0f), Catch::Matchers::WithinAbs(0.0f, 1e-6f));
     REQUIRE_THAT(unit.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
@@ -2263,7 +2263,7 @@ TEST_CASE("Floating Range constrain clamps to contained upper bound",
 }
 
 TEST_CASE("Range boundary touch points remain non-intersections",
-          "[runtime][range][coverage][issue-641]") {
+          "[runtime][range]") {
     REQUIRE_FALSE(IntRange(0, 10).intersects(IntRange(10, 20)));
     REQUIRE(IntRange(0, 10).intersection(IntRange(10, 20)).empty());
     REQUIRE(IntRange(10, 20).intersection(IntRange(0, 10)).empty());
@@ -2274,7 +2274,7 @@ TEST_CASE("Range boundary touch points remain non-intersections",
 }
 
 TEST_CASE("Range intersection is commutative for overlapping integer ranges",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     IntRange a(-4, 8);
     IntRange b(3, 12);
     REQUIRE(a.intersection(b) == IntRange(3, 8));
@@ -2282,7 +2282,7 @@ TEST_CASE("Range intersection is commutative for overlapping integer ranges",
 }
 
 TEST_CASE("Range enclosing union keeps reversed ranges isolated",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     IntRange reversed(8, 3);
     IntRange normal(1, 4);
     REQUIRE(reversed.empty());
@@ -2291,7 +2291,7 @@ TEST_CASE("Range enclosing union keeps reversed ranges isolated",
 }
 
 TEST_CASE("Range expansion handles negative domains",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     IntRange range(-10, -4);
     REQUIRE(range.expanded(-12) == IntRange(-12, -4));
     REQUIRE(range.expanded(-1) == IntRange(-10, 0));
@@ -2299,7 +2299,7 @@ TEST_CASE("Range expansion handles negative domains",
 }
 
 TEST_CASE("FloatRange constrain clamps fractional values",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     FloatRange range(-1.0f, 3.0f);
     REQUIRE_THAT(range.constrain(-2.5f), Catch::Matchers::WithinAbs(-1.0f, 1e-6f));
     REQUIRE_THAT(range.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
@@ -2308,7 +2308,7 @@ TEST_CASE("FloatRange constrain clamps fractional values",
 }
 
 TEST_CASE("DoubleRange empty constrain returns start",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     DoubleRange empty(4.5, 4.5);
     REQUIRE(empty.empty());
     REQUIRE_THAT(empty.constrain(-100.0), Catch::Matchers::WithinAbs(4.5, 1e-12));
@@ -2316,7 +2316,7 @@ TEST_CASE("DoubleRange empty constrain returns start",
 }
 
 TEST_CASE("Range expanded covers negative fractional values",
-          "[runtime][range][coverage]") {
+          "[runtime][range]") {
     DoubleRange empty(2.0, 2.0);
     auto seeded = empty.expanded(-1.5);
     REQUIRE_THAT(seeded.start, Catch::Matchers::WithinAbs(-1.5, 1e-12));

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -185,7 +185,7 @@ TEST_CASE("ParameterEventQueue is available from state",
 }
 
 TEST_CASE("ParameterEventQueue enforces capacity and preserves stable sort order",
-          "[state][params][events][coverage][phase3]") {
+          "[state][params][events]") {
     ParameterEventQueue queue;
 
     REQUIRE(queue.capacity() == ParameterEventQueue::kCapacity);
@@ -219,7 +219,7 @@ TEST_CASE("ParameterEventQueue enforces capacity and preserves stable sort order
 }
 
 TEST_CASE("ParamCursor ignores unregistered events but honors explicit snapshots",
-          "[state][params][cursor][coverage][phase3]") {
+          "[state][params][cursor]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.25f}));
     store.set_value(1, 0.5f);
@@ -247,7 +247,7 @@ TEST_CASE("ParamCursor ignores unregistered events but honors explicit snapshots
 }
 
 TEST_CASE("ParamCursor is monotonic and null event queues fall back to StateStore",
-          "[state][params][cursor][coverage][phase3]") {
+          "[state][params][cursor]") {
     StateStore store;
     store.add_parameter(make_param_info(7, "Mix", "", {-1.0f, 1.0f, 0.0f}));
     store.set_value(7, 0.25f);
@@ -455,7 +455,7 @@ TEST_CASE("ParamCursor clamps ramp targets and treats non-positive durations as 
 }
 
 TEST_CASE("ParameterEventQueue exposes mutable and const iteration over active events",
-          "[state][params][events][coverage][phase3-state]") {
+          "[state][params][events]") {
     ParameterEventQueue queue;
 
     REQUIRE(queue.empty());
@@ -490,7 +490,7 @@ TEST_CASE("ParameterEventQueue exposes mutable and const iteration over active e
 }
 
 TEST_CASE("ParamCursor updates duplicate snapshots and ignores late unknown events",
-          "[state][params][cursor][coverage][phase3-state]") {
+          "[state][params][cursor]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.25f}));
     store.set_value(1, 0.5f);
@@ -538,7 +538,7 @@ TEST_CASE("ParamRange with step", "[state][range]") {
 }
 
 TEST_CASE("ParamRange clamps normalized conversions at range boundaries",
-          "[state][range][coverage][issue-646]") {
+          "[state][range]") {
     ParamRange range{-10.0f, 30.0f, 5.0f, 0.0f};
 
     REQUIRE_THAT(range.normalize(-100.0f), WithinAbs(0.0, 0.001));
@@ -548,7 +548,7 @@ TEST_CASE("ParamRange clamps normalized conversions at range boundaries",
 }
 
 TEST_CASE("ParamRange zero-width ranges normalize safely",
-          "[state][range][coverage][issue-646]") {
+          "[state][range]") {
     ParamRange range{7.0f, 7.0f, 7.0f, 0.0f};
 
     REQUIRE_THAT(range.normalize(7.0f), WithinAbs(0.0, 0.001));
@@ -557,7 +557,7 @@ TEST_CASE("ParamRange zero-width ranges normalize safely",
     REQUIRE_THAT(range.denormalize(2.0f), WithinAbs(7.0, 0.001));
 }
 
-TEST_CASE("ParamRange clamps and handles zero-width ranges", "[state][range][codecov]") {
+TEST_CASE("ParamRange clamps and handles zero-width ranges", "[state][range]") {
     ParamRange range{-10.0f, 10.0f, 0.0f, 0.0f};
 
     REQUIRE_THAT(range.normalize(-100.0f), WithinAbs(0.0, 0.001));
@@ -571,7 +571,7 @@ TEST_CASE("ParamRange clamps and handles zero-width ranges", "[state][range][cod
 }
 
 TEST_CASE("ParamValue tracks modulation and copy move state",
-          "[state][value][codecov]") {
+          "[state][value]") {
     ParamRange range{-1.0f, 1.0f, 0.0f, 0.5f};
     ParamValue value(0.25f);
 
@@ -671,7 +671,7 @@ TEST_CASE("StateStore basic operations", "[state][store]") {
 }
 
 TEST_CASE("StateStore duplicate parameter ids resolve to latest registration",
-          "[state][store][coverage][phase3-github]") {
+          "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(7, "First", "dB", {-60.0f, 12.0f, -6.0f}));
     store.add_parameter(make_param_info(7, "Second", "%", {0.0f, 100.0f, 25.0f}));
@@ -764,7 +764,7 @@ TEST_CASE("StateStore serialization", "[state][serialize]") {
 }
 
 TEST_CASE("StateStore serialization records header fields and rejects future versions",
-          "[state][serialize][coverage][issue-646]") {
+          "[state][serialize]") {
     StateStore store;
     auto p1 = make_param_info(10, "Drive", "", {0.0f, 1.0f, 0.25f});
     auto p2 = make_param_info(20, "Tone", "", {-1.0f, 1.0f, 0.0f});
@@ -793,7 +793,7 @@ TEST_CASE("StateStore serialization records header fields and rejects future ver
 }
 
 TEST_CASE("StateStore serialization honors explicit current schema version",
-          "[state][serialize][coverage][phase3]") {
+          "[state][serialize]") {
     StateStore source;
     auto p = make_param_info(7, "Shape", "", {0.0f, 1.0f, 0.25f});
     source.add_parameter(p);
@@ -811,7 +811,7 @@ TEST_CASE("StateStore serialization honors explicit current schema version",
 }
 
 TEST_CASE("StateStore set_normalized clamps and quantizes via ParamRange",
-          "[state][store][coverage][issue-646]") {
+          "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Steps", "", {0.0f, 10.0f, 5.0f, 2.0f}));
 
@@ -829,7 +829,7 @@ TEST_CASE("StateStore set_normalized clamps and quantizes via ParamRange",
 }
 
 TEST_CASE("StateStore deserialize clamps values to current ranges",
-          "[state][serialize][codecov]") {
+          "[state][serialize]") {
     StateStore source;
     source.add_parameter(make_param_info(1, "Wide", "", {0.0f, 100.0f, 50.0f}));
     source.set_value(1, 80.0f);
@@ -843,7 +843,7 @@ TEST_CASE("StateStore deserialize clamps values to current ranges",
 }
 
 TEST_CASE("StateStore deserialize rejects bad magic and future versions",
-          "[state][serialize][codecov]") {
+          "[state][serialize]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}));
     store.set_value(1, -12.0f);
@@ -865,7 +865,7 @@ TEST_CASE("StateStore deserialize rejects bad magic and future versions",
 }
 
 TEST_CASE("StateStore deserialize rejects corrupted CRC without changing values",
-          "[state][serialize][coverage]") {
+          "[state][serialize]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}));
     store.set_value(1, -6.0f);
@@ -894,7 +894,7 @@ TEST_CASE("StateStore change listener", "[state][listener]") {
     REQUIRE_THAT(changed_value, WithinAbs(0.8, 0.001));
 }
 
-TEST_CASE("StateStore skips empty change listeners", "[state][listener][codecov]") {
+TEST_CASE("StateStore skips empty change listeners", "[state][listener]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.5f}));
 
@@ -911,7 +911,7 @@ TEST_CASE("StateStore skips empty change listeners", "[state][listener][codecov]
 }
 
 TEST_CASE("StateStore ignores unknown value writes without notifying listeners",
-          "[state][listener][coverage]") {
+          "[state][listener]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Known", "", {0.0f, 1.0f, 0.5f}));
 
@@ -994,7 +994,7 @@ TEST_CASE("StateStore exposes registration spans and gesture callbacks", "[state
 }
 
 TEST_CASE("StateStore preserves parameter display conversion callbacks",
-          "[state][store][coverage][phase3]") {
+          "[state][store]") {
     StateStore store;
     ParamInfo info = make_param_info(7, "Frequency", "Hz", {20.0f, 20000.0f, 440.0f});
     info.to_string = [](float value) {
@@ -1014,7 +1014,7 @@ TEST_CASE("StateStore preserves parameter display conversion callbacks",
 }
 
 TEST_CASE("StateStore unknown modulation writes are no-ops",
-          "[state][store][coverage][phase3]") {
+          "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.25f}));
 
@@ -1031,7 +1031,7 @@ TEST_CASE("StateStore unknown modulation writes are no-ops",
 }
 
 TEST_CASE("ParamRange ignores negative step and still clamps output",
-          "[state][range][coverage][phase3-large]") {
+          "[state][range]") {
     ParamRange range{0.0f, 10.0f, 5.0f, -2.0f};
 
     REQUIRE_THAT(range.denormalize(0.25f), WithinAbs(2.5, 0.001));
@@ -1040,7 +1040,7 @@ TEST_CASE("ParamRange ignores negative step and still clamps output",
 }
 
 TEST_CASE("ParamRange quantization clamps non-divisible upper steps",
-          "[state][range][coverage][phase3-large]") {
+          "[state][range]") {
     ParamRange range{0.0f, 10.0f, 0.0f, 3.0f};
 
     REQUIRE_THAT(range.denormalize(0.14f), WithinAbs(0.0, 0.001));
@@ -1050,7 +1050,7 @@ TEST_CASE("ParamRange quantization clamps non-divisible upper steps",
 }
 
 TEST_CASE("ParamValue copy and assignment reset modulation offset",
-          "[state][value][coverage][phase3-large]") {
+          "[state][value]") {
     ParamValue source(2.0f);
     source.set_mod_offset(3.0f);
 
@@ -1065,7 +1065,7 @@ TEST_CASE("ParamValue copy and assignment reset modulation offset",
 }
 
 TEST_CASE("StateStore listener snapshot defers newly added listeners",
-          "[state][listener][coverage][phase3-large]") {
+          "[state][listener]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.0f}));
 
@@ -1090,7 +1090,7 @@ TEST_CASE("StateStore listener snapshot defers newly added listeners",
 }
 
 TEST_CASE("StateStore gesture callbacks can be replaced and cleared",
-          "[state][store][coverage][phase3-large]") {
+          "[state][store]") {
     StateStore store;
     std::vector<ParamID> began;
     std::vector<ParamID> ended;
@@ -1110,7 +1110,7 @@ TEST_CASE("StateStore gesture callbacks can be replaced and cleared",
 }
 
 TEST_CASE("Binding handles unbound and polled parameter changes",
-          "[state][binding][coverage][phase3-large]") {
+          "[state][binding]") {
     Binding empty;
     REQUIRE_FALSE(empty.is_bound());
     REQUIRE(empty.id() == 0);
@@ -1156,7 +1156,7 @@ TEST_CASE("Binding handles unbound and polled parameter changes",
 }
 
 TEST_CASE("Binding gesture end records undoable parameter edits",
-          "[state][binding][coverage][phase3-large]") {
+          "[state][binding]") {
     StateStore store;
     store.add_parameter(make_param_info(9, "Mix", "%", {0.0f, 100.0f, 50.0f}));
 
@@ -1187,7 +1187,7 @@ TEST_CASE("Binding gesture end records undoable parameter edits",
 }
 
 TEST_CASE("Binding normalized writes notify only when the stored value changes",
-          "[state][binding][coverage][phase3-large]") {
+          "[state][binding]") {
     StateStore store;
     store.add_parameter(make_param_info(12, "Pan", "", {-1.0f, 1.0f, 0.0f}));
 
@@ -1234,7 +1234,7 @@ TEST_CASE("Binding normalized writes notify only when the stored value changes",
 }
 
 TEST_CASE("Binding handles unregistered parameters without mutating the store",
-          "[state][binding][coverage][phase3-large]") {
+          "[state][binding]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "dB", {-60.0f, 6.0f, -12.0f}));
 
@@ -1260,7 +1260,7 @@ TEST_CASE("Binding handles unregistered parameters without mutating the store",
 }
 
 TEST_CASE("create_bindings mirrors StateStore parameter registration order",
-          "[state][binding][coverage][phase3-large]") {
+          "[state][binding]") {
     StateStore empty;
     auto empty_bindings = create_bindings(empty);
     REQUIRE(empty_bindings.empty());
@@ -1288,7 +1288,7 @@ TEST_CASE("create_bindings mirrors StateStore parameter registration order",
 }
 
 TEST_CASE("EditHistory trims depth clears redo and toggles coalescing",
-          "[state][edit-history][coverage][phase3-large]") {
+          "[state][edit-history]") {
     EditHistory history(2);
     int value = 0;
 
@@ -1322,7 +1322,7 @@ TEST_CASE("EditHistory trims depth clears redo and toggles coalescing",
 }
 
 TEST_CASE("EditHistory coalesces matching descriptions and clamps max depth",
-          "[state][edit-history][coverage][phase3-large]") {
+          "[state][edit-history]") {
     EditHistory history(4);
     int value = 0;
 
@@ -1343,7 +1343,7 @@ TEST_CASE("EditHistory coalesces matching descriptions and clamps max depth",
 }
 
 TEST_CASE("EditHistory exposes empty descriptions, redo counts, and inert callbacks",
-          "[state][edit-history][coverage][phase3-state]") {
+          "[state][edit-history]") {
     struct BlankAction final : EditAction {
         explicit BlankAction(int& target) : value(&target) {}
 
@@ -1377,7 +1377,7 @@ TEST_CASE("EditHistory exposes empty descriptions, redo counts, and inert callba
 }
 
 TEST_CASE("StateStore unknown modulation and reset calls are inert",
-          "[state][store][coverage][phase3-github]") {
+          "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(3, "Depth", "", {0.0f, 1.0f, 0.25f}));
 
@@ -1391,7 +1391,7 @@ TEST_CASE("StateStore unknown modulation and reset calls are inert",
 }
 
 TEST_CASE("StateStore deserialize rejects short declared count payloads",
-          "[state][serialize][coverage][phase3-large]") {
+          "[state][serialize]") {
     StateStore source;
     auto p1 = make_param_info(1, "One", "", {0.0f, 1.0f, 0.0f});
     source.add_parameter(p1);
@@ -1411,7 +1411,7 @@ TEST_CASE("StateStore deserialize rejects short declared count payloads",
 }
 
 TEST_CASE("StateStore empty serialization round-trips as a minimum frame",
-          "[state][serialize][coverage][phase3]") {
+          "[state][serialize]") {
     StateStore source;
 
     auto data = source.serialize();
@@ -1428,7 +1428,7 @@ TEST_CASE("StateStore empty serialization round-trips as a minimum frame",
 }
 
 TEST_CASE("StateStore deserialize rejects trailing payload extensions",
-          "[state][serialize][coverage][phase3-large]") {
+          "[state][serialize]") {
     StateStore source;
     auto p1 = make_param_info(1, "One", "", {0.0f, 1.0f, 0.0f});
     source.add_parameter(p1);
@@ -1527,7 +1527,7 @@ TEST_CASE("ListenerToken is move-only and transfers ownership",
 }
 
 TEST_CASE("ListenerToken self move-assignment keeps the subscription",
-          "[state][listener][token][coverage][phase3]") {
+          "[state][listener][token]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
 
@@ -1719,7 +1719,7 @@ TEST_CASE("Queued Main callback is cancelled by token reset (PR#2270)",
 }
 
 TEST_CASE("StateStore reset all defaults notifies each registered parameter",
-          "[state][store][coverage][phase3-large]") {
+          "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "A", "", {0.0f, 10.0f, 1.0f}));
     store.add_parameter(make_param_info(2, "B", "", {-1.0f, 1.0f, 0.0f}));
@@ -1738,7 +1738,7 @@ TEST_CASE("StateStore reset all defaults notifies each registered parameter",
 }
 
 TEST_CASE("StateStore custom state version is serialized and accepted",
-          "[state][serialize][coverage][phase3-large]") {
+          "[state][serialize]") {
     StateStore source;
     source.set_state_version(3);
     source.add_parameter(make_param_info(10, "Drive", "", {0.0f, 1.0f, 0.25f}));
@@ -1756,7 +1756,7 @@ TEST_CASE("StateStore custom state version is serialized and accepted",
 }
 
 TEST_CASE("StateStore serializes custom state version",
-          "[state][serialize][coverage][phase3-large]") {
+          "[state][serialize]") {
     StateStore store;
     store.set_state_version(7);
     store.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
@@ -1855,7 +1855,7 @@ TEST_CASE("StateStore migrations are scoped to each store instance",
 }
 
 TEST_CASE("StateStore can copy registered migrations to a restore probe",
-          "[state][serialize][migration][coverage][phase3-large]") {
+          "[state][serialize][migration]") {
     StateStore saved;
     saved.set_state_version(8);
     saved.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
@@ -1941,7 +1941,7 @@ TEST_CASE("StateStore rejects corrupt source blobs before migration callbacks",
 }
 
 TEST_CASE("StateMigrationRegistry rejects invalid and duplicate registrations",
-          "[state][serialize][migration][coverage][phase3]") {
+          "[state][serialize][migration]") {
     StateMigrationRegistry registry;
     auto migration = [](std::span<const uint8_t>, std::vector<uint8_t>&) {
         return true;
@@ -1957,7 +1957,7 @@ TEST_CASE("StateMigrationRegistry rejects invalid and duplicate registrations",
 }
 
 TEST_CASE("StateMigrationRegistry copies current-version blobs and rejects bad sources",
-          "[state][serialize][migration][coverage][phase3]") {
+          "[state][serialize][migration]") {
     StateStore source;
     source.set_state_version(4);
     source.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
@@ -1984,7 +1984,7 @@ TEST_CASE("StateMigrationRegistry copies current-version blobs and rejects bad s
 }
 
 TEST_CASE("StateMigrationRegistry applies multi-hop migrations in order",
-          "[state][serialize][migration][coverage][phase3]") {
+          "[state][serialize][migration]") {
     StateStore source;
     source.set_state_version(1);
     source.add_parameter(make_param_info(7, "Mix", "", {0.0f, 1.0f, 0.25f}));
@@ -2022,7 +2022,7 @@ TEST_CASE("StateMigrationRegistry applies multi-hop migrations in order",
 }
 
 TEST_CASE("StateMigrationRegistry rejects broken migration callbacks",
-          "[state][serialize][migration][coverage][phase3]") {
+          "[state][serialize][migration]") {
     StateStore source;
     source.set_state_version(1);
     source.add_parameter(make_param_info(3, "Drive", "", {0.0f, 1.0f, 0.5f}));
@@ -2073,7 +2073,7 @@ TEST_CASE("StateMigrationRegistry rejects broken migration callbacks",
 }
 
 TEST_CASE("StateStore reset_all_to_defaults notifies in registration order",
-          "[state][listener][coverage][phase3-large]") {
+          "[state][listener]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Gain", "", {-60.0f, 12.0f, 0.0f}));
     store.add_parameter(make_param_info(2, "Mix", "", {0.0f, 100.0f, 50.0f}));
@@ -2212,7 +2212,7 @@ TEST_CASE("set_value_rt clamps and the RT queue is lossy under overflow",
 }
 
 TEST_CASE("StateStore exposes RT listener queue telemetry",
-          "[state][listener][rt][telemetry][phase2]") {
+          "[state][listener][rt][telemetry]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
 
@@ -2247,7 +2247,7 @@ TEST_CASE("StateStore exposes RT listener queue telemetry",
 }
 
 TEST_CASE("StateStore RT listener telemetry hot path allocates zero times",
-          "[state][listener][rt][telemetry][rt-safety][phase2]") {
+          "[state][listener][rt][telemetry][rt-safety]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
 

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -94,7 +94,7 @@ TEST_CASE("UndoManager perform and undo", "[state][undo]") {
     REQUIRE_FALSE(um.can_undo());
 }
 
-TEST_CASE("UndoManager empty undo and redo are no-ops", "[state][undo][coverage][phase3]") {
+TEST_CASE("UndoManager empty undo and redo are no-ops", "[state][undo]") {
     UndoManager um;
     int changes = 0;
     um.on_state_changed = [&] { ++changes; };
@@ -218,7 +218,7 @@ TEST_CASE("UndoManager max_history trims oldest", "[state][undo]") {
 }
 
 TEST_CASE("UndoManager zero max history performs without retaining undo",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     um.set_max_history(0);
     int state_changes = 0;
@@ -238,7 +238,7 @@ TEST_CASE("UndoManager zero max history performs without retaining undo",
 }
 
 TEST_CASE("UndoManager lowering max_history trims existing history",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int v = 0;
 
@@ -265,7 +265,7 @@ TEST_CASE("UndoManager lowering max_history trims existing history",
 }
 
 TEST_CASE("UndoManager zero and negative max_history disable retention",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int v = 0;
 
@@ -375,7 +375,7 @@ TEST_CASE("UndoManager add_without_executing", "[state][undo]") {
 }
 
 TEST_CASE("UndoManager add_without_executing participates in transactions",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int x = 10;
     int y = 20;
@@ -409,7 +409,7 @@ TEST_CASE("UndoManager add_without_executing participates in transactions",
 }
 
 TEST_CASE("UndoManager add_without_executing mixes with performed transaction actions",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     std::vector<int> values;
     values.push_back(1);
@@ -436,7 +436,7 @@ TEST_CASE("UndoManager add_without_executing mixes with performed transaction ac
 }
 
 TEST_CASE("UndoManager committed transaction after undo clears redo history",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int value = 0;
 
@@ -467,7 +467,7 @@ TEST_CASE("UndoManager committed transaction after undo clears redo history",
 }
 
 TEST_CASE("UndoManager add_without_executing outside transaction clears redo history",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int value = 0;
 
@@ -496,7 +496,7 @@ TEST_CASE("UndoManager add_without_executing outside transaction clears redo his
 }
 
 TEST_CASE("UndoManager open transaction publishes history only when ended",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     int value = 0;
     int state_changes = 0;
@@ -524,7 +524,7 @@ TEST_CASE("UndoManager open transaction publishes history only when ended",
 }
 
 TEST_CASE("UndoManager max history trims whole transactions",
-          "[state][undo][coverage][phase3]") {
+          "[state][undo]") {
     UndoManager um;
     um.set_max_history(2);
     int value = 0;
@@ -568,7 +568,7 @@ TEST_CASE("UndoManager multiple undo/redo sequence", "[state][undo]") {
 }
 
 TEST_CASE("UndoManager transaction redo preserves action order",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     UndoManager um;
     std::vector<int> events;
 
@@ -593,7 +593,7 @@ TEST_CASE("UndoManager transaction redo preserves action order",
 }
 
 TEST_CASE("UndoManager clear notifies even when history is empty",
-          "[state][undo][coverage][phase3-large]") {
+          "[state][undo]") {
     UndoManager um;
     int changes = 0;
     um.on_state_changed = [&] { ++changes; };


### PR DESCRIPTION
## Summary

- remove stale Catch2 provenance/noise tags from runtime, state, environment, i18n, and runtime-utils tests
- preserve behavior/domain selectors such as `[runtime]`, `[state]`, `[binding]`, `[properties]`, `[undo]`, `[environment]`, `[runtime][i18n]`, and runtime utility subdomain tags
- rename four environment tests whose duplicate display names were previously distinguished only by removed provenance tags

## Validation

- RepoPrompt/rp-cli pre- and post-edit reviews for each slice
- external selector-consumer greps over `.github`, `.shipyard`, CMake, tools, scripts, and docs for removed selectors
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `cmake --build build --target pulp-test-runtime pulp-test-state pulp-test-properties pulp-test-binding pulp-test-undo-manager pulp-test-edit-history -j$(sysctl -n hw.ncpu)`
- `cmake --build build --target pulp-test-i18n pulp-test-environment -j$(sysctl -n hw.ncpu)`
- `cmake --build build --target pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-runtime "[runtime]"`
- `./build/test/pulp-test-state "[state]"`
- `./build/test/pulp-test-properties "[state][properties]"`
- `./build/test/pulp-test-binding "[binding]"`
- `./build/test/pulp-test-undo-manager "[state][undo]"`
- `./build/test/pulp-test-edit-history "[state][undo]"`
- `./build/test/pulp-test-i18n "[runtime][i18n]"`
- `./build/test/pulp-test-i18n "[runtime][i18n][large]"`
- `./build/test/pulp-test-environment "[environment]"`
- `./build/test/pulp-test-runtime-utils "[runtime]" --reporter compact`
- `./build/test/pulp-test-runtime-utils "[runtime][large]" --reporter compact`
- structured Codex autoreview clean: `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.9)`

Planning log: `pulp-planning` commit `f225c16` (`docs: log runtime utility selector batch`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Catch2 test selector tags across runtime, state, environment, i18n, and runtime-utils. Ensures reliable filtering by keeping domain tags and making four environment tests uniquely named.

- **Refactors**
  - Removed provenance/noise tags (`[coverage]`, `[issue-640]`, `[issue-646]`, `[phase3]`, `[phase4]`).
  - Preserved behavior/domain selectors for filtering (e.g., `[runtime]`, `[state]`, `[binding]`, `[properties]`, `[undo]`, `[environment]`, `[runtime][i18n]`, `[runtime][timer]`).
  - Renamed four environment tests to avoid duplicate display names; no test logic changes.

<sup>Written for commit be09cfb3df3239a26768705d023df9a87337fe69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

