### PR TITLE
docs(test): refresh audio primitive selector tags

### DIFF
--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -115,7 +115,7 @@ TEST_CASE("BufferView clears external storage and supports const access",
 }
 
 TEST_CASE("BufferView supports int16 external storage",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     int16_t ch0[3] = {1, -2, 3};
     int16_t ch1[3] = {4, -5, 6};
     int16_t* ptrs[2] = {ch0, ch1};
@@ -175,7 +175,7 @@ TEST_CASE("Buffer resize and views expose contiguous channel storage",
 }
 
 TEST_CASE("Buffer supports non-float sample storage",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<int16_t> buffer(2, 3);
     buffer.channel(0)[0] = 12;
     buffer.channel(1)[2] = -34;
@@ -192,7 +192,7 @@ TEST_CASE("Buffer supports non-float sample storage",
 }
 
 TEST_CASE("Buffer resize from empty regrows zero-filled channels",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> buf(2, 3);
     buf.channel(0)[0] = 1.0f;
     buf.channel(1)[2] = -1.0f;
@@ -217,7 +217,7 @@ TEST_CASE("Buffer resize from empty regrows zero-filled channels",
 }
 
 TEST_CASE("Buffer zero-channel and zero-sample states remain well formed",
-          "[audio][buffer][codecov]") {
+          "[audio][buffer]") {
     Buffer<float> zero_channels(0, 8);
     REQUIRE(zero_channels.num_channels() == 0);
     REQUIRE(zero_channels.num_samples() == 8);
@@ -241,7 +241,7 @@ TEST_CASE("Buffer zero-channel and zero-sample states remain well formed",
 }
 
 TEST_CASE("Buffer can shrink to empty and grow with fresh zeroed storage",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> buffer(2, 2);
     buffer.channel(0)[0] = 1.0f;
     buffer.channel(1)[1] = -1.0f;
@@ -261,7 +261,7 @@ TEST_CASE("Buffer can shrink to empty and grow with fresh zeroed storage",
 }
 
 TEST_CASE("Buffer resize to smaller shape remaps channel spans",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> buffer(3, 5);
     buffer.channel(0)[4] = 0.25f;
     buffer.channel(2)[4] = -0.5f;
@@ -280,7 +280,7 @@ TEST_CASE("Buffer resize to smaller shape remaps channel spans",
 }
 
 TEST_CASE("Buffer copy owns independent channel storage",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> original(2, 3);
     original.channel(0)[0] = 1.0f;
     original.channel(1)[2] = 2.0f;
@@ -304,7 +304,7 @@ TEST_CASE("Buffer copy owns independent channel storage",
 }
 
 TEST_CASE("Buffer move refreshes channel pointers for the new owner",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> original(2, 2);
     original.channel(0)[0] = 0.25f;
     original.channel(1)[1] = -0.5f;
@@ -377,7 +377,7 @@ TEST_CASE("BufferView clear only zeros sliced sample range",
 }
 
 TEST_CASE("BufferView slice clamps starts past the end to empty views",
-          "[audio][buffer][slice][codecov]") {
+          "[audio][buffer][slice]") {
     Buffer<float> buffer(2, 4);
     for (std::size_t i = 0; i < 4; ++i) {
         buffer.channel(0)[i] = static_cast<float>(i + 1);
@@ -408,7 +408,7 @@ TEST_CASE("BufferView slice clamps starts past the end to empty views",
 }
 
 TEST_CASE("BufferView nested slices accumulate offsets into the same storage",
-          "[audio][buffer][slice][coverage]") {
+          "[audio][buffer][slice]") {
     Buffer<float> buffer(2, 8);
     for (std::size_t i = 0; i < 8; ++i) {
         buffer.channel(0)[i] = static_cast<float>(i);
@@ -431,7 +431,7 @@ TEST_CASE("BufferView nested slices accumulate offsets into the same storage",
 }
 
 TEST_CASE("BufferView zero-length slices keep channel offsets and clear as no-op",
-          "[audio][buffer][slice][coverage]") {
+          "[audio][buffer][slice]") {
     Buffer<float> buffer(2, 5);
     for (std::size_t i = 0; i < 5; ++i) {
         buffer.channel(0)[i] = static_cast<float>(i + 1);
@@ -453,7 +453,7 @@ TEST_CASE("BufferView zero-length slices keep channel offsets and clear as no-op
 }
 
 TEST_CASE("BufferView slices produced from const views still alias source storage",
-          "[audio][buffer][slice][coverage]") {
+          "[audio][buffer][slice]") {
     Buffer<float> buffer(1, 4);
     buffer.channel(0)[0] = 1.0f;
     buffer.channel(0)[1] = 2.0f;
@@ -477,7 +477,7 @@ TEST_CASE("BufferView slices produced from const views still alias source storag
 }
 
 TEST_CASE("Buffer self assignment preserves storage and channel pointers",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> buffer(2, 3);
     buffer.channel(0)[1] = 0.125f;
     buffer.channel(1)[2] = -0.25f;
@@ -504,7 +504,7 @@ TEST_CASE("Buffer self assignment preserves storage and channel pointers",
 }
 
 TEST_CASE("Buffer rejects dimensions that overflow sample storage",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     const auto max = std::numeric_limits<std::size_t>::max();
     REQUIRE_THROWS_AS((Buffer<float>(2, max)), std::length_error);
 
@@ -522,7 +522,7 @@ TEST_CASE("Buffer rejects dimensions that overflow sample storage",
 }
 
 TEST_CASE("Buffer move leaves source empty and rebinds destination views",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> source(2, 3);
     source.channel(0)[2] = 0.75f;
     source.channel(1)[0] = -0.5f;
@@ -551,7 +551,7 @@ TEST_CASE("Buffer move leaves source empty and rebinds destination views",
 }
 
 TEST_CASE("AudioFileData reports shape from first channel",
-          "[audio][file][codecov]") {
+          "[audio][file]") {
     AudioFileData empty;
     REQUIRE(empty.sample_rate == 0);
     REQUIRE(empty.num_channels() == 0);
@@ -574,7 +574,7 @@ TEST_CASE("AudioFileData reports shape from first channel",
 }
 
 TEST_CASE("Device metadata defaults and custom configs are stable",
-          "[audio][device][codecov]") {
+          "[audio][device]") {
     DeviceInfo info;
     REQUIRE(info.id.empty());
     REQUIRE(info.name.empty());
@@ -605,7 +605,7 @@ TEST_CASE("Device metadata defaults and custom configs are stable",
 }
 
 TEST_CASE("AudioSystem default device-change callback is snapshot safe",
-          "[audio][device][coverage]") {
+          "[audio][device]") {
     class DummyAudioSystem final : public AudioSystem {
     public:
         std::vector<DeviceInfo> enumerate_devices() override { return {}; }
@@ -654,7 +654,7 @@ TEST_CASE("AudioSystem default device-change callback is snapshot safe",
 }
 
 TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
-          "[audio][load][coverage]") {
+          "[audio][load]") {
     AudioProcessLoadMeasurer measurer;
 
     measurer.begin(0, 48000.0f);
@@ -669,7 +669,7 @@ TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
 }
 
 TEST_CASE("AudioProcessLoadMeasurer rejects non-finite timing budgets",
-          "[audio][load][coverage]") {
+          "[audio][load]") {
     AudioProcessLoadMeasurer measurer;
 
     measurer.begin(64, std::numeric_limits<float>::infinity());
@@ -684,7 +684,7 @@ TEST_CASE("AudioProcessLoadMeasurer rejects non-finite timing budgets",
 }
 
 TEST_CASE("AudioProcessLoadMeasurer clamps smoothing and resets peak load",
-          "[audio][load][coverage]") {
+          "[audio][load]") {
     AudioProcessLoadMeasurer measurer;
 
     measurer.set_smoothing(-1.0f);
@@ -710,7 +710,7 @@ TEST_CASE("AudioProcessLoadMeasurer clamps smoothing and resets peak load",
 }
 
 TEST_CASE("CallbackContext defaults and sample position remain explicit",
-          "[audio][device][codecov]") {
+          "[audio][device]") {
     CallbackContext empty;
     REQUIRE(empty.sample_rate == 0.0);
     REQUIRE(empty.buffer_size == 0);
@@ -727,7 +727,7 @@ TEST_CASE("CallbackContext defaults and sample position remain explicit",
 }
 
 TEST_CASE("AudioCallback receives stable context and writable output views",
-          "[audio][device][codecov]") {
+          "[audio][device]") {
     CallbackContext defaults;
     REQUIRE(defaults.sample_rate == 0.0);
     REQUIRE(defaults.buffer_size == 0);
@@ -870,7 +870,7 @@ TEST_CASE("ChannelSet immersive layout preserves documented speaker order",
 }
 
 TEST_CASE("Buffer resize handles type changes and preserves new shape",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<double> buf(3, 2);
     buf.channel(0)[0] = 1.0;
     buf.channel(1)[1] = -2.0;
@@ -891,7 +891,7 @@ TEST_CASE("Buffer resize handles type changes and preserves new shape",
 }
 
 TEST_CASE("Buffer resize through empty shapes rebuilds channel pointers",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     Buffer<float> buf(2, 3);
     buf.channel(0)[0] = 1.0f;
     buf.channel(1)[2] = -1.0f;
@@ -921,7 +921,7 @@ TEST_CASE("Buffer resize through empty shapes rebuilds channel pointers",
 }
 
 TEST_CASE("BufferView supports zero-sample clears without touching channel pointers",
-          "[audio][buffer][coverage]") {
+          "[audio][buffer]") {
     float left = 1.0f;
     float right = -1.0f;
     float* ptrs[2] = {&left, &right};
@@ -939,7 +939,7 @@ TEST_CASE("BufferView supports zero-sample clears without touching channel point
 }
 
 TEST_CASE("ChannelSet discrete layouts compare by speaker map not display name",
-          "[audio][channel-set][coverage]") {
+          "[audio][channel-set]") {
     auto named = ChannelSet::discrete(3);
     auto renamed = named;
     renamed.name = "Three unnamed channels";
@@ -950,7 +950,7 @@ TEST_CASE("ChannelSet discrete layouts compare by speaker map not display name",
 }
 
 TEST_CASE("ChannelSet speaker names cover top and discrete positions",
-          "[audio][channel-set][coverage]") {
+          "[audio][channel-set]") {
     REQUIRE(speaker_name(Speaker::TopFrontLeft) == "Top Front Left");
     REQUIRE(speaker_name(Speaker::TopFrontRight) == "Top Front Right");
     REQUIRE(speaker_name(Speaker::TopBackLeft) == "Top Back Left");
@@ -960,7 +960,7 @@ TEST_CASE("ChannelSet speaker names cover top and discrete positions",
 }
 
 TEST_CASE("ChannelSet unsupported surround counts fall back to discrete layouts",
-          "[audio][channel-set][coverage]") {
+          "[audio][channel-set]") {
     for (auto channels : {7u, 9u, 10u, 11u}) {
         auto layout = ChannelSet::from_channel_count(channels);
         CAPTURE(channels);

--- a/test/test_audio_contracts.cpp
+++ b/test/test_audio_contracts.cpp
@@ -2,7 +2,7 @@
 // example plugins (PulpGain effect + PulpTone instrument here; PulpEffect
 // lives in test_audio_contracts_effect.cpp because pulp_gain.hpp and
 // pulp_effect.hpp define colliding unscoped enumerators — same reason the
-// golden suites are split). Slice 3 acceptance: a new effect copies one of
+// golden suites are split). Acceptance: a new effect copies one of
 // these fixtures; failures name the contract that broke.
 //
 // Analyzer Determinism Contract (uniform for every contract in this TU):

--- a/test/test_audio_edge_cases.cpp
+++ b/test/test_audio_edge_cases.cpp
@@ -68,7 +68,7 @@ void process_once(pulp::format::HeadlessHost& host,
 }  // namespace
 
 TEST_CASE("Audio frame fill clamps partial reads and preserves valid samples",
-          "[audio][edges][frame-fill][codecov]") {
+          "[audio][edges][frame-fill]") {
     float buffer[] = {
         1.0f, 2.0f,
         3.0f, 4.0f,

--- a/test/test_audio_excerpt.cpp
+++ b/test/test_audio_excerpt.cpp
@@ -286,7 +286,7 @@ TEST_CASE("AudioSubsectionReader zero-length ranges retain source shape",
 }
 
 TEST_CASE("AudioSubsectionReader ignores invalid read destinations",
-          "[audio][subsection][codecov]") {
+          "[audio][subsection]") {
     AudioFileData audio;
     audio.sample_rate = 48000;
     audio.channels = {{0.0f, 0.5f}, {1.0f, 1.5f}};
@@ -301,7 +301,7 @@ TEST_CASE("AudioSubsectionReader ignores invalid read destinations",
 }
 
 TEST_CASE("AudioSubsectionReader zero-fills ragged source channels",
-          "[audio][subsection][codecov]") {
+          "[audio][subsection]") {
     AudioFileData audio;
     audio.sample_rate = 48000;
     audio.channels = {

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -993,7 +993,7 @@ TEST_CASE("MemoryMappedAudioReader rejects invalid destinations before decoding"
 }
 
 TEST_CASE("MemoryMappedAudioReader reopens files and clamps destination channels",
-          "[audio][file][mmap][codecov]") {
+          "[audio][file][mmap]") {
     auto stereo_path = unique_temp_audio_path("_mmap_reopen_stereo.wav");
     auto mono_path = unique_temp_audio_path("_mmap_reopen_mono.wav");
     std::filesystem::remove(stereo_path);
@@ -1521,7 +1521,7 @@ TEST_CASE("FormatRegistry rejects malformed compressed files through built-in re
 }
 
 TEST_CASE("FormatRegistry reads a valid MP3 fixture through the built-in reader",
-          "[audio][file][registry][codecov]") {
+          "[audio][file][registry]") {
     auto mp3_path = unique_temp_audio_path("_valid.MP3");
     write_base64_audio_fixture(
         mp3_path,
@@ -1796,7 +1796,7 @@ TEST_CASE("FormatRegistry dispatches custom readers and writers through normaliz
 }
 
 TEST_CASE("FormatRegistry keeps the first custom handler for duplicate extensions",
-          "[audio][file][registry][codecov]") {
+          "[audio][file][registry]") {
     auto& registry = FormatRegistry::instance();
     auto first = std::make_shared<RegistryProbeState>();
     auto second = std::make_shared<RegistryProbeState>();

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -93,7 +93,7 @@ TEST_CASE("AudioFocusRegistry: token move transfers ownership",
 }
 
 TEST_CASE("AudioFocusRegistry: move construction empties source token",
-          "[audio][focus][coverage]") {
+          "[audio][focus]") {
     AudioFocusRegistry::instance().reset_for_test();
     int count = 0;
     auto source = AudioFocusRegistry::instance().subscribe(
@@ -129,7 +129,7 @@ TEST_CASE("AudioFocusRegistry: move assignment replaces an existing subscription
 }
 
 TEST_CASE("AudioFocusRegistry: token self move assignment preserves subscription",
-          "[audio][focus][coverage]") {
+          "[audio][focus]") {
     AudioFocusRegistry::instance().reset_for_test();
     int count = 0;
     auto token = AudioFocusRegistry::instance().subscribe(
@@ -201,7 +201,7 @@ TEST_CASE("AudioFocusRegistry: multiple subscribers all receive the signal",
 }
 
 TEST_CASE("AudioFocusRegistry: subscribers added during publish wait for next signal",
-          "[audio][focus][coverage]") {
+          "[audio][focus]") {
     AudioFocusRegistry::instance().reset_for_test();
     int first_count = 0;
     int second_count = 0;
@@ -297,7 +297,7 @@ TEST_CASE("AudioFocusRegistry: reset_for_test clears subscribers and state",
 }
 
 TEST_CASE("AudioFocusRegistry: stale tokens cannot unsubscribe post-reset subscribers",
-          "[audio][focus][coverage]") {
+          "[audio][focus]") {
     AudioFocusRegistry::instance().reset_for_test();
 
     int stale_count = 0;
@@ -329,7 +329,7 @@ TEST_CASE("AudioFocusRegistry: publish with no subscribers still updates state",
 }
 
 TEST_CASE("AudioFocusRegistry: subscriber added during publish waits for next signal",
-          "[audio][focus][coverage][large]") {
+          "[audio][focus][large]") {
     AudioFocusRegistry::instance().reset_for_test();
 
     std::vector<AudioFocusState> first_seen;

--- a/test/test_audio_thumbnail.cpp
+++ b/test/test_audio_thumbnail.cpp
@@ -321,11 +321,7 @@ TEST_CASE("AudioThumbnailCache keeps distinct samples-per-peak entries",
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// WaveformView integration smoke
-// ─────────────────────────────────────────────────────────────────────────
-
-// ─────────────────────────────────────────────────────────────────────────
-// On-disk persistence (item 6.12 follow-up)
+// On-disk persistence
 // ─────────────────────────────────────────────────────────────────────────
 
 namespace {
@@ -439,7 +435,7 @@ TEST_CASE("deserialize_thumbnail rejects bad magic / truncated blobs",
                                         wrong_version.size()).has_value());
 }
 
-TEST_CASE("AudioPeak clamps serialized display ranges", "[audio][thumbnail][coverage]") {
+TEST_CASE("AudioPeak clamps serialized display ranges", "[audio][thumbnail]") {
     const auto clipped = AudioPeak::from_range(-2.0f, 2.0f);
     REQUIRE(clipped.min_q7 == -127);
     REQUIRE(clipped.max_q7 == 127);
@@ -454,7 +450,7 @@ TEST_CASE("AudioPeak clamps serialized display ranges", "[audio][thumbnail][cove
 }
 
 TEST_CASE("AudioThumbnail sanitizes empty resolution and non-finite sample windows",
-          "[audio][thumbnail][coverage]") {
+          "[audio][thumbnail]") {
     auto data = make_sine(48000, 8, 1, 100.0);
     REQUIRE(AudioThumbnail::build_from_buffer(data, 0).empty());
 
@@ -473,7 +469,7 @@ TEST_CASE("AudioThumbnail sanitizes empty resolution and non-finite sample windo
 }
 
 TEST_CASE("AudioThumbnail::render_min_max guards empty and folded requests",
-          "[audio][thumbnail][coverage]") {
+          "[audio][thumbnail]") {
     AudioThumbnail empty;
     float scratch[4] = {};
     REQUIRE(empty.best_level_for(128) == 0);
@@ -500,7 +496,7 @@ TEST_CASE("AudioThumbnail::render_min_max guards empty and folded requests",
 }
 
 TEST_CASE("deserialize_thumbnail rejects malformed structural headers",
-          "[audio][thumbnail][persist][coverage]") {
+          "[audio][thumbnail][persist]") {
     const auto data = make_sine(44100, 1024, 1, 110.0);
     auto thumbnail = AudioThumbnail::build_from_buffer(data, 64);
     const auto valid = serialize_thumbnail(thumbnail);
@@ -528,7 +524,7 @@ TEST_CASE("deserialize_thumbnail rejects malformed structural headers",
 }
 
 TEST_CASE("AudioThumbnailCache handles zero capacity, null inserts, and replacement",
-          "[audio][thumbnail][cache][coverage]") {
+          "[audio][thumbnail][cache]") {
     AudioThumbnailCache cache(0);
     REQUIRE(cache.capacity() == 1);
     REQUIRE(cache.size() == 0);

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -171,7 +171,7 @@ TEST_CASE("audio model registry resolves known models and checkpoint URLs",
 }
 
 TEST_CASE("audio model registry preserves direct URLs and rejects incomplete refs",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     REQUIRE(resolve_checkpoint_url("https://cdn.example.test/models/clap.pt?download=1")
             == "https://cdn.example.test/models/clap.pt?download=1");
     REQUIRE(resolve_checkpoint_url("hf://org/repo/checkpoints/music.pt")
@@ -469,7 +469,7 @@ TEST_CASE("audio model list reports registry and install state", "[audio][tools]
 }
 
 TEST_CASE("audio model registry resolves checkpoint URLs and lookup misses",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     const auto& models = registered_models();
     REQUIRE_FALSE(models.empty());
     REQUIRE(models[0].model_id == "clap_music_audioset_v1");
@@ -527,7 +527,7 @@ TEST_CASE("audio model status reports configured checkpoint loadability", "[audi
 }
 
 TEST_CASE("audio model status reports malformed state files",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     write_text(temp.path / "audio" / "model-state.json", "{ not-json");
 
@@ -540,7 +540,7 @@ TEST_CASE("audio model status reports malformed state files",
 }
 
 TEST_CASE("audio model status reports incomplete state shapes",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
   "backend": "clap"
@@ -577,7 +577,7 @@ TEST_CASE("audio model status reports incomplete state shapes",
 }
 
 TEST_CASE("audio model status reads legacy model.json and installed metadata fallbacks",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -629,7 +629,7 @@ TEST_CASE("audio model activate writes state from installed metadata", "[audio][
 }
 
 TEST_CASE("audio model activate falls back to registered metadata",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -687,7 +687,7 @@ TEST_CASE("audio model activate rejects installed metadata with missing checkpoi
 }
 
 TEST_CASE("audio model store accepts overrides and legacy checkpoint metadata",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "legacy-clap.pt";
     write_text(checkpoint, "stub");
@@ -720,7 +720,7 @@ TEST_CASE("audio model store accepts overrides and legacy checkpoint metadata",
 }
 
 TEST_CASE("audio model store treats malformed install metadata as unloadable",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json",
                "{ not-json");
@@ -735,7 +735,7 @@ TEST_CASE("audio model store treats malformed install metadata as unloadable",
 }
 
 TEST_CASE("audio model store reads active id aliases in priority order",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
   "configured_model_id": "configured",
@@ -769,7 +769,7 @@ TEST_CASE("audio model store reads active id aliases in priority order",
 }
 
 TEST_CASE("audio model and bundle JSON serializers include stable fields",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     ModelListResult list;
     list.pulp_home = "/tmp/pulp-home";
     list.active_model_id = "clap_music_audioset_v1";
@@ -958,7 +958,7 @@ TEST_CASE("excerpt bundle reader fills defaults from model and ranked result fil
 }
 
 TEST_CASE("excerpt bundle reader honors manifest file overrides and numeric fallbacks",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto bundle = temp.path / "bundle";
     fs::create_directories(bundle / "metadata");
@@ -1020,7 +1020,7 @@ TEST_CASE("excerpt bundle reader honors manifest file overrides and numeric fall
 }
 
 TEST_CASE("excerpt bundle reader reports empty and missing ranked inputs",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     auto empty = read_excerpt_bundle({});
     REQUIRE_FALSE(empty.ok);
     REQUIRE(empty.error == "bundle path is required");
@@ -1040,7 +1040,7 @@ TEST_CASE("excerpt bundle reader reports empty and missing ranked inputs",
 }
 
 TEST_CASE("excerpt bundle reader reports malformed manifests and result objects",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto bundle = temp.path / "bundle";
     fs::create_directories(bundle);
@@ -1121,7 +1121,7 @@ TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools
 }
 
 TEST_CASE("excerpt find materializes bundle metadata, skipped inputs, and excerpt WAVs",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -1187,7 +1187,7 @@ TEST_CASE("excerpt find materializes bundle metadata, skipped inputs, and excerp
 }
 
 TEST_CASE("excerpt find validates required request fields before model loading",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto input = temp.path / "input.wav";
     REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
@@ -1225,7 +1225,7 @@ TEST_CASE("excerpt find validates required request fields before model loading",
 }
 
 TEST_CASE("excerpt find reports unsupported inputs after resolving a model",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -1258,7 +1258,7 @@ TEST_CASE("excerpt find reports unsupported inputs after resolving a model",
 }
 
 TEST_CASE("excerpt find JSON serializer includes results and skipped files",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     ExcerptFindResult result;
     result.ok = true;
     result.bundle_path = "/tmp/bundle";
@@ -1283,7 +1283,7 @@ TEST_CASE("excerpt find JSON serializer includes results and skipped files",
 }
 
 TEST_CASE("excerpt find reports explicit unknown models",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto input = temp.path / "input.wav";
     REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
@@ -1300,7 +1300,7 @@ TEST_CASE("excerpt find reports explicit unknown models",
 }
 
 TEST_CASE("excerpt find reports inactive and unavailable installed models",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto input = temp.path / "input.wav";
     REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
@@ -1334,7 +1334,7 @@ TEST_CASE("excerpt find reports inactive and unavailable installed models",
 }
 
 TEST_CASE("excerpt find collects uppercase WAV files and records unsupported siblings",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
 
@@ -1368,7 +1368,7 @@ TEST_CASE("excerpt find collects uppercase WAV files and records unsupported sib
 }
 
 TEST_CASE("excerpt find recursively scans sorted WAV inputs and caps final ranks",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
 
@@ -1399,7 +1399,7 @@ TEST_CASE("excerpt find recursively scans sorted WAV inputs and caps final ranks
 }
 
 TEST_CASE("excerpt find can dry-run with all candidates below min score",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
     auto input = temp.path / "input.wav";
@@ -1425,7 +1425,7 @@ TEST_CASE("excerpt find can dry-run with all candidates below min score",
 }
 
 TEST_CASE("excerpt find skips WAV files that cannot produce excerpt windows",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
 
@@ -1488,7 +1488,7 @@ TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]
 }
 
 TEST_CASE("excerpt find dry-run returns ranked metadata without bundle writes",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = install_active_clap_model(temp);
     auto input = temp.path / "dry-run.wav";
@@ -1520,7 +1520,7 @@ TEST_CASE("excerpt find dry-run returns ranked metadata without bundle writes",
 }
 
 TEST_CASE("excerpt find explicit model id overrides unrelated active state",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -1552,7 +1552,7 @@ TEST_CASE("excerpt find explicit model id overrides unrelated active state",
 }
 
 TEST_CASE("excerpt find nonrecursive directories ignore nested WAV-only inputs",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
     fs::create_directories(temp.path / "nested");
@@ -1580,7 +1580,7 @@ TEST_CASE("excerpt find nonrecursive directories ignore nested WAV-only inputs",
 }
 
 TEST_CASE("excerpt find applies per-file candidate caps before global ranking",
-          "[audio][tools][codecov]") {
+          "[audio][tools]") {
     TempDir temp;
     install_active_clap_model(temp);
     auto first = temp.path / "first.wav";

--- a/test/test_buffering_reader.cpp
+++ b/test/test_buffering_reader.cpp
@@ -271,7 +271,7 @@ TEST_CASE("BufferingReader signals finished when source ends", "[audio][bufferin
 }
 
 TEST_CASE("BufferingReader preserves buffered tail after worker reaches EOF",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
 
     std::atomic<int> emitted{0};
@@ -385,7 +385,7 @@ TEST_CASE("BufferingReader stop is safe to call multiple times", "[audio][buffer
 }
 
 TEST_CASE("BufferingReader rejects invalid start configuration",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
     std::atomic<int> callback_count{0};
     reader.set_read_callback([&](float*, int, int) {
@@ -413,7 +413,7 @@ TEST_CASE("BufferingReader rejects invalid start configuration",
 }
 
 TEST_CASE("BufferingReader invalid restart clears prior running state",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
     reader.set_read_callback([](float* dest, int frames, int channels) {
         for (int i = 0; i < frames * channels; ++i) dest[i] = 1.0f;
@@ -451,7 +451,7 @@ TEST_CASE("BufferingReader channel mismatch returns 0", "[audio][buffering]") {
 }
 
 TEST_CASE("BufferingReader invalid read destinations are no-ops",
-          "[audio][buffering][codecov]") {
+          "[audio][buffering]") {
     BufferingReader reader;
 
     REQUIRE(reader.read(nullptr, 16, 1) == 0);
@@ -471,7 +471,7 @@ TEST_CASE("BufferingReader invalid read destinations are no-ops",
 }
 
 TEST_CASE("BufferingReader invalid start parameters do not launch a worker",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
 
     reader.start(0, 1024);
@@ -493,7 +493,7 @@ TEST_CASE("BufferingReader invalid start parameters do not launch a worker",
 }
 
 TEST_CASE("BufferingReader read rejects overflowing frame-channel requests",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
     reader.set_read_callback([](float* dest, int frames, int channels) {
         for (int i = 0; i < frames * channels; ++i) dest[i] = 1.0f;
@@ -510,7 +510,7 @@ TEST_CASE("BufferingReader read rejects overflowing frame-channel requests",
 }
 
 TEST_CASE("BufferingReader clamps over-reported callback frame counts",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
     std::atomic<int> next{0};
     reader.set_read_callback([&](float* dest, int frames, int channels) {
@@ -538,7 +538,7 @@ TEST_CASE("BufferingReader clamps over-reported callback frame counts",
 }
 
 TEST_CASE("BufferingReader fills ring buffers smaller than the worker chunk",
-          "[audio][buffering][coverage]") {
+          "[audio][buffering]") {
     BufferingReader reader;
     std::atomic<int> emitted{0};
     reader.set_read_callback([&](float* dest, int frames, int channels) {

--- a/test/test_ogg_reader.cpp
+++ b/test/test_ogg_reader.cpp
@@ -149,7 +149,7 @@ TEST_CASE("OggReader rejects missing and malformed files",
 }
 
 TEST_CASE("OggReader reports metadata for a valid Vorbis stream",
-          "[audio][ogg][coverage]") {
+          "[audio][ogg]") {
     auto reader = pulp::audio::create_ogg_reader();
     TempDir temp;
     auto path = temp.path / "tiny.ogg";
@@ -167,7 +167,7 @@ TEST_CASE("OggReader reports metadata for a valid Vorbis stream",
 }
 
 TEST_CASE("OggReader decodes a valid Vorbis stream into deinterleaved channels",
-          "[audio][ogg][coverage]") {
+          "[audio][ogg]") {
     auto reader = pulp::audio::create_ogg_reader();
     TempDir temp;
     auto path = temp.path / "tiny.oga";
@@ -194,7 +194,7 @@ TEST_CASE("OggReader decodes a valid Vorbis stream into deinterleaved channels",
 }
 
 TEST_CASE("FormatRegistry routes OGG metadata and decode through the built-in reader",
-          "[audio][ogg][coverage]") {
+          "[audio][ogg]") {
     TempDir temp;
     auto path = temp.path / "registry.ogg";
     auto uppercase_path = temp.path / "registry-uppercase.OGA";


### PR DESCRIPTION
## Summary
- remove stale `[coverage]` / `[codecov]` selector tags from audio primitive test cases
- preserve semantic selectors such as `[audio]`, `[buffer]`, `[slice]`, `[file]`, `[device]`, `[focus]`, `[buffering]`, `[ogg]`, `[thumbnail]`, `[large]`, `[edge]`, and `[frame-fill]`
- trim two stale local comments while preserving the nearby test rationale

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- mechanical diff verifier: changed files limited to the 10 intended audio test files; changed lines limited to selector strings and the reviewed comment cleanup; no `[codecov]` remains in touched files
- built affected Release targets: `pulp-test-audio`, `pulp-test-audio-focus`, `pulp-test-buffering-reader`, `pulp-test-ogg-reader`, `pulp-test-audio-thumbnail`, `pulp-test-audio-tools`, `pulp-test-audio-file`, `pulp-test-audio-excerpt`, `pulp-test-audio-edge-cases`, `pulp-test-audio-contracts`
- focused Catch2 runs passed for `[audio]`, `[audio][focus]`, `[audio][focus][large]`, `[audio][buffering]`, `[audio][buffering][edge]`, `[audio][ogg]`, `[audio][thumbnail]`, `[audio][thumbnail][edge]`, `[audio][tools]`, `[audio][file]`, `[audio][subsection]`, `[audio][edges][frame-fill]`, plus full `pulp-test-audio-contracts`
- `autoreview --mode branch --base origin/main --reviewers codex,claude --thinking codex=high --thinking claude=max`: clean, 0 findings, overall 0.97


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale `[coverage]`/`[codecov]` selector tags from audio test suites to standardize Catch2 filters and reduce noise. Kept semantic tags (e.g., `[audio]`, `[buffer]`, `[slice]`, `[file]`) and trimmed two stale comments; no test logic changed.

- **Refactors**
  - Dropped `[coverage]` and `[codecov]` from audio-related tests across 10 files.
  - Preserved meaningful selectors for focused runs (e.g., `[device]`, `[focus]`, `[buffering]`, `[ogg]`, `[thumbnail]`, `[edge]`, `[frame-fill]`).
  - Pruned two outdated local comments while keeping the nearby rationale intact.

<sup>Written for commit bb73ceeee09047d71f1d8f7ea6bb7966cc4d1037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

