### PR TITLE
docs(test): refresh state/runtime support selector tags

### DIFF
--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Analytics disabled doesn't log", "[runtime][analytics]") {
 }
 
 TEST_CASE("Analytics exposes enabled state toggles",
-          "[runtime][analytics][coverage][phase3-batch742]") {
+          "[runtime][analytics]") {
     auto& a = Analytics::instance();
 
     a.set_enabled(false);
@@ -136,7 +136,7 @@ TEST_CASE("FileAnalyticsDestination writes JSON", "[runtime][analytics]") {
     REQUIRE(line.find("\"key\":\"value\"") != std::string::npos);
 }
 
-TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics][coverage][issue-656]") {
+TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics][issue-656]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -160,7 +160,7 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
 }
 
 TEST_CASE("FileAnalyticsDestination escapes each special JSON character",
-          "[runtime][analytics][coverage][issue-656]") {
+          "[runtime][analytics][issue-656]") {
     struct Case {
         std::string input;
         std::string expected;
@@ -192,7 +192,7 @@ TEST_CASE("FileAnalyticsDestination escapes each special JSON character",
 }
 
 TEST_CASE("FileAnalyticsDestination escapes non-printable JSON control bytes",
-          "[runtime][analytics][coverage][phase3]") {
+          "[runtime][analytics]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -217,7 +217,7 @@ TEST_CASE("FileAnalyticsDestination escapes non-printable JSON control bytes",
 }
 
 TEST_CASE("FileAnalyticsDestination escapes special JSON property keys and values",
-          "[runtime][analytics][coverage][issue-656]") {
+          "[runtime][analytics][issue-656]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -240,7 +240,8 @@ TEST_CASE("FileAnalyticsDestination escapes special JSON property keys and value
     REQUIRE(line.find("\"tab\\tkey\":\"tab\\tvalue\"") != std::string::npos);
 }
 
-TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {
+TEST_CASE("FileAnalyticsDestination empty flush after released temp does not create output",
+          "[runtime][analytics][issue-656]") {
     TemporaryFile tmp(".jsonl");
     auto path = tmp.path();
     tmp.release();
@@ -252,7 +253,7 @@ TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runti
 }
 
 TEST_CASE("FileAnalyticsDestination keeps buffered events when open fails",
-          "[runtime][analytics][coverage][phase3-batch742]") {
+          "[runtime][analytics]") {
     auto root = std::filesystem::temp_directory_path() / "pulp_analytics_missing_parent_742";
     auto path = root / "events.jsonl";
     std::filesystem::remove_all(root);
@@ -318,7 +319,7 @@ TEST_CASE("FileAnalyticsDestination appends multiple flushes", "[runtime][analyt
 }
 
 TEST_CASE("FileAnalyticsDestination omits props object for empty properties",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -337,7 +338,7 @@ TEST_CASE("FileAnalyticsDestination omits props object for empty properties",
 }
 
 TEST_CASE("FileAnalyticsDestination buffers below auto flush threshold",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -363,7 +364,7 @@ TEST_CASE("FileAnalyticsDestination buffers below auto flush threshold",
 }
 
 TEST_CASE("FileAnalyticsDestination second flush does not duplicate events",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());
 
@@ -382,7 +383,7 @@ TEST_CASE("FileAnalyticsDestination second flush does not duplicate events",
 }
 
 TEST_CASE("FileAnalyticsDestination retains buffered events after open failure",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     auto dir = std::filesystem::temp_directory_path() / "pulp_analytics_dir_dest";
     std::filesystem::remove_all(dir);
     std::filesystem::create_directory(dir);
@@ -420,7 +421,7 @@ TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runti
 }
 
 TEST_CASE("FileAnalyticsDestination failed flush leaves no file at directory path",
-          "[runtime][analytics][coverage]") {
+          "[runtime][analytics]") {
     auto dir = std::filesystem::temp_directory_path() / "pulp-analytics-dir-dest";
     std::filesystem::remove_all(dir);
     std::filesystem::create_directories(dir);
@@ -487,7 +488,7 @@ TEST_CASE("WidgetTracker forwards expected event names and properties",
 }
 
 TEST_CASE("Analytics forwards simple log with empty property map",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     auto events = std::make_shared<std::vector<AnalyticsEvent>>();
     auto flushes = std::make_shared<int>(0);
 
@@ -502,7 +503,7 @@ TEST_CASE("Analytics forwards simple log with empty property map",
 }
 
 TEST_CASE("Analytics ignores null destinations",
-          "[runtime][analytics][coverage][phase3]") {
+          "[runtime][analytics]") {
     auto events = std::make_shared<std::vector<AnalyticsEvent>>();
     auto flushes = std::make_shared<int>(0);
 
@@ -520,7 +521,7 @@ TEST_CASE("Analytics ignores null destinations",
 }
 
 TEST_CASE("Analytics disabled widget tracker calls skip destinations",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     auto events = std::make_shared<std::vector<AnalyticsEvent>>();
     auto flushes = std::make_shared<int>(0);
 
@@ -537,7 +538,7 @@ TEST_CASE("Analytics disabled widget tracker calls skip destinations",
 }
 
 TEST_CASE("WidgetTracker preserves empty identifiers and values",
-          "[runtime][analytics][coverage][phase3-large]") {
+          "[runtime][analytics]") {
     auto events = std::make_shared<std::vector<AnalyticsEvent>>();
     auto flushes = std::make_shared<int>(0);
 

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -26,7 +26,7 @@ TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
 }
 
 TEST_CASE("SHA-256 pointer hex overload handles empty input",
-          "[crypto][sha256][coverage][phase3-batch742]") {
+          "[crypto][sha256]") {
     auto digest = sha256(nullptr, 0);
     auto hex = sha256_hex(nullptr, 0);
 
@@ -35,7 +35,7 @@ TEST_CASE("SHA-256 pointer hex overload handles empty input",
 }
 
 TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
-          "[crypto][sha256][coverage][issue-641]") {
+          "[crypto][sha256][issue-641]") {
     const std::vector<uint8_t> data = {'a', 'b', 'c', 0x00, 'd', 'e', 'f'};
 
     auto digest = sha256(data.data(), data.size());
@@ -50,7 +50,7 @@ TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
 
 // ── SHA-1 ───────────────────────────────────────────────────────────────
 
-TEST_CASE("SHA-1 empty string", "[crypto][sha1][coverage][phase3-batch742]") {
+TEST_CASE("SHA-1 empty string", "[crypto][sha1]") {
     const std::vector<uint8_t> expected = {
         0xda, 0x39, 0xa3, 0xee, 0x5e, 0x6b, 0x4b, 0x0d, 0x32, 0x55,
         0xbf, 0xef, 0x95, 0x60, 0x18, 0x90, 0xaf, 0xd8, 0x07, 0x09,
@@ -69,7 +69,7 @@ TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     REQUIRE(digest == expected);
 }
 
-TEST_CASE("SHA-1 empty input matches known digest", "[crypto][sha1][coverage]") {
+TEST_CASE("SHA-1 empty input matches known digest", "[crypto][sha1]") {
     const std::vector<uint8_t> expected = {
         0xda, 0x39, 0xa3, 0xee, 0x5e, 0x6b, 0x4b, 0x0d, 0x32, 0x55,
         0xbf, 0xef, 0x95, 0x60, 0x18, 0x90, 0xaf, 0xd8, 0x07, 0x09,
@@ -79,7 +79,7 @@ TEST_CASE("SHA-1 empty input matches known digest", "[crypto][sha1][coverage]") 
 }
 
 TEST_CASE("SHA-1 pointer overload preserves embedded NUL bytes",
-          "[crypto][sha1][coverage][issue-641]") {
+          "[crypto][sha1][issue-641]") {
     const std::vector<uint8_t> data = {'w', 's', 0x00, 'k', 'e', 'y'};
     const std::vector<uint8_t> expected = {
         0xb1, 0x24, 0x2e, 0x4b, 0x0c, 0x53, 0x4d, 0x49, 0x0f, 0x5e,
@@ -102,7 +102,7 @@ TEST_CASE("MD5 known value", "[crypto][md5]") {
 }
 
 TEST_CASE("MD5 pointer overload handles empty input",
-          "[crypto][md5][coverage][phase3-batch742]") {
+          "[crypto][md5]") {
     const std::vector<uint8_t> expected = {
         0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
         0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e,
@@ -112,7 +112,7 @@ TEST_CASE("MD5 pointer overload handles empty input",
 }
 
 TEST_CASE("MD5 binary data returns raw digest bytes",
-          "[crypto][md5][coverage][issue-641]") {
+          "[crypto][md5][issue-641]") {
     const std::vector<uint8_t> data = {0x00, 0xff, 0x10, 0x20, 0x00};
     const std::vector<uint8_t> expected = {
         0x96, 0x26, 0x6b, 0xae, 0xb1, 0xeb, 0x57, 0x35,
@@ -123,7 +123,7 @@ TEST_CASE("MD5 binary data returns raw digest bytes",
 }
 
 TEST_CASE("MD5 hex string_view preserves embedded NUL bytes",
-          "[crypto][md5][coverage][phase3-large]") {
+          "[crypto][md5]") {
     std::string payload = "abc";
     payload.push_back('\0');
     payload += "def";
@@ -172,7 +172,7 @@ TEST_CASE("AES empty plaintext", "[crypto][aes]") {
 }
 
 TEST_CASE("AES binary plaintext preserves embedded zero bytes",
-          "[crypto][aes][coverage][phase3]") {
+          "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
     std::memset(key, 0x33, 32);
@@ -189,7 +189,7 @@ TEST_CASE("AES binary plaintext preserves embedded zero bytes",
 }
 
 TEST_CASE("AES one-byte plaintext round-trips with padding",
-          "[crypto][aes][coverage][phase3-batch742]") {
+          "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
     std::memset(key, 0x11, 32);
@@ -206,7 +206,7 @@ TEST_CASE("AES one-byte plaintext round-trips with padding",
 }
 
 TEST_CASE("AES exact block plaintext adds and removes full padding block",
-          "[crypto][aes][coverage][issue-641]") {
+          "[crypto][aes][issue-641]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
     std::memset(key, 0x21, 32);
@@ -247,7 +247,7 @@ TEST_CASE("AES decrypt rejects non-block-aligned ciphertext", "[crypto][aes]") {
 }
 
 TEST_CASE("AES decrypt rejects empty ciphertext",
-          "[crypto][aes][coverage][phase3]") {
+          "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
 
@@ -256,7 +256,7 @@ TEST_CASE("AES decrypt rejects empty ciphertext",
 }
 
 TEST_CASE("AES decrypt rejects explicit zero padding byte",
-          "[crypto][aes][coverage][phase3-batch742]") {
+          "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
 
@@ -271,7 +271,7 @@ TEST_CASE("AES decrypt rejects explicit zero padding byte",
 }
 
 TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
-          "[crypto][aes][coverage][issue-641]") {
+          "[crypto][aes][issue-641]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
     std::memset(key, 0x5c, 32);
@@ -289,7 +289,7 @@ TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
 }
 
 TEST_CASE("AES decrypt rejects inconsistent PKCS7 padding bytes",
-          "[crypto][aes][coverage]") {
+          "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
 
@@ -326,7 +326,7 @@ TEST_CASE("Machine ID is non-empty", "[crypto][machine_id]") {
 }
 
 TEST_CASE("Machine ID is lowercase hexadecimal",
-          "[crypto][machine_id][coverage][phase3]") {
+          "[crypto][machine_id]") {
     auto id = machine_id();
     REQUIRE(id.size() == 64);
     REQUIRE(std::all_of(id.begin(), id.end(), [](unsigned char c) {

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -95,7 +95,7 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
     }
 }
 
-TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][identity][coverage][issue-656]") {
+TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][identity][issue-656]") {
     auto low = Uuid::from_string("00000000-0000-0000-0000-000000000001");
     auto high = Uuid::from_string("00000000-0000-0000-0000-000000000002");
 
@@ -110,13 +110,13 @@ TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][ide
 }
 
 TEST_CASE("Uuid parsing rejects malformed dashed layout",
-          "[runtime][identity][coverage][issue-656]") {
+          "[runtime][identity][issue-656]") {
     auto parsed = Uuid::from_string("0011223344556677-8899-aabb-ccdd-eeff");
     REQUIRE(parsed.is_nil());
 }
 
 TEST_CASE("Uuid parsing rejects dashed strings with empty groups",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     REQUIRE(Uuid::from_string("-0112233-4455-6677-8899-aabbccddeeff").is_nil());
     REQUIRE(Uuid::from_string("00112233--455-6677-8899-aabbccddeeff").is_nil());
     REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddee-").is_nil());
@@ -133,7 +133,7 @@ TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
 }
 
 TEST_CASE("Uuid parsing rejects short, long, and whitespace-padded values",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     REQUIRE(Uuid::from_string("").is_nil());
     REQUIRE(Uuid::from_string("00112233445566778899aabbccddee").is_nil());
     REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
@@ -143,7 +143,7 @@ TEST_CASE("Uuid parsing rejects short, long, and whitespace-padded values",
 }
 
 TEST_CASE("Uuid formatting preserves leading zero bytes",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     Uuid id;
     id.hi = 0x0001020304050607ULL;
     id.lo = 0x08090a0b0c0d0e0fULL;
@@ -223,7 +223,7 @@ TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issu
 }
 
 TEST_CASE("Typed identity nil strings use canonical uuid format",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     REQUIRE(SessionId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
     REQUIRE(RunId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
     REQUIRE(ObjectId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
@@ -231,7 +231,7 @@ TEST_CASE("Typed identity nil strings use canonical uuid format",
 }
 
 TEST_CASE("Typed identity wrappers compare and hash deterministic values",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     auto first = ObjectId::from_string("00000000-0000-0000-0000-000000000001");
     auto second = ObjectId::from_string("00000000-0000-0000-0000-000000000002");
 
@@ -251,7 +251,7 @@ TEST_CASE("Typed identity wrappers compare and hash deterministic values",
 }
 
 TEST_CASE("Typed transient identity wrappers hash deterministic values",
-          "[runtime][identity][codecov]") {
+          "[runtime][identity]") {
     SessionId session{Uuid::from_string("10000000-0000-0000-0000-000000000001")};
     RunId run{Uuid::from_string("20000000-0000-0000-0000-000000000002")};
     CorrelationId correlation{Uuid::from_string("30000000-0000-0000-0000-000000000003")};
@@ -278,7 +278,7 @@ TEST_CASE("Typed transient identity wrappers hash deterministic values",
 }
 
 TEST_CASE("Transient identity wrappers hash deterministic values",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     const Uuid first_uuid{0x1000, 0x2000};
     const Uuid second_uuid{0x1000, 0x2001};
     const RunId first_run{first_uuid};
@@ -302,7 +302,7 @@ TEST_CASE("Transient identity wrappers hash deterministic values",
 }
 
 TEST_CASE("Typed identity generated strings parse back where supported",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     auto object = ObjectId::generate();
 
     REQUIRE_FALSE(object.is_nil());
@@ -310,7 +310,7 @@ TEST_CASE("Typed identity generated strings parse back where supported",
 }
 
 TEST_CASE("Typed transient identities hash and stringify nil values",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     std::unordered_set<SessionId> sessions;
     std::unordered_set<RunId> runs;
     std::unordered_set<CorrelationId> correlations;
@@ -331,7 +331,7 @@ TEST_CASE("Typed transient identities hash and stringify nil values",
 }
 
 TEST_CASE("EventEnvelope defaults are nil and empty before attribution",
-          "[runtime][identity][coverage]") {
+          "[runtime][identity]") {
     EventEnvelope env;
 
     REQUIRE(env.timestamp == 0.0);

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -30,7 +30,7 @@ public:
 } // namespace
 
 TEST_CASE("MessageChannel default text send uses binary send",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     BinaryOnlyMessageChannel channel;
     MessageChannel& base = channel;
 
@@ -80,7 +80,7 @@ TEST_CASE("MemoryMessageChannel delivers text payloads and as_text views",
 }
 
 TEST_CASE("MemoryMessageChannel delivers empty text and binary messages",
-          "[runtime][message_channel][codecov]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<Message> received;
@@ -116,7 +116,7 @@ TEST_CASE("MemoryMessageChannel replaces message callbacks",
 }
 
 TEST_CASE("MemoryMessageChannel clears message callbacks",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int deliveries = 0;
@@ -139,7 +139,7 @@ TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
 }
 
 TEST_CASE("MemoryMessageChannel delivers zero-length binary and text payloads",
-          "[runtime][message_channel][coverage][issue-641]") {
+          "[runtime][message_channel][issue-641]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<Message> received;
@@ -160,7 +160,7 @@ TEST_CASE("MemoryMessageChannel delivers zero-length binary and text payloads",
 }
 
 TEST_CASE("MemoryMessageChannel rejects nonempty null binary sends",
-          "[runtime][message_channel][codecov]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int deliveries = 0;
@@ -175,7 +175,7 @@ TEST_CASE("MemoryMessageChannel rejects nonempty null binary sends",
 }
 
 TEST_CASE("MemoryMessageChannel accepts empty null binary sends",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<Message> received;
@@ -194,7 +194,7 @@ TEST_CASE("MemoryMessageChannel accepts empty null binary sends",
 }
 
 TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",
-          "[runtime][message_channel][coverage][issue-641]") {
+          "[runtime][message_channel][issue-641]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int calls = 0;
@@ -210,7 +210,7 @@ TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",
 }
 
 TEST_CASE("MemoryMessageChannel text views preserve embedded NUL bytes",
-          "[runtime][message_channel][coverage][issue-641]") {
+          "[runtime][message_channel][issue-641]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::string text = "prefix";
@@ -254,7 +254,7 @@ TEST_CASE("MemoryMessageChannel close is peer-wide and idempotent",
 }
 
 TEST_CASE("MemoryMessageChannel replaces close callbacks and leaves error inert",
-          "[runtime][message_channel][codecov]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int first_left_closed = 0;
@@ -294,7 +294,7 @@ TEST_CASE("MemoryMessageChannel peer destruction closes the survivor",
 }
 
 TEST_CASE("MemoryMessageChannel close callback can send no further messages",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int left_closed = 0;
@@ -313,7 +313,7 @@ TEST_CASE("MemoryMessageChannel close callback can send no further messages",
 }
 
 TEST_CASE("MemoryMessageChannel sender observes peer callback replacement during delivery",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int first_calls = 0;
@@ -333,7 +333,7 @@ TEST_CASE("MemoryMessageChannel sender observes peer callback replacement during
 }
 
 TEST_CASE("MemoryMessageChannel supports reentrant replies during delivery",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> seen;
@@ -350,7 +350,7 @@ TEST_CASE("MemoryMessageChannel supports reentrant replies during delivery",
 }
 
 TEST_CASE("MemoryMessageChannel self close does not invoke a late replacement callback",
-          "[runtime][message_channel][coverage]") {
+          "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int closed = 0;

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -406,7 +406,7 @@ TEST_CASE("PresetManager refresh resets cache", "[state][preset]") {
 }
 
 TEST_CASE("PresetManager navigation returns false with no presets",
-          "[state][preset][codecov]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-empty-navigation");
     StateStore store;
     setup_test_store(store);
@@ -474,7 +474,7 @@ TEST_CASE("PresetManager load skips malformed parameter values", "[state][preset
 }
 
 TEST_CASE("PresetManager load skips parameter keys with missing value separators",
-          "[state][preset][coverage]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-load-missing-separator");
     StateStore store;
     setup_test_store(store);
@@ -494,7 +494,7 @@ TEST_CASE("PresetManager load skips parameter keys with missing value separators
 }
 
 TEST_CASE("PresetManager load accepts parameter values that end at EOF",
-          "[state][preset][coverage]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-load-terminal-value");
     StateStore store;
     setup_test_store(store);
@@ -533,7 +533,7 @@ TEST_CASE("PresetManager load rejects partial numeric parameter values", "[state
 }
 
 TEST_CASE("PresetManager load clamps out-of-range parameter values",
-          "[state][preset][coverage][issue-647]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");
     StateStore store;
     setup_test_store(store);
@@ -550,7 +550,7 @@ TEST_CASE("PresetManager load clamps out-of-range parameter values",
 }
 
 TEST_CASE("PresetManager discovery ignores non-json files and reports nested folders",
-          "[state][preset][codecov]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-discovery-filter");
     StateStore store;
     setup_test_store(store);
@@ -572,7 +572,7 @@ TEST_CASE("PresetManager discovery ignores non-json files and reports nested fol
 }
 
 TEST_CASE("PresetManager load via PresetInfo and rename preserves other current names",
-          "[state][preset][codecov]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-info-load-rename");
     StateStore store;
     setup_test_store(store);
@@ -628,7 +628,7 @@ TEST_CASE("PresetManager save scans subfolders and reports list changes", "[stat
 }
 
 TEST_CASE("PresetManager user preset scan ignores non-json files and records nested folders",
-          "[state][preset][coverage][issue-647]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-scan-filter");
     StateStore store;
     setup_test_store(store);
@@ -681,7 +681,7 @@ TEST_CASE("PresetManager rename and delete update current preset and callbacks",
 }
 
 TEST_CASE("PresetManager delete missing user preset is inert",
-          "[state][preset][coverage][issue-647]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-delete-missing");
     StateStore store;
     setup_test_store(store);
@@ -750,7 +750,7 @@ TEST_CASE("PresetManager navigation wraps sorted presets and handles missing cur
 }
 
 TEST_CASE("PresetManager navigation on empty preset list returns false",
-          "[state][preset][coverage][issue-647]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-navigation-empty");
     StateStore store;
     setup_test_store(store);
@@ -762,7 +762,7 @@ TEST_CASE("PresetManager navigation on empty preset list returns false",
 }
 
 TEST_CASE("PresetManager saved file includes metadata and parameter entries",
-          "[state][preset][coverage][large]") {
+          "[state][preset][large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-metadata");
     StateStore store;
     setup_test_store(store);
@@ -784,7 +784,7 @@ TEST_CASE("PresetManager saved file includes metadata and parameter entries",
 }
 
 TEST_CASE("PresetManager saving the same name overwrites the user preset",
-          "[state][preset][coverage][large]") {
+          "[state][preset][large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-overwrite");
     StateStore store;
     setup_test_store(store);
@@ -804,7 +804,7 @@ TEST_CASE("PresetManager saving the same name overwrites the user preset",
 }
 
 TEST_CASE("PresetManager direct path load reports stem in callback",
-          "[state][preset][coverage][large]") {
+          "[state][preset][large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-direct-load-callback");
     StateStore store;
     setup_test_store(store);
@@ -826,7 +826,7 @@ TEST_CASE("PresetManager direct path load reports stem in callback",
 }
 
 TEST_CASE("PresetManager import creates the user preset directory",
-          "[state][preset][coverage][large]") {
+          "[state][preset][large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-import-creates-dir");
     StateStore store;
     setup_test_store(store);
@@ -852,7 +852,7 @@ TEST_CASE("PresetManager import creates the user preset directory",
 }
 
 TEST_CASE("PresetManager import of duplicate destination preserves existing preset",
-          "[state][preset][coverage]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-import-duplicate");
     StateStore store;
     setup_test_store(store);
@@ -884,7 +884,7 @@ TEST_CASE("PresetManager import of duplicate destination preserves existing pres
 }
 
 TEST_CASE("PresetManager rename failure leaves current preset unchanged",
-          "[state][preset][coverage][large]") {
+          "[state][preset][large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-rename-missing-current");
     StateStore store;
     setup_test_store(store);

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -55,7 +55,7 @@ TEST_CASE("StateTree typed getters keep defaults for mismatched property types",
 }
 
 TEST_CASE("StateTree typed getters fall back on mismatched property types",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto tree = StateTree::create("test");
     tree->set("bool_value", true);
     tree->set("int_value", int64_t(9));
@@ -153,7 +153,7 @@ TEST_CASE("StateTree child access and removal ignore invalid indexes",
 }
 
 TEST_CASE("StateTree child removal ignores invalid inputs and clears parent",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     auto child = StateTree::create("child");
     auto stranger = StateTree::create("stranger");
@@ -200,7 +200,7 @@ TEST_CASE("StateTree insert at end and missing child pointer removal are stable"
 }
 
 TEST_CASE("StateTree child insertion clamps invalid indexes and skips null children",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     root->add_child(nullptr);
     root->insert_child(10, nullptr);
@@ -215,7 +215,7 @@ TEST_CASE("StateTree child insertion clamps invalid indexes and skips null child
 }
 
 TEST_CASE("StateTree reparenting detaches children from the old parent",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto old_parent = StateTree::create("old");
     auto new_parent = StateTree::create("new");
     auto sibling = StateTree::create("sibling");
@@ -244,7 +244,7 @@ TEST_CASE("StateTree reparenting detaches children from the old parent",
 }
 
 TEST_CASE("StateTree insert reparents children at the requested new index",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto old_parent = StateTree::create("old");
     auto new_parent = StateTree::create("new");
     auto first = StateTree::create("first");
@@ -266,7 +266,7 @@ TEST_CASE("StateTree insert reparents children at the requested new index",
 }
 
 TEST_CASE("StateTree child insertion listeners observe clamped indexes",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     std::vector<int> indexes;
     std::vector<std::string> names;
@@ -390,7 +390,7 @@ TEST_CASE("StateTree child listener removal stops callbacks", "[state][tree]") {
 }
 
 TEST_CASE("StateTree removing missing listener ids is a no-op",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     auto child = StateTree::create("child");
 
@@ -454,7 +454,7 @@ TEST_CASE("StateTree remove listener", "[state][tree]") {
 }
 
 TEST_CASE("StateTree remove notifies listeners with cleared value",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto tree = StateTree::create("test");
     tree->set("gain", 0.75);
 
@@ -479,7 +479,7 @@ TEST_CASE("StateTree remove notifies listeners with cleared value",
 }
 
 TEST_CASE("StateTree skips empty listeners",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     int property_count = 0;
     int added_count = 0;
@@ -582,7 +582,7 @@ TEST_CASE("StateTree JSON round-trip", "[state][tree][json]") {
 }
 
 TEST_CASE("StateTree JSON round-trip preserves escaped strings",
-          "[state][tree][json][coverage]") {
+          "[state][tree][json]") {
     auto root = StateTree::create(R"(preset "A")");
     root->set(R"(display\name)", std::string("Line 1\nLine \"2\" \\ tail"));
 
@@ -652,7 +652,7 @@ TEST_CASE("StateTree from_json skips unsupported properties and child values",
 }
 
 TEST_CASE("StateTree from_json ignores malformed members and children",
-          "[state][tree][json][coverage]") {
+          "[state][tree][json]") {
     auto non_object = StateTree::from_json("[]");
     REQUIRE(non_object == nullptr);
 
@@ -684,7 +684,7 @@ TEST_CASE("StateTree from_json ignores malformed members and children",
 }
 
 TEST_CASE("StateTree JSON keeps integer values available as doubles",
-          "[state][tree][json][coverage]") {
+          "[state][tree][json]") {
     auto result = StateTree::from_json(R"({
         "type": "numbers",
         "properties": {
@@ -702,7 +702,7 @@ TEST_CASE("StateTree JSON keeps integer values available as doubles",
 }
 
 TEST_CASE("StateTree JSON serialization skips explicit null properties",
-          "[state][tree][json][coverage]") {
+          "[state][tree][json]") {
     auto tree = StateTree::create("root");
     tree->set("nullable", PropertyValue{});
     tree->set("name", std::string("kept"));
@@ -748,7 +748,7 @@ TEST_CASE("StateTree deep copy rewires child parent pointers",
 }
 
 TEST_CASE("StateTree deep copy does not copy listeners",
-          "[state][tree][coverage]") {
+          "[state][tree]") {
     auto root = StateTree::create("root");
     auto child = StateTree::create("child");
     root->add_child(child);
@@ -828,7 +828,7 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
 }
 
 TEST_CASE("ObservableValue removing a missing listener keeps active listeners",
-          "[state][observable][coverage]") {
+          "[state][observable]") {
     ObservableValue<int> val(1);
     int old_value = 0;
     int new_value = 0;
@@ -869,7 +869,7 @@ TEST_CASE("ObservableValue assignment operator emits one change",
     REQUIRE(count == 1);
 }
 
-TEST_CASE("ObservableValue skips empty listeners", "[state][observable][coverage]") {
+TEST_CASE("ObservableValue skips empty listeners", "[state][observable]") {
     ObservableValue<int> val(1);
     int count = 0;
 
@@ -885,7 +885,7 @@ TEST_CASE("ObservableValue skips empty listeners", "[state][observable][coverage
 }
 
 TEST_CASE("ObservableValue removing an unknown listener is a no-op",
-          "[state][observable][coverage]") {
+          "[state][observable]") {
     ObservableValue<int> val(1);
     int count = 0;
     val.add_listener([&](const int&, const int&) { ++count; });
@@ -953,7 +953,7 @@ TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached
 }
 
 TEST_CASE("CachedProperty move of unbound property preserves cached value",
-          "[state][cached][coverage]") {
+          "[state][cached]") {
     CachedProperty<int64_t> size;
     size.set(256);
 
@@ -964,7 +964,7 @@ TEST_CASE("CachedProperty move of unbound property preserves cached value",
 }
 
 TEST_CASE("CachedProperty unbound refresh leaves the local cache unchanged",
-          "[state][cached][coverage]") {
+          "[state][cached]") {
     CachedProperty<std::string> label;
 
     REQUIRE_FALSE(label.is_bound());
@@ -988,7 +988,7 @@ TEST_CASE("CachedProperty ignores mismatched external updates",
 }
 
 TEST_CASE("CachedProperty destruction removes its StateTree listener",
-          "[state][cached][coverage]") {
+          "[state][cached]") {
     auto tree = StateTree::create("params");
     tree->set("gain", 0.25);
 
@@ -1011,7 +1011,7 @@ TEST_CASE("CachedProperty destruction removes its StateTree listener",
 }
 
 TEST_CASE("CachedProperty bool ignores mismatched refresh values",
-          "[state][cached][coverage][large]") {
+          "[state][cached][large]") {
     auto tree = StateTree::create("params");
     tree->set("enabled", true);
     CachedProperty<bool> enabled(tree, "enabled", false);
@@ -1028,7 +1028,7 @@ TEST_CASE("CachedProperty bool ignores mismatched refresh values",
 }
 
 TEST_CASE("CachedProperty int64 move tracks later tree updates",
-          "[state][cached][coverage][large]") {
+          "[state][cached][large]") {
     auto tree = StateTree::create("params");
     tree->set("voices", int64_t(8));
     CachedProperty<int64_t> voices(tree, "voices", 1);
@@ -1041,7 +1041,7 @@ TEST_CASE("CachedProperty int64 move tracks later tree updates",
 }
 
 TEST_CASE("CachedProperty int refresh preserves cache on incompatible values",
-          "[state][cached][coverage]") {
+          "[state][cached]") {
     auto tree = StateTree::create("params");
     CachedProperty<int64_t> count(tree, "count", 4);
 
@@ -1106,7 +1106,7 @@ TEST_CASE("StateTreeSynchroniser attach replaces the previous tree",
     REQUIRE(std::get<std::string>(deltas[0].value) == "recorded");
 }
 
-TEST_CASE("StateTreeSynchroniser records property removals", "[state][sync][coverage]") {
+TEST_CASE("StateTreeSynchroniser records property removals", "[state][sync]") {
     auto tree = StateTree::create("root");
     tree->set("name", std::string("Lead"));
 
@@ -1125,7 +1125,7 @@ TEST_CASE("StateTreeSynchroniser records property removals", "[state][sync][cove
 }
 
 TEST_CASE("StateTreeSynchroniser preserves explicit null property sets",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto tree = StateTree::create("root");
 
     StateTreeSynchroniser sync;
@@ -1162,7 +1162,7 @@ TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[s
 }
 
 TEST_CASE("StateTreeSynchroniser attach nullptr detaches existing listeners",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto tree = StateTree::create("root");
     StateTreeSynchroniser sync;
     sync.attach(tree);
@@ -1244,7 +1244,7 @@ TEST_CASE("StateTreeSynchroniser decode keeps complete prefix on truncated batch
 }
 
 TEST_CASE("StateTreeSynchroniser preserves negative child indexes in encoding",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     std::vector<SyncDelta> deltas = {
         {SyncDeltaType::ChildAdd, "root", "child", {}, -1},
         {SyncDeltaType::ChildRemove, "root", "", {}, -1},
@@ -1259,7 +1259,7 @@ TEST_CASE("StateTreeSynchroniser preserves negative child indexes in encoding",
 }
 
 TEST_CASE("StateTreeSynchroniser decode treats unknown value types as null",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     SyncDelta delta{SyncDeltaType::PropertySet, "root", "mystery", {}, -1};
     auto encoded = StateTreeSynchroniser::encode({delta});
     REQUIRE_FALSE(encoded.empty());
@@ -1273,7 +1273,7 @@ TEST_CASE("StateTreeSynchroniser decode treats unknown value types as null",
 }
 
 TEST_CASE("StateTreeSynchroniser decode rejects truncated typed values",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     const std::vector<SyncDelta> cases = {
         {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), -1},
         {SyncDeltaType::PropertySet, "root", "count", int64_t(42), -1},
@@ -1292,7 +1292,7 @@ TEST_CASE("StateTreeSynchroniser decode rejects truncated typed values",
 }
 
 TEST_CASE("StateTreeSynchroniser decode preserves negative child indexes",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     std::vector<SyncDelta> deltas = {
         {SyncDeltaType::ChildRemove, "root", "", {}, -1},
         {SyncDeltaType::ChildAdd, "root", "tail", {}, -2},
@@ -1309,7 +1309,7 @@ TEST_CASE("StateTreeSynchroniser decode preserves negative child indexes",
 }
 
 TEST_CASE("StateTreeSynchroniser decode rejects malformed delta framing",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto one_delta_prefix = [] {
         return std::vector<uint8_t>{1, 0, static_cast<uint8_t>(SyncDeltaType::PropertySet)};
     };
@@ -1371,7 +1371,7 @@ TEST_CASE("StateTreeSynchroniser decode rejects malformed delta framing",
 }
 
 TEST_CASE("StateTreeSynchroniser decode keeps available deltas when count is too large",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     SyncDelta delta{SyncDeltaType::PropertySet, "0", "gain", 0.75, -1};
     auto encoded = StateTreeSynchroniser::encode({delta});
     encoded[0] = 3;
@@ -1413,7 +1413,7 @@ TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state
 }
 
 TEST_CASE("StateTreeSynchroniser apply skips malformed and unreachable paths",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto root = StateTree::create("root");
     auto child = StateTree::create("child");
     root->add_child(child);
@@ -1443,7 +1443,7 @@ TEST_CASE("StateTreeSynchroniser apply skips malformed and unreachable paths",
 }
 
 TEST_CASE("StateTreeSynchroniser observes descendants of newly added subtrees",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto root = StateTree::create("root");
     auto bank = StateTree::create("bank");
     auto voice = StateTree::create("voice");
@@ -1469,7 +1469,7 @@ TEST_CASE("StateTreeSynchroniser observes descendants of newly added subtrees",
 }
 
 TEST_CASE("StateTreeSynchroniser detaches removed subtrees before later mutations",
-          "[state][sync][coverage]") {
+          "[state][sync]") {
     auto root = StateTree::create("root");
     auto child = StateTree::create("child");
     auto grandchild = StateTree::create("grandchild");


### PR DESCRIPTION
## Summary
- remove stale Catch2 selector provenance from state-tree, preset-manager, and runtime-support tests
- preserve semantic selectors and issue tags where they remain load-bearing
- rename the released-temp analytics empty-flush case so duplicate names do not rely on issue tags

## Validation
- RepoPrompt pre/post reviews clean, including exact diff review
- autoreview clean: no accepted/actionable findings reported
- git diff --check
- docs_noise_lint / version_bump_check / skill_sync_check
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- focused Release builds for affected targets
- focused selector runs for state-tree, preset-manager, analytics, identity, crypto, and memory-message-channel


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed Catch2 selector tags across state-tree and runtime support tests to remove stale provenance and standardize filtering. Kept meaningful `issue-xxx` tags and renamed one analytics test to avoid duplicate names.

- **Refactors**
  - Removed non-semantic tags (`coverage`, `phase3-*`, `large`) in state-tree, preset-manager, analytics, identity, crypto, and memory-message-channel tests.
  - Preserved load-bearing tags `[issue-641]`, `[issue-647]`, `[issue-656]`.
  - Renamed analytics test to “FileAnalyticsDestination empty flush after released temp does not create output” to ensure unique naming without tag reliance.

<sup>Written for commit 7b478fd7c7cbbf6dfab0db55d0f6031b8832d92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

