### PR TITLE
docs(test): consolidate source comment hygiene follow-up

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -7332,7 +7332,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1348 + Wave 2 cheap wiring \u2014 confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
       "issue": "1346"
@@ -7395,7 +7395,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1521 + Wave 2 cheap wiring \u2014 confirmed rotation threads through SkMatrix and CGAffineTransform.",
       "issue": "1346"
@@ -7409,7 +7409,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
       "issue": ""
@@ -7434,7 +7434,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
       "issue": ""
@@ -7591,8 +7591,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [issue-1666]",
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1666]",
+        "test/test_widget_bridge_canvas2d_wave2.cpp [view][bridge][canvas][wave3-canvas2d]"
       ],
       "notes": "pulp #1525 \u2014 maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 \u2014 gradient/pattern fillStyle routes through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphics path now handles gradient fillStyle via kCGTextClip + fill_with_active_paint(). CG pattern fillStyle on glyphs is a separate sub-feature tracked under canvas2d/createPattern follow-ups.",
       "issue": ""
@@ -7608,7 +7608,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1525 + Codex P2 follow-up \u2014 make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring \u2014 confirmed end-to-end and bumped from partial -> supported.",
       "issue": ""
@@ -7690,7 +7690,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [view][canvas2d][issue-1524]"
       ],
       "notes": "pulp #1524. Two-circle support: Skia MakeTwoPointConical, CG full CGContextDrawRadialGradient with both circles. Inner circle (x0,y0,r0) packed in CanvasDrawCmd as (x, y, extra), outer (x1,y1,r1) as (x2, y2, w).",
@@ -7705,7 +7705,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
       "notes": "pulp #1524. Skia uses MakeSweep; CG falls back to a software rasteriser that rebuilds the conic CGImage when the clip-bounding-box changes (caches across repeated fills with the same clip).",
@@ -7722,7 +7722,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
       "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) \u2014 file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
@@ -7805,7 +7805,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [issue-1666]"
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1666]",
+        "test/test_widget_bridge_canvas2d_wave2.cpp [view][bridge][canvas][wave3-canvas2d]"
       ],
       "notes": "pulp Wave 3 c2d.7 \u2014 stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation. PR #1643 added gradient stroke shaders on Skia. pulp #1666 \u2014 added native CG stroke gradient implementation (linear/radial/two-circle) using CGContextReplacePathWithStrokedPath + CGContextDrawLinearGradient/Radial. CG conic stroke + CG pattern stroke fall back to first-stop solid; tracked as separate follow-ups under canvas2d/createConicGradient + canvas2d/createPattern.",
       "issue": ""
@@ -8050,7 +8051,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Box-shadow on the View widget remains the separate setBoxShadow primitive (#925).",
       "issue": "1434"
@@ -8064,7 +8065,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. HTML5 spec: negative values are silently ignored at the shim/bridge boundary.",
       "issue": "1434"
@@ -8078,7 +8079,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
       "issue": "1434"
@@ -8092,7 +8093,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
       "issue": "1434"

--- a/compat/canvas2d.json
+++ b/compat/canvas2d.json
@@ -107,7 +107,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1348 + Wave 2 cheap wiring \u2014 confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
       "issue": "1346"
@@ -170,7 +170,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1521 + Wave 2 cheap wiring \u2014 confirmed rotation threads through SkMatrix and CGAffineTransform.",
       "issue": "1346"
@@ -184,7 +184,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
       "issue": ""
@@ -209,7 +209,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
       "issue": ""
@@ -366,8 +366,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [issue-1666]",
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1666]",
+        "test/test_widget_bridge_canvas2d_wave2.cpp [view][bridge][canvas][wave3-canvas2d]"
       ],
       "notes": "pulp #1525 \u2014 maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 \u2014 gradient/pattern fillStyle routes through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphics path now handles gradient fillStyle via kCGTextClip + fill_with_active_paint(). CG pattern fillStyle on glyphs is a separate sub-feature tracked under canvas2d/createPattern follow-ups.",
       "issue": ""
@@ -383,7 +383,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+        "test/test_widget_bridge_wave2_cheap.cpp [view][bridge][canvas][wave2-canvas2d]"
       ],
       "notes": "PR #1525 + Codex P2 follow-up \u2014 make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring \u2014 confirmed end-to-end and bumped from partial -> supported.",
       "issue": ""
@@ -465,7 +465,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [view][canvas2d][issue-1524]"
       ],
       "notes": "pulp #1524. Two-circle support: Skia MakeTwoPointConical, CG full CGContextDrawRadialGradient with both circles. Inner circle (x0,y0,r0) packed in CanvasDrawCmd as (x, y, extra), outer (x1,y1,r1) as (x2, y2, w).",
@@ -480,7 +480,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
       "notes": "pulp #1524. Skia uses MakeSweep; CG falls back to a software rasteriser that rebuilds the conic CGImage when the clip-bounding-box changes (caches across repeated fills with the same clip).",
@@ -497,7 +497,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
       "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) \u2014 file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
@@ -580,7 +580,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_canvas.cpp [issue-1666]"
+        "test/test_canvas_cg_gradients.cpp [canvas][cg][issue-1666]",
+        "test/test_widget_bridge_canvas2d_wave2.cpp [view][bridge][canvas][wave3-canvas2d]"
       ],
       "notes": "pulp Wave 3 c2d.7 \u2014 stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation. PR #1643 added gradient stroke shaders on Skia. pulp #1666 \u2014 added native CG stroke gradient implementation (linear/radial/two-circle) using CGContextReplacePathWithStrokedPath + CGContextDrawLinearGradient/Radial. CG conic stroke + CG pattern stroke fall back to first-stop solid; tracked as separate follow-ups under canvas2d/createConicGradient + canvas2d/createPattern.",
       "issue": ""
@@ -825,7 +826,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Box-shadow on the View widget remains the separate setBoxShadow primitive (#925).",
       "issue": "1434"
@@ -839,7 +840,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. HTML5 spec: negative values are silently ignored at the shim/bridge boundary.",
       "issue": "1434"
@@ -853,7 +854,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
       "issue": "1434"
@@ -867,7 +868,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
-        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+        "test/test_canvas_widget_shadow.cpp [canvas_widget][issue-1434-batch-7]"
       ],
       "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
       "issue": "1434"

--- a/docs/reference/compat/canvas2d.md
+++ b/docs/reference/compat/canvas2d.md
@@ -27,8 +27,8 @@ Harness verdict counts after evidence validation:
 
 | Verdict | Count |
 | --- | ---: |
-| PASS | 11 |
-| SUPPORTED-NO-EVIDENCE | 55 |
+| PASS | 18 |
+| SUPPORTED-NO-EVIDENCE | 48 |
 | DIVERGE | 0 |
 | NO-OP | 0 |
 | NOT-IMPL | 0 |
@@ -61,7 +61,7 @@ the rows that currently demote to `SUPPORTED-NO-EVIDENCE`:
 | --- | --- |
 | Broad bridge backfill rows such as `_native_canvasFillCircle`, `fillRect`, `beginPath`, `getLineDash` | `test/test_widget_bridge.cpp [issue-1711][evidence-backfill]` |
 | Shim expansion rows such as `arc`, `bezierCurveTo`, `lineCap`, `lineJoin`, `transform` | `test/test_canvas2d_shim.cpp [issue-1526]` or adjacent stale issue tags |
-| Former gotcha rows such as `arcTo`, `ellipse`, `filter`, `direction` | catalog entries are supported, but evidence anchors need a current test tag or explicit removal |
+| Former gotcha rows such as `arcTo`, `filter`, `direction` | catalog entries are supported, but evidence anchors need a current test tag or explicit removal |
 
 Do not reintroduce `partial` or `DIVERGE` just because evidence tags are
 stale. Use `SUPPORTED-NO-EVIDENCE` until the evidence references are

--- a/test/harness/test_canvas2d_adapter.py
+++ b/test/harness/test_canvas2d_adapter.py
@@ -337,7 +337,6 @@ class VerifierEndToEndTest(unittest.TestCase):
         for name in (
             "canvas2d/arc",
             "canvas2d/arcTo",
-            "canvas2d/ellipse",
             "canvas2d/transform",
         ):
             with self.subTest(entry=name):

--- a/test/test_cli_content_commands.cpp
+++ b/test/test_cli_content_commands.cpp
@@ -131,13 +131,13 @@ fs::path write_archive_with_unlisted_payload(const fs::path& archive,
 }  // namespace
 
 TEST_CASE("pulp content validates the content-pack fixture",
-          "[cli][content][phase2]") {
+          "[cli][content]") {
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     REQUIRE(cmd_content({"validate", fixture.string(), "--json"}) == 0);
 }
 
 TEST_CASE("pulp content installs, lists, reveals, and removes data-only packs",
-          "[cli][content][phase2]") {
+          "[cli][content]") {
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     const std::string plugin = "dev.pulp.fixtures.content-target";
@@ -192,7 +192,7 @@ TEST_CASE("pulp content install writes the index atomically with no temp sidecar
 }
 
 TEST_CASE("pulp content install refuses to overwrite an installed pack version",
-          "[cli][content][phase2]") {
+          "[cli][content]") {
     TempDir data;
     TempDir changed_pack;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -214,7 +214,7 @@ TEST_CASE("pulp content install refuses to overwrite an installed pack version",
 }
 
 TEST_CASE("pulp content install is visible through ContentRegistry",
-          "[cli][content][phase2]") {
+          "[cli][content]") {
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     const std::string plugin = "dev.pulp.fixtures.content-target";
@@ -246,7 +246,7 @@ TEST_CASE("pulp content install is visible through ContentRegistry",
 }
 
 TEST_CASE("pulp content commands reject unsafe path components before mutation",
-          "[cli][content][phase2][security]") {
+          "[cli][content][security]") {
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     const std::string plugin = "dev.pulp.fixtures.content-target";
@@ -285,7 +285,7 @@ TEST_CASE("pulp content commands reject unsafe path components before mutation",
 }
 
 TEST_CASE("pulp content install rejects symlinked directory entries before copy",
-          "[cli][content][phase2][security]") {
+          "[cli][content][security]") {
     TempDir data;
     TempDir pack;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -309,7 +309,7 @@ TEST_CASE("pulp content install rejects symlinked directory entries before copy"
 }
 
 TEST_CASE("pulp content install and update reject bare manifest files before mutation",
-          "[cli][content][phase2][security]") {
+          "[cli][content][security]") {
     TempDir data;
     TempDir pack;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -341,7 +341,7 @@ TEST_CASE("pulp content install and update reject bare manifest files before mut
 }
 
 TEST_CASE("pulp content preview reports runtime compatibility and reload policy",
-          "[cli][content][phase3]") {
+          "[cli][content]") {
     TempDir tmp;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     const auto runtime = tmp.path / "pulp.plugin-runtime.json";
@@ -384,7 +384,7 @@ TEST_CASE("pulp content preview reports runtime compatibility and reload policy"
 }
 
 TEST_CASE("pulp content update replaces a local pack version without touching user files",
-          "[cli][content][phase5]") {
+          "[cli][content]") {
     TempDir data;
     TempDir updated_pack;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -414,7 +414,7 @@ TEST_CASE("pulp content update replaces a local pack version without touching us
 }
 
 TEST_CASE("pulp content update rejects invalid packs before replacing installed content",
-          "[cli][content][phase5]") {
+          "[cli][content]") {
     TempDir data;
     TempDir invalid_pack;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -451,7 +451,7 @@ TEST_CASE("pulp content update rejects invalid packs before replacing installed 
 }
 
 TEST_CASE("pulp content rescan rebuilds the content index without touching packs",
-          "[cli][content][phase3]") {
+          "[cli][content]") {
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
     const std::string plugin = "dev.pulp.fixtures.content-target";
@@ -479,7 +479,7 @@ TEST_CASE("pulp content rescan rebuilds the content index without touching packs
 }
 
 TEST_CASE("pulp content validates and installs a packed .pulpcontent archive",
-          "[cli][content][phase2]") {
+          "[cli][content]") {
     TempDir tmp;
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -503,7 +503,7 @@ TEST_CASE("pulp content validates and installs a packed .pulpcontent archive",
 }
 
 TEST_CASE("pulp content rejects archives without files.sha256 manifests",
-          "[cli][content][phase2][security]") {
+          "[cli][content][security]") {
     TempDir tmp;
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -524,7 +524,7 @@ TEST_CASE("pulp content rejects archives without files.sha256 manifests",
 }
 
 TEST_CASE("pulp content rejects archives with unlisted payload files",
-          "[cli][content][phase2][security]") {
+          "[cli][content][security]") {
     TempDir tmp;
     TempDir data;
     const auto fixture = repo_root() / "fixtures/packages/basic-content-pack";
@@ -545,7 +545,7 @@ TEST_CASE("pulp content rejects archives with unlisted payload files",
 }
 
 TEST_CASE("pulp content validation catches missing sample and wavetable exports",
-          "[cli][content][phase3]") {
+          "[cli][content]") {
     TempDir pack;
     write_file(pack.path / "pulp.package.json", R"json({
   "schema": "pulp-package-v1",

--- a/test/test_cli_kit_commands.cpp
+++ b/test/test_cli_kit_commands.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Focused tests for Phase 1 `pulp kit` metadata-only validation.
+// Focused tests for `pulp kit` metadata-only validation.
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -276,8 +276,8 @@ int run_success_command(const std::string& cmd) {
 
 }  // namespace
 
-TEST_CASE("pulp kit validates the Phase 1 kit-lane fixture manifests",
-          "[cli][kit][phase1]") {
+TEST_CASE("pulp kit validates metadata-only kit fixture manifests",
+          "[cli][kit]") {
     const auto root = repo_root();
     for (const auto& rel : {
              "fixtures/packages/gain-dsp-kit",
@@ -297,7 +297,7 @@ TEST_CASE("pulp kit validates the Phase 1 kit-lane fixture manifests",
 }
 
 TEST_CASE("pulp kit rejects incompatible requires.pulp constraints",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -348,7 +348,7 @@ TEST_CASE("pulp kit rejects incompatible requires.pulp constraints",
 }
 
 TEST_CASE("pulp kit rejects incompatible requires.cpp constraints",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -393,7 +393,7 @@ TEST_CASE("pulp kit rejects incompatible requires.cpp constraints",
 }
 
 TEST_CASE("pulp kit rejects malformed requires.cpp constraints",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -438,7 +438,7 @@ TEST_CASE("pulp kit rejects malformed requires.cpp constraints",
 }
 
 TEST_CASE("pulp kit rejects fractional requires.cpp constraints",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -483,7 +483,7 @@ TEST_CASE("pulp kit rejects fractional requires.cpp constraints",
 }
 
 TEST_CASE("pulp kit rejects unknown Pulp module dependencies",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -528,7 +528,7 @@ TEST_CASE("pulp kit rejects unknown Pulp module dependencies",
 }
 
 TEST_CASE("pulp kit rejects manifest array entries that violate the schema",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -581,7 +581,7 @@ TEST_CASE("pulp kit rejects manifest array entries that violate the schema",
 }
 
 TEST_CASE("pulp kit rejects malformed Pulp module dependencies",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -626,7 +626,7 @@ TEST_CASE("pulp kit rejects malformed Pulp module dependencies",
 }
 
 TEST_CASE("pulp kit search separates local kit and content lanes",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     const auto root = repo_root() / "fixtures/packages";
 
     int exit_code = 0;
@@ -648,7 +648,7 @@ TEST_CASE("pulp kit search separates local kit and content lanes",
 }
 
 TEST_CASE("pulp kit search discovers verified local kit and content archives",
-          "[cli][kit][phase5][archive]") {
+          "[cli][kit][archive]") {
     const auto root = repo_root() / "fixtures/packages";
     TempDir search_root;
     const auto kit_archive = search_root.path / "basic-ui-kit.pulpkit";
@@ -719,7 +719,7 @@ TEST_CASE("pulp kit metadata can inspect content archives but cannot plan, apply
 }
 
 TEST_CASE("pulp kit search filters local manifests by package kind",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     const auto root = repo_root() / "fixtures/packages";
 
     int exit_code = 0;
@@ -732,13 +732,13 @@ TEST_CASE("pulp kit search filters local manifests by package kind",
 }
 
 TEST_CASE("pulp kit search rejects invalid lane filters before scanning",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     const auto root = repo_root() / "fixtures/packages";
     REQUIRE(cmd_kit({"search", "basic", "--root", root.string(), "--lane", "dependency", "--json"}) == 2);
 }
 
 TEST_CASE("pulp kit validation accepts template generated-project golden diffs",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     const auto root = repo_root();
     const auto fixture = root / "fixtures/packages/simple-plugin-template";
 
@@ -751,7 +751,7 @@ TEST_CASE("pulp kit validation accepts template generated-project golden diffs",
 }
 
 TEST_CASE("pulp kit validation rejects template kits without generated-project diffs",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "templates" / "basic-plugin" / "CMakeLists.txt",
                "cmake_minimum_required(VERSION 3.24)\nproject(MissingTemplateDiff)\n");
@@ -795,7 +795,7 @@ TEST_CASE("pulp kit validation rejects template kits without generated-project d
 }
 
 TEST_CASE("pulp package JSON Schema carries kind-specific review evidence rules",
-          "[cli][kit][phase3][schema]") {
+          "[cli][kit][schema]") {
     const auto schema = read_file(repo_root() / "tools/kits/pulp-package.schema.json");
 
     REQUIRE(schema.find(R"("allOf")") != std::string::npos);
@@ -811,7 +811,7 @@ TEST_CASE("pulp package JSON Schema carries kind-specific review evidence rules"
 }
 
 TEST_CASE("pulp kit validation accepts UI screenshot evidence paths",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     const auto root = repo_root();
     const auto fixture = root / "fixtures/packages/basic-ui-kit";
 
@@ -829,7 +829,7 @@ TEST_CASE("pulp kit validation accepts UI screenshot evidence paths",
 }
 
 TEST_CASE("pulp kit init scaffolds structured authoring provenance",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
 
     REQUIRE(cmd_kit({"init", "--kind", "source",
@@ -848,7 +848,7 @@ TEST_CASE("pulp kit init scaffolds structured authoring provenance",
 }
 
 TEST_CASE("pulp kit validation verifies hashed evidence objects",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -914,7 +914,7 @@ TEST_CASE("pulp kit validation verifies hashed evidence objects",
 }
 
 TEST_CASE("pulp kit validation requires a per-asset license inventory",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -959,7 +959,7 @@ TEST_CASE("pulp kit validation requires a per-asset license inventory",
 }
 
 TEST_CASE("pulp kit validation rejects mismatched evidence digests",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "src" / "gain.cpp", "// gain\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -1015,7 +1015,7 @@ TEST_CASE("pulp kit validation rejects mismatched evidence digests",
 }
 
 TEST_CASE("pulp kit validation rejects missing UI screenshot evidence paths",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "ui" / "index.js", "export const fixtureName = 'Missing Evidence';\n");
     write_file(kit.path / "ui" / "tokens.json", "{}\n");
@@ -1068,7 +1068,7 @@ TEST_CASE("pulp kit validation rejects missing UI screenshot evidence paths",
 }
 
 TEST_CASE("pulp kit validation rejects UI kits with no screenshot evidence",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "ui" / "index.js", "export const fixtureName = 'No Evidence';\n");
     write_file(kit.path / "ui" / "tokens.json", "{}\n");
@@ -1117,7 +1117,7 @@ TEST_CASE("pulp kit validation rejects UI kits with no screenshot evidence",
 }
 
 TEST_CASE("pulp kit verify evaluates Pulp screenshot profile reports after plan review",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerify)\n");
 
@@ -1138,7 +1138,7 @@ TEST_CASE("pulp kit verify evaluates Pulp screenshot profile reports after plan 
 }
 
 TEST_CASE("pulp kit verify can explicitly execute screenshot profiles after review",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyRender)\n");
     write_fake_screenshot_tool(project.path, "fake png bytes");
@@ -1163,7 +1163,7 @@ TEST_CASE("pulp kit verify can explicitly execute screenshot profiles after revi
 }
 
 TEST_CASE("pulp kit verify writes visual diff reports for explicit screenshot baselines",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyVisualDiff)\n");
     write_fake_screenshot_tool(project.path, "fake png bytes");
@@ -1262,7 +1262,7 @@ TEST_CASE("pulp kit verify writes visual diff reports for explicit screenshot ba
 }
 
 TEST_CASE("pulp kit verify fails explicit screenshot baselines on visual mismatch",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyVisualMismatch)\n");
     write_fake_screenshot_tool(project.path, "actual bytes");
@@ -1360,7 +1360,7 @@ TEST_CASE("pulp kit verify fails explicit screenshot baselines on visual mismatc
 }
 
 TEST_CASE("pulp kit verify allows visual diffs within declared byte tolerance",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyVisualTolerance)\n");
     write_fake_screenshot_tool(project.path, "actual bytes");
@@ -1462,7 +1462,7 @@ TEST_CASE("pulp kit verify allows visual diffs within declared byte tolerance",
 }
 
 TEST_CASE("pulp kit verify rejects negative visual diff tolerance without screenshot execution",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyBadVisualTolerance)\n");
 
@@ -1552,7 +1552,7 @@ TEST_CASE("pulp kit verify rejects negative visual diff tolerance without screen
 }
 
 TEST_CASE("pulp kit verify rejects mismatched screenshot profile reports",
-          "[cli][kit][phase3]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitVerifyBad)\n");
 
@@ -1630,8 +1630,8 @@ TEST_CASE("pulp kit verify rejects mismatched screenshot profile reports",
     REQUIRE(cmd_kit({"verify", kit.path.string(), "--project", project.path.string(), "--json"}) == 1);
 }
 
-TEST_CASE("pulp kit validates Phase 4 graph, node-pack, and native-component fixtures",
-          "[cli][kit][phase4]") {
+TEST_CASE("pulp kit validates graph, node-pack, and native-component fixtures",
+          "[cli][kit]") {
     const auto root = repo_root();
     for (const auto& rel : {
              "fixtures/packages/level-graph-node-kit",
@@ -1648,8 +1648,8 @@ TEST_CASE("pulp kit validates Phase 4 graph, node-pack, and native-component fix
     }
 }
 
-TEST_CASE("pulp kit verify checks Phase 4 graph, node-pack, and native profiles",
-          "[cli][kit][phase4]") {
+TEST_CASE("pulp kit verify checks graph, node-pack, and native profiles",
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitPhase4Verify)\n");
     const auto root = repo_root();
@@ -1666,7 +1666,7 @@ TEST_CASE("pulp kit verify checks Phase 4 graph, node-pack, and native profiles"
 }
 
 TEST_CASE("pulp kit verify rejects executable node-pack inspect profiles",
-          "[cli][kit][phase4]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitBadNodeVerify)\n");
 
@@ -1745,7 +1745,7 @@ TEST_CASE("pulp kit verify rejects executable node-pack inspect profiles",
 }
 
 TEST_CASE("pulp kit validation rejects dynamic-native kits on iOS and AUv3",
-          "[cli][kit][phase4]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "AGENTS.md", "# Unsupported native kit\n");
     write_file(kit.path / "validation" / "node-pack-smoke.json", "{}\n");
@@ -1796,8 +1796,8 @@ TEST_CASE("pulp kit validation rejects dynamic-native kits on iOS and AUv3",
     REQUIRE(has_issue(result, "dynamic-native-unsupported"));
 }
 
-TEST_CASE("pulp kit validation requires realtime contracts for Phase 4 kits",
-          "[cli][kit][phase4]") {
+TEST_CASE("pulp kit validation requires realtime contracts for graph and native kits",
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "AGENTS.md", "# Missing realtime contract\n");
     write_file(kit.path / "include" / "gain_core.h", "#pragma once\n");
@@ -1853,7 +1853,7 @@ TEST_CASE("pulp kit validation requires realtime contracts for Phase 4 kits",
 }
 
 TEST_CASE("pulp kit validation rejects incomplete realtime contracts for graph kits",
-          "[cli][kit][phase4]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "AGENTS.md", "# Incomplete graph realtime contract\n");
     write_file(kit.path / "src" / "node.cpp", "int graph_node() { return 0; }\n");
@@ -1908,7 +1908,7 @@ TEST_CASE("pulp kit validation rejects incomplete realtime contracts for graph k
 }
 
 TEST_CASE("pulp kit validation reports actionable manifest errors",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir tmp;
     write_file(tmp.path / "pulp.package.json", R"JSON({
   "schema": "pulp-package-v1",
@@ -1952,7 +1952,7 @@ TEST_CASE("pulp kit validation reports actionable manifest errors",
 }
 
 TEST_CASE("pulp kit validation rejects ids unsafe as project path components",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     TempDir tmp;
     write_file(tmp.path / "ui" / "main.js", "export function setup() {}\n");
     write_file(tmp.path / "licenses" / "LICENSE.txt", "MIT\n");
@@ -1996,7 +1996,7 @@ TEST_CASE("pulp kit validation rejects ids unsafe as project path components",
 }
 
 TEST_CASE("pulp kit inspect JSON summarizes without executing package files",
-          "[cli][kit][phase1]") {
+          "[cli][kit]") {
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
     auto result = validate_manifest_path(fixture);
     auto json = validation_result_json(result);
@@ -2007,7 +2007,7 @@ TEST_CASE("pulp kit inspect JSON summarizes without executing package files",
 }
 
 TEST_CASE("pulp kit plan previews project mutations without writing files",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitPlan)\n");
 
@@ -2068,7 +2068,7 @@ TEST_CASE("pulp kit rejects preview alias to preserve plan/apply trust wording",
 }
 
 TEST_CASE("pulp kit plan resolves dependency packages only through curated registry",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitPlanDeps)\n");
     write_file(project.path / "tools" / "packages" / "registry.json", R"JSON({
@@ -2183,7 +2183,7 @@ TEST_CASE("pulp kit rejects unsafe CMake target metadata before generated files"
 }
 
 TEST_CASE("pulp kit apply writes owned lock, CMake include, and declared UI files",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitApply)\n");
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
@@ -2232,7 +2232,7 @@ TEST_CASE("pulp kit apply writes owned lock, CMake include, and declared UI file
 }
 
 TEST_CASE("pulp kit apply replaces same-id kit roots without leaving stale owned files",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     TempDir first_pack;
     TempDir second_pack;
@@ -2268,7 +2268,7 @@ TEST_CASE("pulp kit apply replaces same-id kit roots without leaving stale owned
 }
 
 TEST_CASE("pulp kit apply rolls back copied files when ownership lock cannot be written",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitRollback)\n");
     write_file(project.path / ".pulp", "not a directory\n");
@@ -2284,7 +2284,7 @@ TEST_CASE("pulp kit apply rolls back copied files when ownership lock cannot be 
 }
 
 TEST_CASE("pulp kit apply rejects symlinks inside exported directories before copying",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     TempDir kit_copy;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitSymlinkReject)\n");
@@ -2312,7 +2312,7 @@ TEST_CASE("pulp kit apply rejects symlinks inside exported directories before co
 }
 
 TEST_CASE("pulp kit remove deletes only lock-recorded owned files",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitRemove)\n");
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
@@ -2336,7 +2336,7 @@ TEST_CASE("pulp kit remove deletes only lock-recorded owned files",
 }
 
 TEST_CASE("pulp kit apply builds, tests, and removes cleanly from a CMake project",
-          "[cli][kit][phase2][acceptance]") {
+          "[cli][kit][acceptance]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt",
                "cmake_minimum_required(VERSION 3.24)\n"
@@ -2368,7 +2368,7 @@ TEST_CASE("pulp kit apply builds, tests, and removes cleanly from a CMake projec
 }
 
 TEST_CASE("pulp kit remove rejects tampered lock paths outside the kit-owned tree",
-          "[cli][kit][phase2][security]") {
+          "[cli][kit][security]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitRemoveTamper)\n");
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
@@ -2389,8 +2389,8 @@ TEST_CASE("pulp kit remove rejects tampered lock paths outside the kit-owned tre
     REQUIRE(fs::exists(lock_path));
 }
 
-TEST_CASE("pulp kit apply copies Phase 4 graph, node-pack, and native exports",
-          "[cli][kit][phase4]") {
+TEST_CASE("pulp kit apply copies graph, node-pack, and native exports",
+          "[cli][kit]") {
     TempDir project;
     write_file(project.path / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.24)\nproject(KitPhase4)\n");
     const auto root = repo_root();
@@ -2456,7 +2456,7 @@ TEST_CASE("pulp kit apply copies Phase 4 graph, node-pack, and native exports",
 }
 
 TEST_CASE("pulp kit pack writes archive with SHA-256 manifest",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir tmp;
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
     const auto out = tmp.path / "basic-ui-kit.pulpkit";
@@ -2473,7 +2473,7 @@ TEST_CASE("pulp kit pack writes archive with SHA-256 manifest",
 }
 
 TEST_CASE("pulp kit pack rejects symlinks before writing archive payloads",
-          "[cli][kit][phase2][security]") {
+          "[cli][kit][security]") {
     TempDir tmp;
     TempDir kit_copy;
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
@@ -2498,7 +2498,7 @@ TEST_CASE("pulp kit pack rejects symlinks before writing archive payloads",
 }
 
 TEST_CASE("pulp kit accepts packed pulpkit archives for validate, plan, and apply",
-          "[cli][kit][phase2][archive]") {
+          "[cli][kit][archive]") {
     TempDir tmp;
     TempDir project;
     write_file(project.path / "CMakeLists.txt",
@@ -2537,7 +2537,7 @@ TEST_CASE("pulp kit accepts packed pulpkit archives for validate, plan, and appl
 }
 
 TEST_CASE("pulp kit rejects pulpkit archives without hash manifests",
-          "[cli][kit][phase2][archive][security]") {
+          "[cli][kit][archive][security]") {
     TempDir tmp;
     TempDir project;
     write_file(project.path / "CMakeLists.txt",
@@ -2560,7 +2560,7 @@ TEST_CASE("pulp kit rejects pulpkit archives without hash manifests",
 }
 
 TEST_CASE("pulp kit rejects pulpkit archives with unlisted payload files",
-          "[cli][kit][phase2][archive][security]") {
+          "[cli][kit][archive][security]") {
     TempDir tmp;
     TempDir project;
     write_file(project.path / "CMakeLists.txt",
@@ -2583,7 +2583,7 @@ TEST_CASE("pulp kit rejects pulpkit archives with unlisted payload files",
 }
 
 TEST_CASE("pulp kit publish dry-run enforces publish policy without remote mutation",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     TempDir tmp;
     const auto fixture = tmp.path / "basic-ui-kit";
     fs::copy(repo_root() / "fixtures/packages/basic-ui-kit", fixture,
@@ -2603,7 +2603,7 @@ TEST_CASE("pulp kit publish dry-run enforces publish policy without remote mutat
 }
 
 TEST_CASE("pulp kit publish dry-run rejects mismatched signed registry manifests",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     TempDir tmp;
     const auto fixture = tmp.path / "basic-ui-kit";
     fs::copy(repo_root() / "fixtures/packages/basic-ui-kit", fixture,
@@ -2616,7 +2616,7 @@ TEST_CASE("pulp kit publish dry-run rejects mismatched signed registry manifests
 }
 
 TEST_CASE("pulp kit publish dry-run requires NOTICE-compatible license files",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     TempDir tmp;
     const auto fixture = tmp.path / "basic-ui-kit";
     fs::copy(repo_root() / "fixtures/packages/basic-ui-kit", fixture,
@@ -2641,7 +2641,7 @@ TEST_CASE("pulp kit publish dry-run requires NOTICE-compatible license files",
 }
 
 TEST_CASE("pulp kit publish dry-run rejects agent-authored packages without human review",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "AGENTS.md", "# Agent kit\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -2686,7 +2686,7 @@ TEST_CASE("pulp kit publish dry-run rejects agent-authored packages without huma
 }
 
 TEST_CASE("pulp kit publish dry-run rejects structured agent provenance without human review",
-          "[cli][kit][phase5]") {
+          "[cli][kit]") {
     TempDir kit;
     write_file(kit.path / "AGENTS.md", "# Structured agent kit\n");
     write_file(kit.path / "validation" / "smoke.json", "{}\n");
@@ -2738,7 +2738,7 @@ TEST_CASE("pulp kit publish dry-run rejects structured agent provenance without 
 }
 
 TEST_CASE("pulp kit apply rejects non-project roots before writing files",
-          "[cli][kit][phase2]") {
+          "[cli][kit]") {
     TempDir not_project;
     const auto fixture = repo_root() / "fixtures/packages/basic-ui-kit";
 

--- a/test/test_cli_mac_runtime_validators.cpp
+++ b/test/test_cli_mac_runtime_validators.cpp
@@ -58,7 +58,7 @@ struct StubEnv {
 
 }  // namespace
 
-TEST_CASE("expand_target_name", "[cli][mac-validators][phase5]") {
+TEST_CASE("expand_target_name", "[cli][mac-validators]") {
     REQUIRE(mr::expand_target_name("standalone")
             == std::vector<std::string>{"standalone"});
     REQUIRE(mr::expand_target_name("auv3")
@@ -71,7 +71,7 @@ TEST_CASE("expand_target_name", "[cli][mac-validators][phase5]") {
     REQUIRE(mr::expand_target_name("").empty());
 }
 
-TEST_CASE("resolve_standalone_executable", "[cli][mac-validators][phase5]") {
+TEST_CASE("resolve_standalone_executable", "[cli][mac-validators]") {
     StubEnv s;
     fs::path bundle = "/tmp/Foo.app";
     s.existing_paths.insert((bundle / "Contents" / "MacOS").string());
@@ -83,7 +83,7 @@ TEST_CASE("resolve_standalone_executable", "[cli][mac-validators][phase5]") {
 }
 
 TEST_CASE("resolve_standalone_executable rejects non-app",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     auto env = s.build();
     REQUIRE(mr::resolve_standalone_executable("/tmp/Foo.appex", env).empty());
@@ -92,7 +92,7 @@ TEST_CASE("resolve_standalone_executable rejects non-app",
 }
 
 TEST_CASE("standalone validator: missing bundle fails",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     auto env = s.build();
     auto r = mr::run_standalone_validator("/tmp/missing.app", env);
@@ -101,7 +101,7 @@ TEST_CASE("standalone validator: missing bundle fails",
 }
 
 TEST_CASE("standalone validator: skips non-Apple hosts",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     s.is_apple = false;
     auto env = s.build();
@@ -111,7 +111,7 @@ TEST_CASE("standalone validator: skips non-Apple hosts",
 }
 
 TEST_CASE("standalone validator: passes when smoke exec returns 0",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     fs::path bundle = "/tmp/Synth.app";
     s.existing_paths.insert(bundle.string());
@@ -127,7 +127,7 @@ TEST_CASE("standalone validator: passes when smoke exec returns 0",
 }
 
 TEST_CASE("standalone validator: surfaces non-zero exit",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     fs::path bundle = "/tmp/Crashy.app";
     s.existing_paths.insert(bundle.string());
@@ -204,7 +204,7 @@ TEST_CASE("standalone validator fails (not skips) on a malformed "
     }
 }
 
-TEST_CASE("parse_au_component_tuple", "[cli][mac-validators][phase5]") {
+TEST_CASE("parse_au_component_tuple", "[cli][mac-validators]") {
     std::string plist_dump = R"(
         "AudioComponents" => [
             0 => {
@@ -222,7 +222,7 @@ TEST_CASE("parse_au_component_tuple", "[cli][mac-validators][phase5]") {
 }
 
 TEST_CASE("parse_au_component_tuple handles missing fields",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     auto tuple = mr::parse_au_component_tuple("nothing here");
     REQUIRE(tuple.type.empty());
     REQUIRE(tuple.subtype.empty());
@@ -230,7 +230,7 @@ TEST_CASE("parse_au_component_tuple handles missing fields",
 }
 
 TEST_CASE("auv3 validator: skips on non-Apple",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     s.is_apple = false;
     auto env = s.build();
@@ -239,7 +239,7 @@ TEST_CASE("auv3 validator: skips on non-Apple",
 }
 
 TEST_CASE("auv3 validator: pass path through auval",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     // Use the appex directly — the container-walk path uses real
     // fs::directory_iterator, which can't be stubbed via MacValidatorEnv.
@@ -261,7 +261,7 @@ TEST_CASE("auv3 validator: pass path through auval",
 }
 
 TEST_CASE("auv3 validator: container walk finds embedded appex",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     // Real-FS variant: build a tiny .app bundle on disk so the
     // directory_iterator inside run_auv3_validator can find the
     // embedded .appex. We make the auval call deterministic by
@@ -293,7 +293,7 @@ TEST_CASE("auv3 validator: container walk finds embedded appex",
 }
 
 TEST_CASE("auv3 validator: skips when auval not installed",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     fs::path bundle = "/tmp/Synth.appex";
     s.existing_paths.insert(bundle.string());
@@ -308,7 +308,7 @@ TEST_CASE("auv3 validator: skips when auval not installed",
 }
 
 TEST_CASE("auv3 validator: rejects unparseable Info.plist",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     fs::path bundle = "/tmp/Broken.appex";
     s.existing_paths.insert(bundle.string());
@@ -322,7 +322,7 @@ TEST_CASE("auv3 validator: rejects unparseable Info.plist",
 }
 
 TEST_CASE("extract_min_macos_version: LC_BUILD_VERSION minos",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     std::string otool_out = R"(
         Load command 4
               cmd LC_BUILD_VERSION
@@ -336,7 +336,7 @@ TEST_CASE("extract_min_macos_version: LC_BUILD_VERSION minos",
 }
 
 TEST_CASE("extract_min_macos_version: LC_VERSION_MIN_MACOSX",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     std::string otool_out = R"(
         Load command 2
               cmd LC_VERSION_MIN_MACOSX
@@ -348,11 +348,11 @@ TEST_CASE("extract_min_macos_version: LC_VERSION_MIN_MACOSX",
 }
 
 TEST_CASE("extract_min_macos_version: no load command",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     REQUIRE(mr::extract_min_macos_version("nothing").empty());
 }
 
-TEST_CASE("meets_macos_floor", "[cli][mac-validators][phase5]") {
+TEST_CASE("meets_macos_floor", "[cli][mac-validators]") {
     REQUIRE(mr::meets_macos_floor("13.0"));
     REQUIRE(mr::meets_macos_floor("13.4"));
     REQUIRE(mr::meets_macos_floor("14.1"));
@@ -364,7 +364,7 @@ TEST_CASE("meets_macos_floor", "[cli][mac-validators][phase5]") {
 }
 
 TEST_CASE("macho validator: skips on non-Apple",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     s.is_apple = false;
     auto env = s.build();
@@ -373,7 +373,7 @@ TEST_CASE("macho validator: skips on non-Apple",
 }
 
 TEST_CASE("macho validator: missing bundle fails",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     auto env = s.build();
     auto r = mr::run_macho_validator("/tmp/missing.app", env);
@@ -381,7 +381,7 @@ TEST_CASE("macho validator: missing bundle fails",
 }
 
 TEST_CASE("macho validator: skips when no payloads found",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     // Bundle exists but no files inside — enumerate returns empty
     // since the dir is empty / unreadable.
     static std::atomic<int> seq{0};
@@ -398,7 +398,7 @@ TEST_CASE("macho validator: skips when no payloads found",
 }
 
 TEST_CASE("enumerate_mach_o_payloads picks up dylib + executable",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     static std::atomic<int> seq{0};
     fs::path tmp = fs::temp_directory_path() /
                ("pulp-mac-validator-payloads-" +
@@ -427,7 +427,7 @@ TEST_CASE("enumerate_mach_o_payloads picks up dylib + executable",
 }
 
 TEST_CASE("macho validator: pass when codesign + otool happy",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     static std::atomic<int> seq{0};
     fs::path tmp = fs::temp_directory_path() /
                ("pulp-mac-validator-pass-" +
@@ -449,7 +449,7 @@ TEST_CASE("macho validator: pass when codesign + otool happy",
 }
 
 TEST_CASE("macho validator: fails when codesign --verify rejects",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     static std::atomic<int> seq{0};
     fs::path tmp = fs::temp_directory_path() /
                ("pulp-mac-validator-fail-" +
@@ -472,7 +472,7 @@ TEST_CASE("macho validator: fails when codesign --verify rejects",
 }
 
 TEST_CASE("macho validator: rejects pre-13.0 minos",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     static std::atomic<int> seq{0};
     fs::path tmp = fs::temp_directory_path() /
                ("pulp-mac-validator-floor-" +
@@ -495,7 +495,7 @@ TEST_CASE("macho validator: rejects pre-13.0 minos",
 }
 
 TEST_CASE("run_all_targets dispatches three validators in order",
-          "[cli][mac-validators][phase5]") {
+          "[cli][mac-validators]") {
     StubEnv s;
     auto env = s.build();
     auto results = mr::run_all_targets("/tmp/missing.app", env);

--- a/test/test_cli_mac_runtime_validators.cpp
+++ b/test/test_cli_mac_runtime_validators.cpp
@@ -141,14 +141,11 @@ TEST_CASE("standalone validator: surfaces non-zero exit",
     REQUIRE(r.summary.find("Library not loaded") != std::string::npos);
 }
 
-// Regression: PR #3005. The smoke command must pass
-// PULP_SCREENSHOT alongside PULP_HEADLESS so `run_with_editor` doesn't
-// early-fail on the missing screenshot path (see
-// core/format/src/standalone.cpp:264). Without PULP_SCREENSHOT, every
-// healthy standalone bundle would report a false failure.
+// The smoke command must pass PULP_SCREENSHOT alongside PULP_HEADLESS so
+// `run_with_editor` does not early-fail on the missing screenshot path. Without
+// PULP_SCREENSHOT, every healthy standalone bundle would report a false failure.
 TEST_CASE("standalone validator passes PULP_SCREENSHOT alongside "
-          "PULP_HEADLESS so the binary actually smoke-runs "
-          "(regression: PR #3005 review)",
+          "PULP_HEADLESS so the binary actually smoke-runs",
           "[cli][mac-validators][issue-3005]") {
     StubEnv s;
     fs::path bundle = "/tmp/Synth.app";
@@ -170,14 +167,11 @@ TEST_CASE("standalone validator passes PULP_SCREENSHOT alongside "
     REQUIRE(cmd.find("PULP_HEADLESS=1") != std::string::npos);
 }
 
-// Regression: PR #3005. A `.app` bundle that exists but has no
-// runnable binary inside is a packaging regression. Previously this
-// returned `skip` (exit 0 unless --strict), letting malformed standalone
-// artifacts sneak past `pulp validate --target standalone`. Now it
-// returns `fail` so the gate actually gates.
+// A `.app` bundle that exists but has no runnable binary inside is a packaging
+// regression. It must fail so malformed standalone artifacts cannot pass
+// `pulp validate --target standalone`.
 TEST_CASE("standalone validator fails (not skips) on a malformed "
-          ".app bundle with no runnable binary "
-          "(regression: PR #3005 review)",
+          ".app bundle with no runnable binary",
           "[cli][mac-validators][issue-3005]") {
     StubEnv s;
     fs::path bundle = "/tmp/Headless.app";

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -471,7 +471,7 @@ TEST_CASE("pulp audio excerpt-find surfaces service errors through text and json
 }
 
 TEST_CASE("pulp cache usage and parser errors are deterministic",
-          "[cli][shellout][cache][coverage][phase3]") {
+          "[cli][shellout][cache][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-cache-shellout-home");
@@ -637,7 +637,7 @@ TEST_CASE("pulp status reports effective PR workflow",
 }
 
 TEST_CASE("pulp status and clean reject unexpected arguments before side effects",
-          "[cli][shellout][misc][coverage][phase3]") {
+          "[cli][shellout][misc][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto status_extra = run_pulp({"status", "extra"});
@@ -654,7 +654,7 @@ TEST_CASE("pulp status and clean reject unexpected arguments before side effects
 }
 
 TEST_CASE("pulp clean removes the active project build directory",
-          "[cli][shellout][misc][coverage][phase3]") {
+          "[cli][shellout][misc][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto project = unique_temp_dir("pulp-clean-shellout");
@@ -1230,7 +1230,7 @@ TEST_CASE("pulp help output lists the top-level subcommands",
 }
 
 TEST_CASE("pulp macos validates local operator arguments before gh calls",
-          "[cli][shellout][macos][coverage][phase3]") {
+          "[cli][shellout][macos][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
@@ -1287,7 +1287,7 @@ TEST_CASE("pulp macos validates local operator arguments before gh calls",
 }
 
 TEST_CASE("pulp overflow validates non-mutating operator arguments",
-          "[cli][shellout][overflow][coverage][phase3]") {
+          "[cli][shellout][overflow][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
@@ -1549,7 +1549,7 @@ TEST_CASE("pulp create rejects invalid type before scaffolding",
 }
 
 TEST_CASE("pulp create validates parser errors before scaffolding",
-          "[cli][shellout][create][coverage][phase3]") {
+          "[cli][shellout][create][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto base = fs::temp_directory_path() /
@@ -1789,7 +1789,7 @@ TEST_CASE("pulp build allows explicit unsupported SDK bypass",
 }
 
 TEST_CASE("pulp build validates js engine option before compatibility checks",
-          "[cli][shellout][build][coverage][phase3]") {
+          "[cli][shellout][build][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp = unique_temp_dir("pulp-shellout-build-js-engine");
@@ -2091,7 +2091,7 @@ TEST_CASE("pulp project bump rejects non-semver --to",
 }
 
 TEST_CASE("pulp project bump rejects missing --to values before project lookup",
-          "[cli][shellout][project][coverage][phase3]") {
+          "[cli][shellout][project][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());
@@ -2115,7 +2115,7 @@ TEST_CASE("pulp project bump rejects missing --to values before project lookup",
 }
 
 TEST_CASE("pulp project validates stray parser arguments before project lookup",
-          "[cli][shellout][project][coverage][phase3]") {
+          "[cli][shellout][project][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());

--- a/test/test_cli_shellout_lifecycle.cpp
+++ b/test/test_cli_shellout_lifecycle.cpp
@@ -116,7 +116,7 @@ TEST_CASE("pulp dev fails fast when standalone SDK is ahead of the installed CLI
 }
 
 TEST_CASE("pulp design validates owned option values before autobind",
-          "[cli][shellout][design][coverage][phase3]") {
+          "[cli][shellout][design][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     struct Case {
@@ -141,7 +141,7 @@ TEST_CASE("pulp design validates owned option values before autobind",
 }
 
 TEST_CASE("pulp dev validates value options before build or watch",
-          "[cli][shellout][dev][coverage][phase3]") {
+          "[cli][shellout][dev][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp = fs::temp_directory_path() /
@@ -269,7 +269,7 @@ TEST_CASE("pulp upgrade --notes --json emits stable-shape JSON keys",
 }
 
 TEST_CASE("pulp upgrade validates parser errors before network access",
-          "[cli][shellout][upgrade][coverage][phase3]") {
+          "[cli][shellout][upgrade][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     struct Case {
@@ -295,7 +295,7 @@ TEST_CASE("pulp upgrade validates parser errors before network access",
 }
 
 TEST_CASE("pulp sdk install validates parser errors before side effects",
-          "[cli][shellout][sdk][coverage][phase3]") {
+          "[cli][shellout][sdk][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-sdk-parser-home");

--- a/test/test_cli_shellout_loop.cpp
+++ b/test/test_cli_shellout_loop.cpp
@@ -138,7 +138,7 @@ TEST_CASE("pulp loop --platform=<unknown> exits non-zero with diagnostic",
 }
 
 TEST_CASE("pulp loop validates value options before focus state changes",
-          "[cli][shellout][loop][coverage][phase3]") {
+          "[cli][shellout][loop][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp_home = unique_temp_dir("pulp-loop-parser-errors");

--- a/test/test_cli_shellout_pr.cpp
+++ b/test/test_cli_shellout_pr.cpp
@@ -254,7 +254,7 @@ TEST_CASE("pulp pr native help stays available without shipyard",
 }
 
 TEST_CASE("pulp pr native validates option values before checkout lookup",
-          "[cli][shellout][pr][coverage][phase3]") {
+          "[cli][shellout][pr][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());

--- a/test/test_cli_shellout_scan_projects.cpp
+++ b/test/test_cli_shellout_scan_projects.cpp
@@ -53,7 +53,7 @@ TEST_CASE("pulp projects list (no --json) emits human text",
 }
 
 TEST_CASE("pulp projects validates parser errors before registry mutation",
-          "[cli][shellout][projects][coverage][phase3]") {
+          "[cli][shellout][projects][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto pulp_home = unique_temp_dir("pulp-projects-parser-home");
@@ -201,7 +201,7 @@ TEST_CASE("pulp scan --help exits 0 with usage on stdout",
 }
 
 TEST_CASE("pulp scan validates parser errors before filesystem enumeration",
-          "[cli][shellout][scan][coverage][phase3]") {
+          "[cli][shellout][scan][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const struct {
@@ -226,7 +226,7 @@ TEST_CASE("pulp scan validates parser errors before filesystem enumeration",
 }
 
 TEST_CASE("pulp host validates parser errors before plugin loading",
-          "[cli][shellout][host][coverage][phase3]") {
+          "[cli][shellout][host][coverage]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const struct {
@@ -346,8 +346,8 @@ TEST_CASE("pulp scan --no-load reports filename-derived CLAP entries from HOME",
 #else
     auto clap_dir = home / ".clap";
 #endif
-    auto alpha_path = clap_dir / "Phase8Alpha.clap";
-    auto beta_path = clap_dir / "Phase8Beta.clap";
+    auto alpha_path = clap_dir / "ScanAlpha.clap";
+    auto beta_path = clap_dir / "ScanBeta.clap";
     fs::create_directories(beta_path);
     fs::create_directories(alpha_path);
 
@@ -360,8 +360,8 @@ TEST_CASE("pulp scan --no-load reports filename-derived CLAP entries from HOME",
     REQUIRE(r.stdout_output.find(alpha_path.string()) != std::string::npos);
     REQUIRE(r.stdout_output.find(beta_path.string()) != std::string::npos);
 
-    auto alpha = r.stdout_output.find("Phase8Alpha");
-    auto beta = r.stdout_output.find("Phase8Beta");
+    auto alpha = r.stdout_output.find("ScanAlpha");
+    auto beta = r.stdout_output.find("ScanBeta");
     REQUIRE(alpha != std::string::npos);
     REQUIRE(beta != std::string::npos);
     REQUIRE(alpha < beta);
@@ -380,11 +380,11 @@ TEST_CASE("pulp scan --format lv2 reaches rich scanner path and exits cleanly",
     scoped_home.set(home.string());
 
 #if defined(__linux__)
-    auto lv2_dir = home / ".lv2" / "Phase8Probe.lv2";
+    auto lv2_dir = home / ".lv2" / "ScanProbe.lv2";
     fs::create_directories(lv2_dir);
     write_text(lv2_dir / "manifest.ttl",
                "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n"
-               "<http://example.org/phase8-probe> a lv2:Plugin .\n");
+               "<http://example.org/scan-probe> a lv2:Plugin .\n");
 #endif
 
     auto r = run_pulp({"scan", "--format", "lv2"}, /*timeout_ms=*/30000);
@@ -392,7 +392,7 @@ TEST_CASE("pulp scan --format lv2 reaches rich scanner path and exits cleanly",
     REQUIRE(r.exit_code == 0);
     REQUIRE(r.stderr_output.find("libc++abi: terminating") == std::string::npos);
 #if defined(__linux__)
-    REQUIRE(r.stdout_output.find("Phase8Probe") != std::string::npos);
+    REQUIRE(r.stdout_output.find("ScanProbe") != std::string::npos);
 #else
     REQUIRE((r.stdout_output.find("[LV2]") != std::string::npos ||
              r.stdout_output.find("No plugins found") != std::string::npos));

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -457,7 +457,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship validates option parser errors before side effects",
-                 "[cli][shellout][ship][coverage][phase3]") {
+                 "[cli][shellout][ship][coverage]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("parser-errors", true);
 

--- a/test/test_cli_tweaks_shellout.cpp
+++ b/test/test_cli_tweaks_shellout.cpp
@@ -31,7 +31,7 @@ const char* kTweaksFixture = R"({
 }  // namespace
 
 TEST_CASE("pulp tweaks --help prints usage and exits 0",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto r = run_pulp({"tweaks", "--help"});
     REQUIRE(r.exit_code == 0);
@@ -41,7 +41,7 @@ TEST_CASE("pulp tweaks --help prints usage and exits 0",
 }
 
 TEST_CASE("pulp tweaks with no subcommand prints usage and exits 0",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto r = run_pulp({"tweaks"});
     REQUIRE(r.exit_code == 0);
@@ -49,7 +49,7 @@ TEST_CASE("pulp tweaks with no subcommand prints usage and exits 0",
 }
 
 TEST_CASE("pulp tweaks <unknown-subcommand> exits 2 with a diagnostic",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto r = run_pulp({"tweaks", "frobnicate"});
     REQUIRE(r.exit_code == 2);
@@ -57,7 +57,7 @@ TEST_CASE("pulp tweaks <unknown-subcommand> exits 2 with a diagnostic",
 }
 
 TEST_CASE("pulp tweaks diff reports orphaned tweaks and exits 1",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto dir = unique_temp_dir("pulp-tweaks-diff-orphan");
@@ -83,7 +83,7 @@ TEST_CASE("pulp tweaks diff reports orphaned tweaks and exits 1",
 }
 
 TEST_CASE("pulp tweaks diff with no drift exits 0",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto dir = unique_temp_dir("pulp-tweaks-diff-clean");
@@ -105,7 +105,7 @@ TEST_CASE("pulp tweaks diff with no drift exits 0",
 }
 
 TEST_CASE("pulp tweaks diff --json emits a structured report",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto dir = unique_temp_dir("pulp-tweaks-diff-json");
@@ -131,7 +131,7 @@ TEST_CASE("pulp tweaks diff --json emits a structured report",
 }
 
 TEST_CASE("pulp tweaks diff detects property-level drift via the anchors map",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto dir = unique_temp_dir("pulp-tweaks-diff-prop");
@@ -159,7 +159,7 @@ TEST_CASE("pulp tweaks diff detects property-level drift via the anchors map",
 }
 
 TEST_CASE("pulp tweaks diff with a missing tweaks file exits 2",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto dir = unique_temp_dir("pulp-tweaks-diff-missing");
     fs::create_directories(dir);
@@ -174,7 +174,7 @@ TEST_CASE("pulp tweaks diff with a missing tweaks file exits 2",
 }
 
 TEST_CASE("pulp tweaks diff with a malformed design file exits 2",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto dir = unique_temp_dir("pulp-tweaks-diff-baddesign");
     fs::create_directories(dir);
@@ -194,7 +194,7 @@ TEST_CASE("pulp tweaks diff with a malformed design file exits 2",
 }
 
 TEST_CASE("pulp tweaks diff rejects a non-array property manifest entry",
-          "[cli][shellout][tweaks][phase2][regression]") {
+          "[cli][shellout][tweaks][regression]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto dir = unique_temp_dir("pulp-tweaks-diff-bad-props");
     fs::create_directories(dir);
@@ -220,7 +220,7 @@ TEST_CASE("pulp tweaks diff rejects a non-array property manifest entry",
 // `property-not-found`.
 // drift (exit 1).
 TEST_CASE("pulp tweaks diff rejects a string-valued anchor manifest entry",
-          "[cli][shellout][tweaks][phase2][regression][issue-2437]") {
+          "[cli][shellout][tweaks][regression][issue-2437]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto dir = unique_temp_dir("pulp-tweaks-diff-string-anchor");
     fs::create_directories(dir);
@@ -245,7 +245,7 @@ TEST_CASE("pulp tweaks diff rejects a string-valued anchor manifest entry",
 }
 
 TEST_CASE("pulp tweaks diff rejects an unknown flag with exit 2",
-          "[cli][shellout][tweaks][phase2]") {
+          "[cli][shellout][tweaks]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
     auto r = run_pulp({"tweaks", "diff", "--bogus-flag"});
     REQUIRE(r.exit_code == 2);

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -161,7 +161,7 @@ TEST_CASE("create_dmg produces a file from valid source", "[ship][codesign]") {
 }
 
 TEST_CASE("codesign reports unsigned regular files without identity metadata",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
     ScopedTempDir temp("pulp-codesign-unsigned");
     const auto file = temp.path / "plain-tool";
     std::ofstream(file) << "not a Mach-O";
@@ -185,7 +185,7 @@ TEST_CASE("codesign reports unsigned regular files without identity metadata",
 }
 
 TEST_CASE("codesign failure paths leave requested outputs absent",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
     ScopedTempDir temp("pulp-codesign-failures");
     const auto pkg = temp.path / "missing.pkg";
     const auto signed_pkg = temp.path / "missing-signed.pkg";
@@ -211,7 +211,7 @@ TEST_CASE("codesign failure paths leave requested outputs absent",
 }
 
 TEST_CASE("combined pkg rejects empty and missing component inputs",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
     ScopedTempDir temp("pulp-combined-pkg-failures");
     const auto empty_output = temp.path / "empty.pkg";
     const auto missing_output = temp.path / "missing.pkg";
@@ -343,7 +343,7 @@ TEST_CASE("codesign parsers tolerate noisy command output",
 #endif
 
 TEST_CASE("default audio entitlements keep hardened runtime permissions narrow",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
     const auto plist = default_audio_entitlements();
 #ifdef __APPLE__
     REQUIRE(plist.find(R"(<?xml version="1.0" encoding="UTF-8"?>)") != std::string::npos);
@@ -362,7 +362,7 @@ TEST_CASE("default audio entitlements keep hardened runtime permissions narrow",
 }
 
 TEST_CASE("codesign detail parser extracts identity and team fields",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
 #ifdef __APPLE__
     auto info = pulp::ship::detail::parse_codesign_details(R"(
 Executable=/Applications/Pulp.app/Contents/MacOS/Pulp
@@ -401,7 +401,7 @@ TeamIdentifier=FIRST12345
 }
 
 TEST_CASE("notarytool submit parser accepts UUID ids only",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
 #ifdef __APPLE__
     auto accepted = pulp::ship::detail::parse_notarytool_submit_id(R"(
 Submission ID received
@@ -456,7 +456,7 @@ TEST_CASE("notarytool submit parser keeps UUID boundaries strict",
 }
 
 TEST_CASE("notarytool status parser classifies terminal states",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
 #ifdef __APPLE__
     auto accepted = pulp::ship::detail::parse_notarytool_status("status: Accepted\nmessage: Ready");
     REQUIRE(accepted.complete);
@@ -503,7 +503,7 @@ issues:
 }
 
 TEST_CASE("security identity parser preserves quoted display names",
-          "[ship][codesign][coverage][phase3]") {
+          "[ship][codesign][coverage]") {
 #ifdef __APPLE__
     auto identities = pulp::ship::detail::parse_signing_identities(R"IDENTITIES(
   1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Developer ID Application: Pulp Audio LLC (ABCDE12345)"

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -3017,7 +3017,7 @@ TEST_CASE("DomainHandler: dispatches inspector domain edge paths", "[inspect][do
     REQUIRE(no_perf.params_json.find("false") != std::string::npos);
 }
 
-// ─── StateInspector ListenerToken migration (Slice 3) ───────────────────────
+// ─── StateInspector ListenerToken migration ─────────────────────────────────
 
 TEST_CASE("StateInspector records parameter changes after subscribing",
           "[inspect][state][listener]") {
@@ -3067,7 +3067,7 @@ TEST_CASE("Destroying StateInspector removes its listener (no alive-guard)",
     REQUIRE_THAT(store.get_value(1), Catch::Matchers::WithinAbs(0.75, 0.001));
 }
 
-// ─── Performance.setRepaintFlash (Tier A Slice 6) ───────────────────────────
+// ─── Performance.setRepaintFlash ────────────────────────────────────────────
 
 #include <pulp/render/dirty_tracker.hpp>
 
@@ -3119,7 +3119,7 @@ TEST_CASE("Performance.setRepaintFlash without a tracker reports unavailable",
     REQUIRE(set_resp.is_error);
 }
 
-// ─── LiveConstant RPC (Tier A Slice 13) ─────────────────────────────────────
+// ─── LiveConstant RPC ───────────────────────────────────────────────────────
 
 #include <pulp/view/live_constant_editor.hpp>
 

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -7,7 +7,7 @@
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/lock_to_source.hpp>  // WYSIWYG T5 — reparent → source rewrite
 #include <pulp/view/widgets.hpp>
-#include <pulp/view/window_host.hpp>  // P2 scale test: compute_design_viewport_transform
+#include <pulp/view/window_host.hpp>  // Viewport-scale test: compute_design_viewport_transform
 
 #include <cstddef>
 #include <cstdint>
@@ -90,9 +90,8 @@ private:
 };
 
 // A RecordingCanvas that also serves real pixel readback over a small
-// synthetic surface — lets phase-3e tests exercise the loupe's
-// readback path (which the plain RecordingCanvas never does) and
-// assert the read rect that the loupe actually requested.
+// synthetic surface. Loupe tests use this path because the plain
+// RecordingCanvas never exercises readback or records the requested read rect.
 class ReadbackCanvas : public pulp::canvas::RecordingCanvas {
 public:
     ReadbackCanvas(int w, int h) : surface_w_(w), surface_h_(h) {}
@@ -1992,7 +1991,7 @@ TEST_CASE("InspectorWindow builds tabs and updates element properties", "[inspec
     inspected_root.add_child(std::move(knob));
 
     InspectorWindow window(inspected_root);
-    // P3 — the window now has a tool-strip header child + the tab panel.
+    // The window now has a tool-strip header child + the tab panel.
     REQUIRE(window.child_count() == 2);
 
     auto* tabs = first_view_of_type<TabPanel>(window);
@@ -2508,7 +2507,7 @@ TEST_CASE("WYSIWYG anchored reparent undo no-ops after the moved view "
     overlay.set_dragging_enabled(true);
     overlay.set_selected_view(moving_ptr);
 
-    // Drive the reflow reparent (mirrors the P2c reparent test).
+    // Drive the reflow reparent (mirrors the reparent test).
     const Rect mb = moving_ptr->bounds();
     MouseEvent press; press.position = {mb.x + 10, mb.y + 10}; press.is_down = true;
     REQUIRE(overlay.handle_mouse_event(press));
@@ -3191,19 +3190,18 @@ TEST_CASE("LiveConstant.reset rolls a value back to its default",
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// P1 — overlay reachability / drill-down / minimal manipulate layer
-// P2 — drag-to-move via absolute + layout.position/left/top tweaks
+// Overlay reachability / drill-down / minimal manipulate layer
+// Drag-to-move via absolute + layout.position/left/top tweaks
 //
-// planning/2026-05-21-wysiwyg-direct-manipulation-extension.md
 // ════════════════════════════════════════════════════════════════════════════
 
-// P1 acceptance: the overlay actually receives a press-on-handle → move →
+// Overlay reachability acceptance: the overlay actually receives a press-on-handle → move →
 // release sequence and lands a layout.width tweak. Proves the gesture
 // pipeline works on the input path (the ui-preview composing hooks route
 // here). Mirrors the prerequisite's stated acceptance criterion.
-TEST_CASE("InspectorOverlay P1: handle drag lands a layout.width tweak "
+TEST_CASE("InspectorOverlay: handle drag lands a layout.width tweak "
           "(overlay receives mouse)",
-          "[inspect][overlay][p1][issue-wysiwyg-p1]") {
+          "[inspect][overlay][issue-wysiwyg-p1]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -3232,12 +3230,12 @@ TEST_CASE("InspectorOverlay P1: handle drag lands a layout.width tweak "
     REQUIRE(w->getFloat32() == 100.0f);
 }
 
-// P1 drill-down: a click resolves to the DEEPEST hittable element, not the
+// Drill-down: a click resolves to the DEEPEST hittable element, not the
 // container. Esc then DESELECTS (one press, stays active) — the maintainer's
 // requested behavior so hover + click keep working without a Cmd+I cycle.
-TEST_CASE("InspectorOverlay P1: click selects deepest nested element, "
+TEST_CASE("InspectorOverlay: click selects deepest nested element, "
           "Esc deselects and stays active",
-          "[inspect][overlay][p1][drill-down][issue-wysiwyg-p1]") {
+          "[inspect][overlay][drill-down][issue-wysiwyg-p1]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
 
@@ -3288,11 +3286,11 @@ TEST_CASE("InspectorOverlay P1: click selects deepest nested element, "
     REQUIRE(overlay.is_active());
 }
 
-// P1 minimal manipulate layer: in manipulate-only mode point_in_panel is
+// Minimal manipulate layer: in manipulate-only mode point_in_panel is
 // false everywhere (whole canvas is live) and paint draws only the
 // selection box + handles (no dev side-panel rows).
-TEST_CASE("InspectorOverlay P1: manipulate-only mode suppresses the dev panel",
-          "[inspect][overlay][p1][manipulate][issue-wysiwyg-p1]") {
+TEST_CASE("InspectorOverlay: manipulate-only mode suppresses the dev panel",
+          "[inspect][overlay][manipulate][issue-wysiwyg-p1]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -3324,12 +3322,12 @@ TEST_CASE("InspectorOverlay P1: manipulate-only mode suppresses the dev panel",
     REQUIRE(overlay.tweak_row_count() == 0);   // panel never laid out
 }
 
-// ── P2: drag-to-move ────────────────────────────────────────────────────────
+// ── Drag-to-move ────────────────────────────────────────────────────────────
 
 // Core acceptance: body-drag converts to absolute and writes
 // position+left+top atomically (one batch).
-TEST_CASE("InspectorOverlay P2: body-drag moves via absolute + 3 atomic tweaks",
-          "[inspect][overlay][p2][move][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: body-drag moves via absolute + 3 atomic tweaks",
+          "[inspect][overlay][move][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     root.flex().direction = FlexDirection::row;
@@ -3359,7 +3357,7 @@ TEST_CASE("InspectorOverlay P2: body-drag moves via absolute + 3 atomic tweaks",
     overlay.handle_mouse_event(click);
     REQUIRE(overlay.selected_view() == child_ptr);
 
-    // Press on the BODY (not a handle) to start the move. P2c: the DEFAULT
+    // Press on the BODY (not a handle) to start the move. The default
     // body-drag is now reflow-aware; ⌘-drag is the ABSOLUTE FLOAT escape
     // hatch this test exercises, so hold Cmd on the press + drag.
     MouseEvent press;
@@ -3401,8 +3399,8 @@ TEST_CASE("InspectorOverlay P2: body-drag moves via absolute + 3 atomic tweaks",
 
 // No-visual-jump on conversion: the seeded left/top reproduce the pre-move
 // resolved position within ~1px when the drag delta is zero.
-TEST_CASE("InspectorOverlay P2: conversion seeds origin so there is no jump",
-          "[inspect][overlay][p2][move][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: conversion seeds origin so there is no jump",
+          "[inspect][overlay][move][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     root.flex().direction = FlexDirection::column;
@@ -3436,7 +3434,7 @@ TEST_CASE("InspectorOverlay P2: conversion seeds origin so there is no jump",
 
     // Start a ⌘-move (absolute float) and immediately "drag" by zero (move
     // event at the press position) — this exercises the seed without any
-    // delta. P2c: absolute float is the ⌘-drag path.
+    // delta. Absolute float is the ⌘-drag path.
     MouseEvent press;
     press.position = {before.x + 5, before.y + 5};
     press.is_down = true;
@@ -3455,8 +3453,8 @@ TEST_CASE("InspectorOverlay P2: conversion seeds origin so there is no jump",
 
 // Sibling reflow: after the moved child leaves flow (absolute), an in-flow
 // sibling shifts to fill the freed space.
-TEST_CASE("InspectorOverlay P2: moving a child reflows its in-flow sibling",
-          "[inspect][overlay][p2][move][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: moving a child reflows its in-flow sibling",
+          "[inspect][overlay][move][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 200});
     root.flex().direction = FlexDirection::row;
@@ -3484,7 +3482,7 @@ TEST_CASE("InspectorOverlay P2: moving a child reflows its in-flow sibling",
     overlay.set_dragging_enabled(true);
     overlay.set_selected_view(a_ptr);
 
-    // P2c: absolute float (the path that pulls a OUT of flow) is the
+    // Absolute float (the path that pulls a OUT of flow) is the
     // ⌘-drag escape hatch — hold Cmd so the sibling reflows.
     MouseEvent press;
     press.position = {a_ptr->bounds().x + 10, a_ptr->bounds().y + 10};
@@ -3505,8 +3503,8 @@ TEST_CASE("InspectorOverlay P2: moving a child reflows its in-flow sibling",
 }
 
 // Grid guard: a move on a grid child is refused (no tweaks, no conversion).
-TEST_CASE("InspectorOverlay P2: move is refused for a grid child",
-          "[inspect][overlay][p2][move][grid-guard][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: move is refused for a grid child",
+          "[inspect][overlay][move][grid-guard][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
 
@@ -3529,7 +3527,7 @@ TEST_CASE("InspectorOverlay P2: move is refused for a grid child",
     overlay.set_selected_view(cell_ptr);
 
     // ⌘-body-press on the grid child: absolute-float refused (grid children
-    // ignore position/top/left). P2c: only the float path is grid-guarded;
+    // ignore position/top/left). Only the float path is grid-guarded;
     // plain reflow drag-out is allowed, so the refusal test holds Cmd.
     MouseEvent press;
     press.position = {40, 40};
@@ -3550,9 +3548,9 @@ TEST_CASE("InspectorOverlay P2: move is refused for a grid child",
 
 // Resize still works alongside move (no regression): a handle press starts
 // a resize, not a move, and emits width/height tweaks.
-TEST_CASE("InspectorOverlay P2: resize handle still wins over body-move "
+TEST_CASE("InspectorOverlay: resize handle still wins over body-move "
           "(no regression)",
-          "[inspect][overlay][p2][move][regression][issue-wysiwyg-p2]") {
+          "[inspect][overlay][move][regression][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -3582,8 +3580,8 @@ TEST_CASE("InspectorOverlay P2: resize handle still wins over body-move "
 }
 
 // Nested element is movable (not just containers).
-TEST_CASE("InspectorOverlay P2: a nested element can be moved",
-          "[inspect][overlay][p2][move][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: a nested element can be moved",
+          "[inspect][overlay][move][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
 
@@ -3607,7 +3605,7 @@ TEST_CASE("InspectorOverlay P2: a nested element can be moved",
     overlay.handle_mouse_event(click);
     REQUIRE(overlay.selected_view() == nested_ptr);
 
-    // P2c: absolute float via ⌘-drag.
+    // Absolute float via ⌘-drag.
     MouseEvent press; press.position = {45, 38}; press.is_down = true;
     press.modifiers = kModCmd;
     REQUIRE(overlay.handle_mouse_event(press));
@@ -3625,8 +3623,8 @@ TEST_CASE("InspectorOverlay P2: a nested element can be moved",
 // gesture math in logical (post-inverse) space, so the host inverse-maps
 // before dispatch. This test reproduces that wiring with
 // compute_design_viewport_transform and asserts the logical delta.
-TEST_CASE("InspectorOverlay P2: drag delta is in logical space under viewport scale",
-          "[inspect][overlay][p2][move][scale][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: drag delta is in logical space under viewport scale",
+          "[inspect][overlay][move][scale][issue-wysiwyg-p2]") {
     // Design surface 300×200 shown in a 600×400 window → scale 2.0.
     const float design_w = 300, design_h = 200;
     const float window_w = 600, window_h = 400;
@@ -3663,7 +3661,7 @@ TEST_CASE("InspectorOverlay P2: drag delta is in logical space under viewport sc
     MouseEvent press;
     press.position = to_logical(press_screen.x, press_screen.y);
     press.is_down = true;
-    press.modifiers = kModCmd;  // P2c: absolute float via ⌘-drag
+    press.modifiers = kModCmd;  // Absolute float via ⌘-drag
     REQUIRE(overlay.handle_mouse_event(press));
 
     // Drag +100 SCREEN px in x, +60 SCREEN px in y → at scale 2.0 that is
@@ -3686,8 +3684,8 @@ TEST_CASE("InspectorOverlay P2: drag delta is in logical space under viewport sc
 
 // Two-IR-worlds shim: a move tweak (layout.* namespace) is consumable by the
 // C++/native apply path via apply_move_tweak_to_view.
-TEST_CASE("InspectorOverlay P2: move tweak round-trips on the C++ apply path",
-          "[inspect][overlay][p2][move][round-trip][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: move tweak round-trips on the C++ apply path",
+          "[inspect][overlay][move][round-trip][issue-wysiwyg-p2]") {
     View v;
     // Apply the three move-tweak property paths the gesture emits.
     REQUIRE(apply_move_tweak_to_view(v, "layout.position",
@@ -3771,8 +3769,8 @@ TEST_CASE("compute_badge_placement flips below near the window top",
 
 // Re-import round-trip: a moved element's tweaks survive an apply pass — the
 // TweakStore values reconstruct an absolute view at the moved left/top.
-TEST_CASE("InspectorOverlay P2: move tweaks reconstruct absolute view on re-apply",
-          "[inspect][overlay][p2][move][round-trip][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: move tweaks reconstruct absolute view on re-apply",
+          "[inspect][overlay][move][round-trip][issue-wysiwyg-p2]") {
     // Simulate: gesture wrote tweaks; a fresh import re-creates the view and
     // re-applies the stored tweaks by anchor.
     TweakStore store;
@@ -3799,17 +3797,16 @@ TEST_CASE("InspectorOverlay P2: move tweaks reconstruct absolute view on re-appl
     REQUIRE(fresh.top() == 75.0f);
 }
 
-// ── P2a: undo safety net ────────────────────────────────────────────────────
+// ── Undo safety net ─────────────────────────────────────────────────────────
 //
-// planning/2026-05-21-wysiwyg-direct-manipulation-extension.md § R2.2.
 // Every committed manipulation gesture becomes ONE undoable EditHistory
 // entry whose undo restores BOTH the live View layout inputs AND the
 // TweakStore. These drive the real handle_mouse_event() gesture path
 // (press → move → release) with an EditHistory attached, then assert
 // undo/redo behavior.
 
-TEST_CASE("InspectorOverlay P2a: resize gesture is one undoable unit",
-          "[inspect][overlay][p2a][undo][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: resize gesture is one undoable unit",
+          "[inspect][overlay][undo][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -3883,8 +3880,8 @@ TEST_CASE("InspectorOverlay P2a: resize gesture is one undoable unit",
     REQUIRE(store.lookup("figma:0:42", "layout.height")->getFloat32() == 55.0f);
 }
 
-TEST_CASE("InspectorOverlay P2a: resize undo restores a PRIOR tweak value",
-          "[inspect][overlay][p2a][undo][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: resize undo restores a PRIOR tweak value",
+          "[inspect][overlay][undo][issue-wysiwyg-p2]") {
     // When a width tweak already exists, undo must RESTORE it (not remove
     // it) — proving the prior-value capture path, not just the remove path.
     View root;
@@ -3940,8 +3937,8 @@ TEST_CASE("InspectorOverlay P2a: resize undo restores a PRIOR tweak value",
     REQUIRE(h->getFloat32() == 40.0f);
 }
 
-TEST_CASE("InspectorOverlay P2a: move gesture undo reverts all 3 tweaks atomically",
-          "[inspect][overlay][p2a][undo][move][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: move gesture undo reverts all 3 tweaks atomically",
+          "[inspect][overlay][undo][move][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     root.flex().direction = FlexDirection::row;
@@ -3972,7 +3969,7 @@ TEST_CASE("InspectorOverlay P2a: move gesture undo reverts all 3 tweaks atomical
     overlay.handle_mouse_event(click);
     REQUIRE(overlay.selected_view() == child_ptr);
 
-    // P2c: absolute float (3 tweaks) is the ⌘-drag path.
+    // Absolute float (3 tweaks) is the ⌘-drag path.
     MouseEvent press;
     press.position = {before.x + 20, before.y + 20};
     press.is_down = true;
@@ -4018,8 +4015,8 @@ TEST_CASE("InspectorOverlay P2a: move gesture undo reverts all 3 tweaks atomical
     REQUIRE(store.lookup("anchor-move", "layout.left").has_value());
 }
 
-TEST_CASE("InspectorOverlay P2a: gestures behave normally when no EditHistory",
-          "[inspect][overlay][p2a][undo][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: gestures behave normally when no EditHistory",
+          "[inspect][overlay][undo][issue-wysiwyg-p2]") {
     // Guard: without an EditHistory wired, the resize gesture still applies
     // live + emits tweaks exactly as before (the safety net is additive).
     View root;
@@ -4060,8 +4057,8 @@ TEST_CASE("InspectorOverlay P2a: gestures behave normally when no EditHistory",
     REQUIRE(store.lookup("a", "layout.width")->getFloat32() == 100.0f);
 }
 
-TEST_CASE("InspectorOverlay P2a: Cmd+Z / Cmd+Shift+Z drive undo and redo",
-          "[inspect][overlay][p2a][undo][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: Cmd+Z / Cmd+Shift+Z drive undo and redo",
+          "[inspect][overlay][undo][issue-wysiwyg-p2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -4122,13 +4119,13 @@ TEST_CASE("InspectorOverlay P2a: Cmd+Z / Cmd+Shift+Z drive undo and redo",
     REQUIRE(child_ptr->flex().preferred_width == 100.0f);
 }
 
-TEST_CASE("InspectorOverlay P2a: tweak-panel delete is undoable",
-          "[inspect][overlay][p2a][undo][delete][issue-wysiwyg-p2]") {
+TEST_CASE("InspectorOverlay: tweak-panel delete is undoable",
+          "[inspect][overlay][undo][delete][issue-wysiwyg-p2]") {
     // Drive the REAL panel delete-icon click path through
     // handle_mouse_event() (the TweakAction::remove branch that builds the
     // EditHistory entry), then undo to restore the deleted tweak. The icon
     // hit-rects are private, so we sweep the known delete-icon column the
-    // same way the Phase 2.5 panel tests do.
+    // same way the tweak-panel tests do.
     View root;
     root.set_bounds({0, 0, 600, 600});
     TweakStore store;
@@ -4177,12 +4174,11 @@ TEST_CASE("InspectorOverlay P2a: tweak-panel delete is undoable",
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// P2c — WYSIWYG "Figma feel" pivot
+// Reflow-aware manipulation pivot
 //
-// planning/2026-05-21-wysiwyg-direct-manipulation-extension.md § Refinement 2.
 //   - Reflow-aware MOVE is the DEFAULT body-drag (reorder among siblings /
 //     reparent into a container); ⌘-drag is the absolute-float escape hatch
-//     (covered by the P2 tests above, now Cmd-gated).
+//     (covered by the absolute-move tests above, now Cmd-gated).
 //   - Proportional RESIZE via Shift + handle-drag (scales content).
 //   - Selection comes ONLY from the canvas; the floating window reflects.
 // ════════════════════════════════════════════════════════════════════════════
@@ -4191,8 +4187,8 @@ TEST_CASE("InspectorOverlay P2a: tweak-panel delete is undoable",
 // sibling's midpoint rewrites flex().order so the dragged child re-sequences,
 // WITHOUT converting to absolute. Asserts the resolved child order changed and
 // the gesture is undoable.
-TEST_CASE("InspectorOverlay P2c: reflow drag reorders flex siblings via order",
-          "[inspect][overlay][p2c][reflow][move][issue-wysiwyg-p2c]") {
+TEST_CASE("InspectorOverlay: reflow drag reorders flex siblings via order",
+          "[inspect][overlay][reflow][move][issue-wysiwyg-p2c]") {
     View root;
     root.set_bounds({0, 0, 600, 200});
     root.flex().direction = FlexDirection::row;
@@ -4275,12 +4271,12 @@ TEST_CASE("InspectorOverlay P2c: reflow drag reorders flex siblings via order",
     REQUIRE(a_ptr->bounds().x < b_ptr->bounds().x);
 }
 
-// WYSIWYG sweep P1 — a same-parent reflow REORDER must PERSIST the new order as
+// Reflow regression — a same-parent reflow REORDER must PERSIST the new order as
 // a layout.order tweak (it was previously live-only; the "persisted elsewhere"
 // comment was wrong). The moved child AND any normalized sibling whose order
 // changed get a tweak keyed by their OWN anchor, and the value round-trips
 // through lock_tweak_into_source as `el.style.order`.
-TEST_CASE("InspectorOverlay sweep P1: same-parent reorder emits a layout.order "
+TEST_CASE("InspectorOverlay reflow: same-parent reorder emits a layout.order "
           "tweak that round-trips",
           "[inspect][overlay][reflow][reorder][issue-wysiwyg-reflow-slot]") {
     View root;
@@ -4358,10 +4354,10 @@ TEST_CASE("InspectorOverlay sweep P1: same-parent reorder emits a layout.order "
             != std::string::npos);
 }
 
-// WYSIWYG sweep P1 — a cross-parent reflow drop must carry the insertion SLOT
+// Reflow regression — a cross-parent reflow drop must carry the insertion SLOT
 // (preceding-sibling anchor) through the ReparentSourceEdit so the source
 // rewrite lands the moved block at the dragged position, not always first-child.
-TEST_CASE("InspectorOverlay sweep P1: cross-parent reflow drop carries the "
+TEST_CASE("InspectorOverlay reflow: cross-parent reflow drop carries the "
           "insertion slot to the source sink",
           "[inspect][overlay][reflow][reparent][issue-wysiwyg-reflow-slot]") {
     View root;
@@ -4436,9 +4432,9 @@ TEST_CASE("InspectorOverlay sweep P1: cross-parent reflow drop carries the "
 // Reflow reparent: a plain body-drag of a node whose cursor ends INSIDE a
 // different container reparents the node into that container, and undo
 // restores the original parent.
-TEST_CASE("InspectorOverlay P2c: reflow drag reparents a node into another "
+TEST_CASE("InspectorOverlay: reflow drag reparents a node into another "
           "container, undo restores parent",
-          "[inspect][overlay][p2c][reflow][reparent][move][issue-wysiwyg-p2c]") {
+          "[inspect][overlay][reflow][reparent][move][issue-wysiwyg-p2c]") {
     View root;
     root.set_bounds({0, 0, 600, 300});
     root.flex().direction = FlexDirection::row;
@@ -4619,7 +4615,7 @@ TEST_CASE("InspectorOverlay T5: reflow reparent locks the structural edit to "
     // Before: moving's block sits under left (precedes right's block).
     REQUIRE(pos("a-moving") < pos("a-right"));
 
-    // ── Drive the reflow reparent gesture (mirror the P2c reparent test). ──
+    // ── Drive the reflow reparent gesture (mirror the reparent test). ──
     const Rect mb = moving_ptr->bounds();
     MouseEvent press;
     press.position = {mb.x + 10, mb.y + 10};
@@ -4745,8 +4741,8 @@ TEST_CASE("InspectorOverlay T5: reflow reparent without a source sink is "
 // Proportional resize: Shift + corner-handle drag SCALES the container's
 // content (View::set_scale) rather than just stretching the box, and the
 // scale is undoable.
-TEST_CASE("InspectorOverlay P2c: Shift + handle drag scales content proportionally",
-          "[inspect][overlay][p2c][resize][proportional][issue-wysiwyg-p2c]") {
+TEST_CASE("InspectorOverlay: Shift + handle drag scales content proportionally",
+          "[inspect][overlay][resize][proportional][issue-wysiwyg-p2c]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -4806,14 +4802,14 @@ TEST_CASE("InspectorOverlay P2c: Shift + handle drag scales content proportional
     REQUIRE(child_ptr->scale() == Catch::Approx(scaled));
 }
 
-// Read-only mode is the supported OPT-OUT (the default is two-way, P2e). In
+// Read-only mode is the supported OPT-OUT (the default is two-way selection). In
 // read-only mode a tree-row "click" (firing the tree's on_select) shows the
 // node's properties but does NOT change the shared selection / fire
 // on_view_selected. reflect_selection() never fires the callback either (it is
 // the no-feedback canvas → window mirror).
-TEST_CASE("InspectorWindow P2e: read-only mode opt-out suppresses the select "
+TEST_CASE("InspectorWindow: read-only mode opt-out suppresses the select "
           "callback",
-          "[inspect][window][p2e][readonly][issue-wysiwyg-p2e]") {
+          "[inspect][window][readonly][issue-wysiwyg-p2e]") {
     View inspected_root;
     inspected_root.set_bounds({0, 0, 400, 300});
     auto child = std::make_unique<View>();
@@ -4849,17 +4845,17 @@ TEST_CASE("InspectorWindow P2e: read-only mode opt-out suppresses the select "
     REQUIRE_FALSE(callback_fired);
 }
 
-// ── WYSIWYG P2d polish ──────────────────────────────────────────────────────
+// ── Drop indicator, cursor, and selection polish ───────────────────────────
 //
-// planning/2026-05-21-wysiwyg-direct-manipulation-extension.md (P2d):
-//   B. cursor affordances over the selected element (move vs resize vs none)
-//   D. drop-indicator clarity — never shown at rest, only during an active drag
-//   A. reflect-state-only — a canvas reflection must NOT highlight a tree row
+// - Cursor affordances distinguish selected-element body, handles, and outside.
+// - Drop indicators appear only during an active reflow drag.
+// - Canvas reflection highlights the matching tree row without painting a
+//   stray in-canvas selection box inside the inspector window.
 
-// P2d (D): a selected-but-idle element shows no drop indicator. The blue
+// D: a selected-but-idle element shows no drop indicator. The blue
 // insertion line / container highlight is reserved for an ACTIVE reflow drag.
-TEST_CASE("InspectorOverlay P2d: drop indicator is NOT shown when idle",
-          "[inspect][overlay][p2d][drop-indicator][issue-wysiwyg-p2d]") {
+TEST_CASE("InspectorOverlay: drop indicator is NOT shown when idle",
+          "[inspect][overlay][drop-indicator][issue-wysiwyg-p2d]") {
     View root;
     root.set_bounds({0, 0, 600, 200});
     root.flex().direction = FlexDirection::row;
@@ -4926,11 +4922,11 @@ TEST_CASE("InspectorOverlay P2d: drop indicator is NOT shown when idle",
     REQUIRE_FALSE(overlay.drop_indicator_active());
 }
 
-// P2d (D) regression: an ABSOLUTE-float (⌘-drag) move must also never raise
+// Drop-indicator regression: an ABSOLUTE-float (⌘-drag) move must also never raise
 // the reflow drop indicator (the float path moves the live element directly
 // and uses a ghost, not the insertion line).
-TEST_CASE("InspectorOverlay P2d: float (Cmd) move shows no reflow drop indicator",
-          "[inspect][overlay][p2d][drop-indicator][issue-wysiwyg-p2d]") {
+TEST_CASE("InspectorOverlay: float (Cmd) move shows no reflow drop indicator",
+          "[inspect][overlay][drop-indicator][issue-wysiwyg-p2d]") {
     View root;
     root.set_bounds({0, 0, 600, 200});
 
@@ -4967,11 +4963,11 @@ TEST_CASE("InspectorOverlay P2d: float (Cmd) move shows no reflow drop indicator
     REQUIRE_FALSE(overlay.drop_indicator_active());
 }
 
-// P2d (B): the cursor-affordance hit-test returns resize over a corner
+// B: the cursor-affordance hit-test returns resize over a corner
 // handle, move over the body, and none outside / when dragging mode is off.
-TEST_CASE("InspectorOverlay P2d: cursor affordance is move on body, resize on "
+TEST_CASE("InspectorOverlay: cursor affordance is move on body, resize on "
           "corner, none outside",
-          "[inspect][overlay][p2d][cursor][issue-wysiwyg-p2d]") {
+          "[inspect][overlay][cursor][issue-wysiwyg-p2d]") {
     using CA = InspectorOverlay::CursorAffordance;
 
     View root;
@@ -5022,15 +5018,15 @@ TEST_CASE("InspectorOverlay P2d: cursor affordance is move on body, resize on "
     REQUIRE(overlay.cursor_affordance_at({160, 110}) == CA::none);
 }
 
-// P2e (CORRECTS P2d): reflect_selection (a canvas-driven mirror) DOES
+// Reflection selection: reflect_selection (a canvas-driven mirror) DOES
 // highlight the matching tree row AND shows the node's properties — two-way
 // selection means a canvas pick highlights the corresponding row in the
 // inspector tree. (Maintainer correction: "we DO want to be able to tap and
 // select an item in the inspector as it works today." The only forbidden
 // thing is a stray selection BOX inside the inspector window — that leak is
 // fixed in the paint hook, not by stripping the row highlight.)
-TEST_CASE("InspectorWindow P2e: reflect_selection highlights the matching tree row",
-          "[inspect][window][p2e][reflect][issue-wysiwyg-p2e]") {
+TEST_CASE("InspectorWindow: reflect_selection highlights the matching tree row",
+          "[inspect][window][reflect][issue-wysiwyg-p2e]") {
     View inspected_root;
     inspected_root.set_id("root");
 
@@ -5069,14 +5065,14 @@ TEST_CASE("InspectorWindow P2e: reflect_selection highlights the matching tree r
     REQUIRE(tree->selected_node() == node);
 }
 
-// P2e Fix 1 — paint-leak gate. The installed inspector paint hook must NOT
+// Paint-leak fix — paint-leak gate. The installed inspector paint hook must NOT
 // paint the in-canvas overlay when the painting root is NOT the inspected
 // root (e.g. the floating InspectorWindow painting its own root). This is the
 // root cause of the "stray box at a random coordinate inside the inspector
 // window": the global paint hook fired for every root that painted, so the
 // overlay's selection box leaked into the inspector window's surface.
-TEST_CASE("InspectorOverlay P2e: paint hook gates on the painting root",
-          "[inspect][overlay][p2e][paint-leak][issue-wysiwyg-p2e]") {
+TEST_CASE("InspectorOverlay: paint hook gates on the painting root",
+          "[inspect][overlay][paint-leak][issue-wysiwyg-p2e]") {
     View inspected_root;
     inspected_root.set_bounds({0, 0, 400, 300});
     auto child = std::make_unique<View>();
@@ -5117,12 +5113,12 @@ TEST_CASE("InspectorOverlay P2e: paint hook gates on the painting root",
     View::set_inspector_mouse_hook({});
 }
 
-// P2e Fix 2 — two-way selection. A tree-row click (default, non-read-only)
+// Two-way selection fix. A tree-row click (default, non-read-only)
 // fires on_view_selected so the host can drive the SHARED canvas selection,
 // and a canvas-driven reflection highlights the matching tree row. This
 // asserts the round-trip both directions without recursing.
-TEST_CASE("InspectorWindow P2e: two-way selection (canvas <-> tree row)",
-          "[inspect][window][p2e][two-way][issue-wysiwyg-p2e]") {
+TEST_CASE("InspectorWindow: two-way selection (canvas <-> tree row)",
+          "[inspect][window][two-way][issue-wysiwyg-p2e]") {
     View inspected_root;
     inspected_root.set_bounds({0, 0, 400, 300});
     auto child = std::make_unique<View>();
@@ -5131,7 +5127,7 @@ TEST_CASE("InspectorWindow P2e: two-way selection (canvas <-> tree row)",
     inspected_root.add_child(std::move(child));
 
     InspectorWindow window(inspected_root);
-    // Default (NOT read-only) — two-way selection is the P2e default.
+    // Default (NOT read-only) — two-way selection is the default.
     REQUIRE_FALSE(window.selection_readonly());
 
     auto* tabs = first_view_of_type<TabPanel>(window);
@@ -5163,16 +5159,16 @@ TEST_CASE("InspectorWindow P2e: two-way selection (canvas <-> tree row)",
     REQUIRE(tree->selected_node() == node);  // row highlighted by the reflection
 }
 
-// ── WYSIWYG P2h — interactive manipulation regressions ──────────────────────
+// ── Interactive manipulation regressions ───────────────────────────────────
 //
 // These exercise the gesture state machine with the EXPLICIT MousePhase the
 // mac host now stamps (press / drag / release / hover), which is the OPPOSITE
-// is_down convention from the legacy headless tests above. The pre-P2h
+// is_down convention from the legacy headless tests above. The pre-fix
 // machine inferred drag-vs-release from is_down alone, so a live mac drag
 // ended the gesture on the first drag tick and fell through to re-selection.
 
 namespace {
-// Build a two-child root used by the P2h move/resize cases. `a` is the
+// Build a two-child root used by the move/resize cases. `a` is the
 // element under manipulation; `b` is a second, non-overlapping element the
 // drag must NOT accidentally re-select.
 struct TwoChild {
@@ -5199,9 +5195,9 @@ std::unique_ptr<TwoChild> make_two_child() {
 }
 }  // namespace
 
-TEST_CASE("InspectorOverlay P2h: body-press of selected element begins a MOVE, "
+TEST_CASE("InspectorOverlay: body-press of selected element begins a MOVE, "
           "drag moves THAT element and never re-selects",
-          "[inspect][overlay][p2h][move][regression1]") {
+          "[inspect][overlay][move][regression1]") {
     auto tc = make_two_child();
     TweakStore store;
     InspectorOverlay overlay(tc->root);
@@ -5249,9 +5245,9 @@ TEST_CASE("InspectorOverlay P2h: body-press of selected element begins a MOVE, "
     (void)left0; (void)top0;
 }
 
-TEST_CASE("InspectorOverlay P2h: ⌘-drag float move repositions the selected "
+TEST_CASE("InspectorOverlay: ⌘-drag float move repositions the selected "
           "element (and only it)",
-          "[inspect][overlay][p2h][move][regression1]") {
+          "[inspect][overlay][move][regression1]") {
     auto tc = make_two_child();
     TweakStore store;
     InspectorOverlay overlay(tc->root);
@@ -5291,9 +5287,9 @@ TEST_CASE("InspectorOverlay P2h: ⌘-drag float move repositions the selected "
     REQUIRE(overlay.selected_view() == tc->a);
 }
 
-TEST_CASE("InspectorOverlay P2h: corner-handle press begins a RESIZE and the "
+TEST_CASE("InspectorOverlay: corner-handle press begins a RESIZE and the "
           "drag changes size (explicit phase)",
-          "[inspect][overlay][p2h][resize][regression2]") {
+          "[inspect][overlay][resize][regression2]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -5335,8 +5331,8 @@ TEST_CASE("InspectorOverlay P2h: corner-handle press begins a RESIZE and the "
     overlay.handle_mouse_event(release);
 }
 
-TEST_CASE("InspectorOverlay P2h: edge-handle press resizes a single axis",
-          "[inspect][overlay][p2h][resize][regression2][regression5]") {
+TEST_CASE("InspectorOverlay: edge-handle press resizes a single axis",
+          "[inspect][overlay][resize][regression2][regression5]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -5370,9 +5366,9 @@ TEST_CASE("InspectorOverlay P2h: edge-handle press resizes a single axis",
     REQUIRE(child_ptr->bounds().height == 40.0f);  // unchanged
 }
 
-TEST_CASE("InspectorOverlay P2h: Esc deselect leaves hover + click-to-select "
+TEST_CASE("InspectorOverlay: Esc deselect leaves hover + click-to-select "
           "working with no Cmd+I cycle",
-          "[inspect][overlay][p2h][regression3]") {
+          "[inspect][overlay][regression3]") {
     auto tc = make_two_child();
     InspectorOverlay overlay(tc->root);
     overlay.set_manipulate_only(true);
@@ -5405,9 +5401,9 @@ TEST_CASE("InspectorOverlay P2h: Esc deselect leaves hover + click-to-select "
     REQUIRE(overlay.selected_view() == tc->b);
 }
 
-TEST_CASE("InspectorOverlay P2h: a drag tick on empty canvas never mutates "
+TEST_CASE("InspectorOverlay: a drag tick on empty canvas never mutates "
           "selection (no rubber-band re-select)",
-          "[inspect][overlay][p2h][regression1]") {
+          "[inspect][overlay][regression1]") {
     auto tc = make_two_child();
     InspectorOverlay overlay(tc->root);
     overlay.set_manipulate_only(true);
@@ -5425,8 +5421,8 @@ TEST_CASE("InspectorOverlay P2h: a drag tick on empty canvas never mutates "
     REQUIRE(overlay.selected_view() == tc->a);  // selection NOT hijacked
 }
 
-TEST_CASE("InspectorOverlay P2h: context-aware resize/move cursor per zone",
-          "[inspect][overlay][p2h][regression5][cursor]") {
+TEST_CASE("InspectorOverlay: context-aware resize/move cursor per zone",
+          "[inspect][overlay][regression5][cursor]") {
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -5473,12 +5469,12 @@ TEST_CASE("InspectorOverlay P2h: context-aware resize/move cursor per zone",
     REQUIRE(overlay.cursor_style_for({500, 300}) == -1);  // default
 }
 
-TEST_CASE("InspectorOverlay P2h: legacy is_down gesture convention still works "
+TEST_CASE("InspectorOverlay: legacy is_down gesture convention still works "
           "(no explicit phase)",
-          "[inspect][overlay][p2h][regression2]") {
+          "[inspect][overlay][regression2]") {
     // Guards the headless JUCE-style convention path: press=is_down,
     // drag=!is_down, release=is_down, phase left automatic. This is the
-    // convention the pre-P2h tests use, and it must remain intact.
+    // convention the pre-fix tests use, and it must remain intact.
     View root;
     root.set_bounds({0, 0, 600, 400});
     auto child = std::make_unique<View>();
@@ -5507,15 +5503,15 @@ TEST_CASE("InspectorOverlay P2h: legacy is_down gesture convention still works "
     REQUIRE(child_ptr->bounds().height == 55.0f);
 }
 
-// ── WYSIWYG P2i (Refinement A) ────────────────────────────────────────────
+// ── Reflow drop-indicator coverage ─────────────────────────────────────────
 // During a reflow body-drag over a flex container, resolve_drop_target() must
 // resolve a valid insertion slot for EVERY cursor position across the child
 // span (before-first, between each pair, after-last) and surface the
 // Figma-style blue insertion LINE — not a vague container highlight — at the
 // resolved boundary. The committed drop must land at the indicated slot.
-TEST_CASE("InspectorOverlay P2i: reflow drag shows an insertion LINE at every "
+TEST_CASE("InspectorOverlay: reflow drag shows an insertion LINE at every "
           "slot across a row container's children",
-          "[inspect][overlay][p2i][reflow][drop-indicator][issue-wysiwyg-p2i]") {
+          "[inspect][overlay][reflow][drop-indicator][issue-wysiwyg-p2i]") {
     View root;
     root.set_bounds({0, 0, 600, 200});
     root.flex().direction = FlexDirection::row;
@@ -5611,9 +5607,9 @@ TEST_CASE("InspectorOverlay P2i: reflow drag shows an insertion LINE at every "
 
 // Column container variant — the insertion LINE is horizontal and the slot
 // index tracks the cursor's Y across the child span.
-TEST_CASE("InspectorOverlay P2i: reflow drag shows a horizontal insertion LINE "
+TEST_CASE("InspectorOverlay: reflow drag shows a horizontal insertion LINE "
           "across a column container's children",
-          "[inspect][overlay][p2i][reflow][drop-indicator][issue-wysiwyg-p2i]") {
+          "[inspect][overlay][reflow][drop-indicator][issue-wysiwyg-p2i]") {
     View root;
     root.set_bounds({0, 0, 200, 600});
     root.flex().direction = FlexDirection::column;
@@ -5668,15 +5664,15 @@ TEST_CASE("InspectorOverlay P2i: reflow drag shows a horizontal insertion LINE "
     REQUIRE(s_after == 2);
 }
 
-// ── WYSIWYG P2i (Refinement B) ────────────────────────────────────────────
+// ── Proportional resize coverage ───────────────────────────────────────────
 // After a Shift (proportional) resize, the scaled content must stay WITHIN
 // the resize box: every direct child's scaled rect (origin-(0,0) anchored,
 // scaled by the view's scale()) must lie inside the container's box bounds —
 // no spill past any edge. Also asserts the box is clipped (overflow:hidden)
 // and the scale anchor is top-left.
-TEST_CASE("InspectorOverlay P2i: Shift-resize keeps scaled content inside the "
+TEST_CASE("InspectorOverlay: Shift-resize keeps scaled content inside the "
           "box (no spill past the selection rectangle)",
-          "[inspect][overlay][p2i][resize][proportional][issue-wysiwyg-p2i]") {
+          "[inspect][overlay][resize][proportional][issue-wysiwyg-p2i]") {
     View root;
     root.set_bounds({0, 0, 800, 600});
 
@@ -5685,7 +5681,7 @@ TEST_CASE("InspectorOverlay P2i: Shift-resize keeps scaled content inside the "
     // set manually and we do NOT call layout_children() before the gesture so
     // the box stays put (Yoga would otherwise reflow a flex child to the
     // content origin and move the resize handles). This mirrors the existing
-    // P2c proportional-resize test's setup.
+    // Proportional-resize test's setup.
     auto box = std::make_unique<View>();
     box->set_anchor_id("anchor-box");
     box->set_bounds({40, 40, 120, 80});
@@ -5771,17 +5767,15 @@ TEST_CASE("InspectorOverlay P2i: Shift-resize keeps scaled content inside the "
     REQUIRE(box_ptr->overflow() == View::Overflow::visible);
 }
 
-// ── P3: Figma-style tool palette + inline text editing ──────────────────────
+// ── Tool palette and inline text editing ───────────────────────────────────
 //
-// planning/2026-05-21-wysiwyg-direct-manipulation-extension.md
-// § "Future idea — Figma-style tool palette + inline text editing".
 // V = Select tool (default), T = Text tool. The Text tool clicks a
 // text-bearing element to edit its copy in place: Enter commits (live
 // View text + a `text` content tweak, ONE undoable EditHistory unit),
 // Esc cancels. The bare T tweak-panel toggle moved to Shift+T.
 
-TEST_CASE("InspectorOverlay P3: set_tool / V / T switch tools",
-          "[inspect][overlay][phase3][tools]") {
+TEST_CASE("InspectorOverlay: set_tool / V / T switch tools",
+          "[inspect][overlay][tools]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     InspectorOverlay overlay(root);
@@ -5811,9 +5805,9 @@ TEST_CASE("InspectorOverlay P3: set_tool / V / T switch tools",
     REQUIRE(overlay.tool() == InspectorOverlay::Tool::select);
 }
 
-TEST_CASE("InspectorOverlay P3: Text tool click begins inline edit, not "
+TEST_CASE("InspectorOverlay: Text tool click begins inline edit, not "
           "select-for-drag",
-          "[inspect][overlay][phase3][text-tool]") {
+          "[inspect][overlay][text-tool]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     auto label = std::make_unique<Label>("Hello");
@@ -5847,9 +5841,9 @@ TEST_CASE("InspectorOverlay P3: Text tool click begins inline edit, not "
     REQUIRE(store.count() == 0);
 }
 
-TEST_CASE("InspectorOverlay P3: typing + Enter commits text, emits `text` "
+TEST_CASE("InspectorOverlay: typing + Enter commits text, emits `text` "
           "tweak, undoable",
-          "[inspect][overlay][phase3][text-tool][undo]") {
+          "[inspect][overlay][text-tool][undo]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     auto label = std::make_unique<Label>("Old");
@@ -5910,8 +5904,8 @@ TEST_CASE("InspectorOverlay P3: typing + Enter commits text, emits `text` "
     REQUIRE(store.lookup("figma:label-1", "text")->getString() == "New");
 }
 
-TEST_CASE("InspectorOverlay P3: Esc cancels inline text edit, reverts copy",
-          "[inspect][overlay][phase3][text-tool]") {
+TEST_CASE("InspectorOverlay: Esc cancels inline text edit, reverts copy",
+          "[inspect][overlay][text-tool]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     auto label = std::make_unique<Label>("Keep");
@@ -6087,7 +6081,7 @@ TEST_CASE("InspectorOverlay T2: caret + selection paint as a light overlay",
 
     InspectorOverlay overlay(root);
     overlay.set_active(true);
-    overlay.set_manipulate_only(true);  // P1 manipulate layer (ui-preview path)
+    overlay.set_manipulate_only(true);  // manipulate layer (ui-preview path)
     overlay.set_tool(InspectorOverlay::Tool::text);
     REQUIRE(overlay.begin_text_edit(label));
     overlay.text_select_all();
@@ -6284,8 +6278,8 @@ TEST_CASE("InspectorOverlay QA BUG4: text-edit shows subtle outline, no handles"
     }
 }
 
-TEST_CASE("InspectorOverlay P3: Select tool clicks still select (unchanged)",
-          "[inspect][overlay][phase3][text-tool][regression]") {
+TEST_CASE("InspectorOverlay: Select tool clicks still select (unchanged)",
+          "[inspect][overlay][text-tool][regression]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     auto label = std::make_unique<Label>("Click me");
@@ -6307,8 +6301,8 @@ TEST_CASE("InspectorOverlay P3: Select tool clicks still select (unchanged)",
     REQUIRE_FALSE(overlay.text_editing());
 }
 
-TEST_CASE("InspectorOverlay P3: Text tool only edits text-bearing views",
-          "[inspect][overlay][phase3][text-tool]") {
+TEST_CASE("InspectorOverlay: Text tool only edits text-bearing views",
+          "[inspect][overlay][text-tool]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     // A plain (non-text) View.
@@ -6336,8 +6330,8 @@ TEST_CASE("InspectorOverlay P3: Text tool only edits text-bearing views",
     REQUIRE_FALSE(overlay.text_editing());
 }
 
-TEST_CASE("InspectorOverlay P3: TextEditor is also editable via the Text tool",
-          "[inspect][overlay][phase3][text-tool]") {
+TEST_CASE("InspectorOverlay: TextEditor is also editable via the Text tool",
+          "[inspect][overlay][text-tool]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     auto editor = std::make_unique<pulp::view::TextEditor>();
@@ -6618,16 +6612,16 @@ TEST_CASE("InspectorOverlay P5: editing text re-shapes — laid-out width update
     overlay.cancel_text_edit();
 }
 
-// ── P3: InspectorWindow tool strip ──────────────────────────────────────────
+// ── InspectorWindow tool strip ─────────────────────────────────────────────
 //
 // The window header carries a Figma-style tool strip wired to the overlay
 // tool BOTH ways via the host: a strip-button click fires on_tool_picked
 // (host → overlay.set_tool); a keyboard V/T flip is mirrored back by the
 // host calling set_active_tool so the strip highlights the active tool.
 
-TEST_CASE("InspectorWindow P3: tool strip is present and active-tool "
+TEST_CASE("InspectorWindow: tool strip is present and active-tool "
           "round-trips",
-          "[inspect][window][phase3][tools]") {
+          "[inspect][window][tools]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     InspectorWindow window(root);

--- a/test/test_inspector_atlas_viewer.cpp
+++ b/test/test_inspector_atlas_viewer.cpp
@@ -53,8 +53,8 @@ AtlasInventory make_atlas_inventory() {
 
 } // namespace
 
-TEST_CASE("InspectorOverlay Phase 6.2: A key toggles the atlas viewer",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: A key toggles the atlas viewer",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     InspectorOverlay overlay(root);
@@ -73,8 +73,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: A key toggles the atlas viewer",
     REQUIRE_FALSE(overlay.atlas_viewer_visible());
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: A key ignored when inspector inactive",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: A key ignored when inspector inactive",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 400, 300});
     InspectorOverlay overlay(root);
@@ -89,8 +89,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: A key ignored when inspector inactive",
     REQUIRE_FALSE(overlay.atlas_viewer_visible());
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: viewer renders a row per atlas",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: viewer renders a row per atlas",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_id("root");
     // Tall enough that the panel's lower section fits both atlas rows.
@@ -117,8 +117,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: viewer renders a row per atlas",
     REQUIRE(overlay.atlas_row_count() == 2);
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: viewer degrades gracefully with no inventory",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: viewer degrades gracefully with no inventory",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 500, 320});
     InspectorOverlay overlay(root);
@@ -132,8 +132,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: viewer degrades gracefully with no invent
     REQUIRE(overlay.atlas_row_count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: empty inventory shows the unavailable state",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: empty inventory shows the unavailable state",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 500, 320});
     InspectorOverlay overlay(root);
@@ -149,8 +149,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: empty inventory shows the unavailable sta
     REQUIRE(overlay.atlas_row_count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: dismissing the inspector clears atlas rows",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: dismissing the inspector clears atlas rows",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 500, 720});
     InspectorOverlay overlay(root);
@@ -171,8 +171,8 @@ TEST_CASE("InspectorOverlay Phase 6.2: dismissing the inspector clears atlas row
     REQUIRE(overlay.atlas_viewer_visible());
 }
 
-TEST_CASE("InspectorOverlay Phase 6.2: pass viewer takes precedence over atlas tab",
-          "[inspect][overlay][atlas][phase6.2]") {
+TEST_CASE("InspectorOverlay atlas viewer: pass viewer takes precedence over atlas tab",
+          "[inspect][overlay][atlas][atlas-viewer]") {
     View root;
     root.set_bounds({0, 0, 500, 720});
     InspectorOverlay overlay(root);

--- a/test/test_inspector_eyedropper.cpp
+++ b/test/test_inspector_eyedropper.cpp
@@ -95,8 +95,8 @@ KeyEvent make_key(KeyCode k, bool is_down = true, uint16_t mods = 0) {
 
 } // namespace
 
-TEST_CASE("InspectorOverlay Phase 3c: eyedropper defaults OFF",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: eyedropper defaults OFF",
+          "[inspect][overlay][eyedropper]") {
     View root;
     InspectorOverlay overlay(root);
     REQUIRE_FALSE(overlay.eyedropper_active());
@@ -109,8 +109,8 @@ TEST_CASE("InspectorOverlay Phase 3c: eyedropper defaults OFF",
     REQUIRE_FALSE(overlay.eyedropper_active());
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: 'E' key toggles eyedropper only when active",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: 'E' key toggles eyedropper only when active",
+          "[inspect][overlay][eyedropper]") {
     View root;
     InspectorOverlay overlay(root);
 
@@ -130,8 +130,8 @@ TEST_CASE("InspectorOverlay Phase 3c: 'E' key toggles eyedropper only when activ
     REQUIRE_FALSE(overlay.eyedropper_active());
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: mouse-move samples color under cursor",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: mouse-move samples color under cursor",
+          "[inspect][overlay][eyedropper]") {
     Phase3cScene s(Color::rgba8(0x12, 0xab, 0x5f));
     s.overlay.set_eyedropper_active(true);
     REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
@@ -145,8 +145,8 @@ TEST_CASE("InspectorOverlay Phase 3c: mouse-move samples color under cursor",
     REQUIRE(c.b8() == 0x5f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: click captures color and emits tweak",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: click captures color and emits tweak",
+          "[inspect][overlay][eyedropper]") {
     Phase3cScene s(Color::rgba8(0xff, 0x80, 0x00));
     s.overlay.set_eyedropper_active(true);
 
@@ -165,8 +165,8 @@ TEST_CASE("InspectorOverlay Phase 3c: click captures color and emits tweak",
     REQUIRE(std::string(v->getString()) == "#ff8000");
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: click without prior move still picks",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: click without prior move still picks",
+          "[inspect][overlay][eyedropper]") {
     // Resolved-style sampling is synchronous, so a click with no
     // preceding mouse-move still captures a real color (covers
     // scripted / fast-click use).
@@ -181,8 +181,8 @@ TEST_CASE("InspectorOverlay Phase 3c: click without prior move still picks",
     REQUIRE(std::string(v->getString()) == "#404040");
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: click refreshes stale hover sample",
-          "[inspect][overlay][phase3c][regression]") {
+TEST_CASE("InspectorOverlay eyedropper: click refreshes stale hover sample",
+          "[inspect][overlay][eyedropper][regression]") {
     Phase3cScene s(Color::rgba8(0xff, 0x00, 0x00));
 
     auto second = std::make_unique<View>();
@@ -210,8 +210,8 @@ TEST_CASE("InspectorOverlay Phase 3c: click refreshes stale hover sample",
     REQUIRE(std::string(v->getString()) == "#0066ff");
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: click never commits a stale sample",
-          "[inspect][overlay][phase3c][regression]") {
+TEST_CASE("InspectorOverlay eyedropper: click never commits a stale sample",
+          "[inspect][overlay][eyedropper][regression]") {
     // Regression cover for #2434: pressing E and clicking on empty canvas must
     // not write a stale color into the tweak store. A prior sample can be left
     // behind by an earlier hover, or by paint_eyedropper_cursor sampling from
@@ -240,8 +240,8 @@ TEST_CASE("InspectorOverlay Phase 3c: click never commits a stale sample",
     REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: retargeting writes a different property",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: retargeting writes a different property",
+          "[inspect][overlay][eyedropper]") {
     Phase3cScene s(Color::rgba8(0x00, 0x99, 0xff));
     s.overlay.set_eyedropper_target("style.border_color");
     s.overlay.set_eyedropper_active(true);
@@ -256,8 +256,8 @@ TEST_CASE("InspectorOverlay Phase 3c: retargeting writes a different property",
     REQUIRE(s.overlay.eyedropper_target() == "style.border_color");
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: sample_color_at hex round-trips alpha",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: sample_color_at hex round-trips alpha",
+          "[inspect][overlay][eyedropper]") {
     // A semi-transparent background encodes as 8-digit "#rrggbbaa".
     Phase3cScene s(Color::rgba8(0x20, 0x30, 0x40, 0x80));
     s.overlay.set_eyedropper_active(true);
@@ -267,8 +267,8 @@ TEST_CASE("InspectorOverlay Phase 3c: sample_color_at hex round-trips alpha",
     REQUIRE(std::string(v->getString()) == "#20304080");
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: eyedropper yields to the panel",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: eyedropper yields to the panel",
+          "[inspect][overlay][eyedropper]") {
     // A click inside the inspector panel must NOT be eaten by the
     // eyedropper — the user still needs tree / field interaction.
     Phase3cScene s;
@@ -283,8 +283,8 @@ TEST_CASE("InspectorOverlay Phase 3c: eyedropper yields to the panel",
     REQUIRE(s.store.count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: pick no-ops without a selection anchor",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: pick no-ops without a selection anchor",
+          "[inspect][overlay][eyedropper]") {
     // Hand-authored view with no anchor — the eyedropper still
     // disables (the click was a deliberate spend) but emits nothing.
     View root;
@@ -306,8 +306,8 @@ TEST_CASE("InspectorOverlay Phase 3c: pick no-ops without a selection anchor",
     REQUIRE(store.count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: deactivating inspector clears eyedropper",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: deactivating inspector clears eyedropper",
+          "[inspect][overlay][eyedropper]") {
     Phase3cScene s;
     s.overlay.set_eyedropper_active(true);
     s.overlay.handle_mouse_event(make_move(80, 70));
@@ -318,8 +318,8 @@ TEST_CASE("InspectorOverlay Phase 3c: deactivating inspector clears eyedropper",
     REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
 }
 
-TEST_CASE("InspectorOverlay Phase 3c: paint draws swatch when armed",
-          "[inspect][overlay][phase3c]") {
+TEST_CASE("InspectorOverlay eyedropper: paint draws swatch when armed",
+          "[inspect][overlay][eyedropper]") {
     // The cursor swatch must paint without crashing once a sample
     // exists; RecordingCanvas has no pixel readback so this exercises
     // the resolved-style path + the swatch chrome.

--- a/test/test_inspector_eyedropper.cpp
+++ b/test/test_inspector_eyedropper.cpp
@@ -45,16 +45,16 @@ namespace {
 // Build a root + child where the child carries an explicit background
 // color (so the resolved-style fallback has something to sample) and
 // an anchor (so the eyedropper tweak can land in the store).
-struct Phase3cScene {
+struct EyedropperScene {
     View root;
     View* child = nullptr;
     TweakStore store;
     InspectorOverlay overlay{root};
 
-    explicit Phase3cScene(Color child_bg = Color::rgba8(0x33, 0x66, 0xcc)) {
+    explicit EyedropperScene(Color child_bg = Color::rgba8(0x33, 0x66, 0xcc)) {
         root.set_bounds({0, 0, 500, 400});
         auto c = std::make_unique<View>();
-        c->set_anchor_id("figma:3c:1");
+        c->set_anchor_id("figma:eyedropper:1");
         c->set_bounds({40, 40, 120, 80});
         c->set_background_color(child_bg);
         child = c.get();
@@ -132,7 +132,7 @@ TEST_CASE("InspectorOverlay eyedropper: 'E' key toggles eyedropper only when act
 
 TEST_CASE("InspectorOverlay eyedropper: mouse-move samples color under cursor",
           "[inspect][overlay][eyedropper]") {
-    Phase3cScene s(Color::rgba8(0x12, 0xab, 0x5f));
+    EyedropperScene s(Color::rgba8(0x12, 0xab, 0x5f));
     s.overlay.set_eyedropper_active(true);
     REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
 
@@ -147,7 +147,7 @@ TEST_CASE("InspectorOverlay eyedropper: mouse-move samples color under cursor",
 
 TEST_CASE("InspectorOverlay eyedropper: click captures color and emits tweak",
           "[inspect][overlay][eyedropper]") {
-    Phase3cScene s(Color::rgba8(0xff, 0x80, 0x00));
+    EyedropperScene s(Color::rgba8(0xff, 0x80, 0x00));
     s.overlay.set_eyedropper_active(true);
 
     // Hover to sample, then click to apply.
@@ -160,7 +160,7 @@ TEST_CASE("InspectorOverlay eyedropper: click captures color and emits tweak",
 
     // The tweak landed in the store under the selection's anchor.
     REQUIRE(s.store.count() == 1);
-    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    auto v = s.store.lookup("figma:eyedropper:1", "style.background_color");
     REQUIRE(v.has_value());
     REQUIRE(std::string(v->getString()) == "#ff8000");
 }
@@ -170,23 +170,23 @@ TEST_CASE("InspectorOverlay eyedropper: click without prior move still picks",
     // Resolved-style sampling is synchronous, so a click with no
     // preceding mouse-move still captures a real color (covers
     // scripted / fast-click use).
-    Phase3cScene s(Color::rgba8(0x40, 0x40, 0x40));
+    EyedropperScene s(Color::rgba8(0x40, 0x40, 0x40));
     s.overlay.set_eyedropper_active(true);
 
     bool consumed = s.overlay.handle_mouse_event(make_click(100, 90));
     REQUIRE(consumed);
     REQUIRE(s.store.count() == 1);
-    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    auto v = s.store.lookup("figma:eyedropper:1", "style.background_color");
     REQUIRE(v.has_value());
     REQUIRE(std::string(v->getString()) == "#404040");
 }
 
 TEST_CASE("InspectorOverlay eyedropper: click refreshes stale hover sample",
           "[inspect][overlay][eyedropper][regression]") {
-    Phase3cScene s(Color::rgba8(0xff, 0x00, 0x00));
+    EyedropperScene s(Color::rgba8(0xff, 0x00, 0x00));
 
     auto second = std::make_unique<View>();
-    second->set_anchor_id("figma:3c:2");
+    second->set_anchor_id("figma:eyedropper:2");
     second->set_bounds({40, 150, 120, 80});
     second->set_background_color(Color::rgba8(0x00, 0x66, 0xff));
     s.root.add_child(std::move(second));
@@ -205,7 +205,7 @@ TEST_CASE("InspectorOverlay eyedropper: click refreshes stale hover sample",
     bool consumed = s.overlay.handle_mouse_event(make_click(90, 170));
     REQUIRE(consumed);
 
-    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    auto v = s.store.lookup("figma:eyedropper:1", "style.background_color");
     REQUIRE(v.has_value());
     REQUIRE(std::string(v->getString()) == "#0066ff");
 }
@@ -219,7 +219,7 @@ TEST_CASE("InspectorOverlay eyedropper: click never commits a stale sample",
     // When the click lands where the resolved-style fallback finds no
     // background-colored view, the resample fails — and the pick must
     // no-op rather than commit the stale color from the old position.
-    Phase3cScene s(Color::rgba8(0xff, 0x00, 0x00));
+    EyedropperScene s(Color::rgba8(0xff, 0x00, 0x00));
     s.overlay.set_eyedropper_active(true);
 
     // Seed a stale sample by hovering over the colored child.
@@ -242,12 +242,12 @@ TEST_CASE("InspectorOverlay eyedropper: click never commits a stale sample",
 
 TEST_CASE("InspectorOverlay eyedropper: retargeting writes a different property",
           "[inspect][overlay][eyedropper]") {
-    Phase3cScene s(Color::rgba8(0x00, 0x99, 0xff));
+    EyedropperScene s(Color::rgba8(0x00, 0x99, 0xff));
     s.overlay.set_eyedropper_target("style.border_color");
     s.overlay.set_eyedropper_active(true);
 
     s.overlay.handle_mouse_event(make_click(80, 70));
-    auto v = s.store.lookup("figma:3c:1", "style.border_color");
+    auto v = s.store.lookup("figma:eyedropper:1", "style.border_color");
     REQUIRE(v.has_value());
     REQUIRE(std::string(v->getString()) == "#0099ff");
 
@@ -259,10 +259,10 @@ TEST_CASE("InspectorOverlay eyedropper: retargeting writes a different property"
 TEST_CASE("InspectorOverlay eyedropper: sample_color_at hex round-trips alpha",
           "[inspect][overlay][eyedropper]") {
     // A semi-transparent background encodes as 8-digit "#rrggbbaa".
-    Phase3cScene s(Color::rgba8(0x20, 0x30, 0x40, 0x80));
+    EyedropperScene s(Color::rgba8(0x20, 0x30, 0x40, 0x80));
     s.overlay.set_eyedropper_active(true);
     s.overlay.handle_mouse_event(make_click(80, 70));
-    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    auto v = s.store.lookup("figma:eyedropper:1", "style.background_color");
     REQUIRE(v.has_value());
     REQUIRE(std::string(v->getString()) == "#20304080");
 }
@@ -271,7 +271,7 @@ TEST_CASE("InspectorOverlay eyedropper: eyedropper yields to the panel",
           "[inspect][overlay][eyedropper]") {
     // A click inside the inspector panel must NOT be eaten by the
     // eyedropper — the user still needs tree / field interaction.
-    Phase3cScene s;
+    EyedropperScene s;
     s.overlay.set_eyedropper_active(true);
 
     // Panel occupies the right 300px of the 500px-wide root.
@@ -308,7 +308,7 @@ TEST_CASE("InspectorOverlay eyedropper: pick no-ops without a selection anchor",
 
 TEST_CASE("InspectorOverlay eyedropper: deactivating inspector clears eyedropper",
           "[inspect][overlay][eyedropper]") {
-    Phase3cScene s;
+    EyedropperScene s;
     s.overlay.set_eyedropper_active(true);
     s.overlay.handle_mouse_event(make_move(80, 70));
     REQUIRE(s.overlay.eyedropper_has_sample());
@@ -323,7 +323,7 @@ TEST_CASE("InspectorOverlay eyedropper: paint draws swatch when armed",
     // The cursor swatch must paint without crashing once a sample
     // exists; RecordingCanvas has no pixel readback so this exercises
     // the resolved-style path + the swatch chrome.
-    Phase3cScene s;
+    EyedropperScene s;
     s.overlay.set_eyedropper_active(true);
     s.overlay.handle_mouse_event(make_move(80, 70));
     REQUIRE(s.overlay.eyedropper_has_sample());

--- a/test/test_inspector_field_edit.cpp
+++ b/test/test_inspector_field_edit.cpp
@@ -87,8 +87,8 @@ KeyEvent make_key(KeyCode k, bool is_down = true, uint16_t mods = 0) {
 
 } // namespace
 
-TEST_CASE("InspectorOverlay Phase 3b: begin_field_edit sets editing state",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: begin_field_edit sets editing state",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     REQUIRE(s.overlay.selected_view() == s.child);
     REQUIRE_FALSE(s.overlay.is_editing());
@@ -101,8 +101,8 @@ TEST_CASE("InspectorOverlay Phase 3b: begin_field_edit sets editing state",
     REQUIRE(s.overlay.edit_caret_pos() == 1);  // caret at end of "8"
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: begin_field_edit refuses without selection",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: begin_field_edit refuses without selection",
+          "[inspect][overlay][field-edit]") {
     View root;
     InspectorOverlay overlay(root);
     overlay.set_active(true);
@@ -112,8 +112,8 @@ TEST_CASE("InspectorOverlay Phase 3b: begin_field_edit refuses without selection
     REQUIRE_FALSE(overlay.is_editing());
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: typing digits extends edit buffer",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: typing digits extends edit buffer",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     REQUIRE(s.overlay.begin_field_edit("layout.padding", 8.0f));
     REQUIRE(s.overlay.edit_buffer() == "8");
@@ -131,8 +131,8 @@ TEST_CASE("InspectorOverlay Phase 3b: typing digits extends edit buffer",
     REQUIRE(s.child->flex().padding == 850.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: backspace trims buffer",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: backspace trims buffer",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     s.overlay.handle_key_event(make_key(KeyCode::num5));
@@ -143,8 +143,8 @@ TEST_CASE("InspectorOverlay Phase 3b: backspace trims buffer",
     REQUIRE(s.overlay.edit_caret_pos() == 1);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Enter commits tweak to TweakStore",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Enter commits tweak to TweakStore",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Type "5" → buffer is "85"
@@ -164,8 +164,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Enter commits tweak to TweakStore",
     REQUIRE(s.child->flex().padding == 85.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Esc cancels and reverts",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Esc cancels and reverts",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Bump to "85" — real-time preview mutates the View.
@@ -178,8 +178,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Esc cancels and reverts",
     REQUIRE(s.child->flex().padding == 8.0f);      // reverted
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Up arrow increments by 1",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Up arrow increments by 1",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
@@ -192,8 +192,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Up arrow increments by 1",
     REQUIRE(s.child->flex().padding == 10.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Down arrow decrements by 1",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Down arrow decrements by 1",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
@@ -202,8 +202,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Down arrow decrements by 1",
     REQUIRE(s.child->flex().padding == 7.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Shift+Up nudges by 10",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Shift+Up nudges by 10",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
@@ -215,8 +215,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Shift+Up nudges by 10",
     REQUIRE(s.overlay.edit_buffer() == "8");
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Cmd+Up nudges by 100 (Figma semantics)",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Cmd+Up nudges by 100 (Figma semantics)",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
@@ -230,8 +230,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Cmd+Up nudges by 100 (Figma semantics)",
     REQUIRE(s.child->flex().padding == 108.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Tab commits and moves to next field",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Tab commits and moves to next field",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     // Paint once so editable_fields_ is populated with the panel's
     // tab order.
@@ -251,8 +251,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Tab commits and moves to next field",
     REQUIRE(s.overlay.editing_field() != "layout.padding");
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: clicking a numeric value enters edit mode",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: clicking a numeric value enters edit mode",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     // Paint to populate editable_fields_ (the panel-side hit rects).
     pulp::canvas::RecordingCanvas canvas;
@@ -293,8 +293,8 @@ TEST_CASE("InspectorOverlay Phase 3b: clicking a numeric value enters edit mode"
     REQUIRE(entered);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: editing layout.width writes to preferred_width",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: editing layout.width writes to preferred_width",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.width", s.child->flex().preferred_width);
     REQUIRE(s.overlay.edit_buffer() == "80");
@@ -309,8 +309,8 @@ TEST_CASE("InspectorOverlay Phase 3b: editing layout.width writes to preferred_w
     REQUIRE(v->getFloat32() == 805.0f);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: editing style.opacity round-trips",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: editing style.opacity round-trips",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.child->set_opacity(0.5f);
     s.overlay.begin_field_edit("style.opacity", 0.5f);
@@ -328,8 +328,8 @@ TEST_CASE("InspectorOverlay Phase 3b: editing style.opacity round-trips",
     REQUIRE(v.has_value());
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: cancel_field_edit on inactive is no-op",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: cancel_field_edit on inactive is no-op",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     REQUIRE_FALSE(s.overlay.is_editing());
     s.overlay.cancel_field_edit();  // must not crash
@@ -337,9 +337,9 @@ TEST_CASE("InspectorOverlay Phase 3b: cancel_field_edit on inactive is no-op",
     REQUIRE(s.store.count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: commit_field_edit with empty buffer "
+TEST_CASE("InspectorOverlay field edit: commit_field_edit with empty buffer "
           "exits edit without emitting tweak",
-          "[inspect][overlay][phase3b]") {
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Backspace twice to empty the buffer ("8" → "")
@@ -351,8 +351,8 @@ TEST_CASE("InspectorOverlay Phase 3b: commit_field_edit with empty buffer "
     REQUIRE(s.store.count() == 0);
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: caret moves with Left/Right/Home/End",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: caret moves with Left/Right/Home/End",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 80.0f);
     REQUIRE(s.overlay.edit_buffer() == "80");
@@ -371,8 +371,8 @@ TEST_CASE("InspectorOverlay Phase 3b: caret moves with Left/Right/Home/End",
     REQUIRE(s.overlay.edit_caret_pos() == 2);  // already at end
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: deactivating inspector cancels active edit",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: deactivating inspector cancels active edit",
+          "[inspect][overlay][field-edit]") {
     Phase3bScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     s.overlay.handle_key_event(make_key(KeyCode::num5));
@@ -385,8 +385,8 @@ TEST_CASE("InspectorOverlay Phase 3b: deactivating inspector cancels active edit
     REQUIRE(s.store.count() == 0);              // no tweak emitted
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Esc while editing does NOT exit inspector",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Esc while editing does NOT exit inspector",
+          "[inspect][overlay][field-edit]") {
     // Esc inside an edit cancels the edit (selection intact). After that, Esc
     // with a selection DESELECTS (it no longer ascends to the parent), and Esc
     // with nothing selected is a NO-OP — Esc never exits the inspector (Cmd+I /
@@ -413,8 +413,8 @@ TEST_CASE("InspectorOverlay Phase 3b: Esc while editing does NOT exit inspector"
     REQUIRE(s.overlay.is_active());
 }
 
-TEST_CASE("InspectorOverlay Phase 3b: Tab without paint does nothing extra",
-          "[inspect][overlay][phase3b]") {
+TEST_CASE("InspectorOverlay field edit: Tab without paint does nothing extra",
+          "[inspect][overlay][field-edit]") {
     // Tab consults the editable_fields_ list populated by the last
     // paint. If we Tab without ever painting, commit happens but no
     // next-field move occurs (gracefully).

--- a/test/test_inspector_field_edit.cpp
+++ b/test/test_inspector_field_edit.cpp
@@ -48,16 +48,16 @@ using namespace pulp::inspect;
 namespace {
 
 // Build a small root + child with an anchor for tweak-emission tests.
-struct Phase3bScene {
+struct FieldEditScene {
     View root;
     View* child = nullptr;
     TweakStore store;
     InspectorOverlay overlay{root};
 
-    Phase3bScene() {
+    FieldEditScene() {
         root.set_bounds({0, 0, 500, 400});
         auto c = std::make_unique<View>();
-        c->set_anchor_id("figma:3b:1");
+        c->set_anchor_id("figma:field-edit:1");
         c->set_bounds({10, 10, 80, 40});
         c->flex().padding = 8;
         c->flex().margin = 4;
@@ -89,7 +89,7 @@ KeyEvent make_key(KeyCode k, bool is_down = true, uint16_t mods = 0) {
 
 TEST_CASE("InspectorOverlay field edit: begin_field_edit sets editing state",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     REQUIRE(s.overlay.selected_view() == s.child);
     REQUIRE_FALSE(s.overlay.is_editing());
 
@@ -114,7 +114,7 @@ TEST_CASE("InspectorOverlay field edit: begin_field_edit refuses without selecti
 
 TEST_CASE("InspectorOverlay field edit: typing digits extends edit buffer",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     REQUIRE(s.overlay.begin_field_edit("layout.padding", 8.0f));
     REQUIRE(s.overlay.edit_buffer() == "8");
 
@@ -133,7 +133,7 @@ TEST_CASE("InspectorOverlay field edit: typing digits extends edit buffer",
 
 TEST_CASE("InspectorOverlay field edit: backspace trims buffer",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     s.overlay.handle_key_event(make_key(KeyCode::num5));
     REQUIRE(s.overlay.edit_buffer() == "85");
@@ -145,7 +145,7 @@ TEST_CASE("InspectorOverlay field edit: backspace trims buffer",
 
 TEST_CASE("InspectorOverlay field edit: Enter commits tweak to TweakStore",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Type "5" → buffer is "85"
     s.overlay.handle_key_event(make_key(KeyCode::num5));
@@ -156,7 +156,7 @@ TEST_CASE("InspectorOverlay field edit: Enter commits tweak to TweakStore",
     // Edit mode exited, tweak persisted, View reflects committed value.
     REQUIRE_FALSE(s.overlay.is_editing());
     REQUIRE(s.store.count() == 1);
-    auto v = s.store.lookup("figma:3b:1", "layout.padding");
+    auto v = s.store.lookup("figma:field-edit:1", "layout.padding");
     REQUIRE(v.has_value());
     // Value stored as float32 — round-trip equality at integer values
     // is safe.
@@ -166,7 +166,7 @@ TEST_CASE("InspectorOverlay field edit: Enter commits tweak to TweakStore",
 
 TEST_CASE("InspectorOverlay field edit: Esc cancels and reverts",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Bump to "85" — real-time preview mutates the View.
     s.overlay.handle_key_event(make_key(KeyCode::num5));
@@ -180,7 +180,7 @@ TEST_CASE("InspectorOverlay field edit: Esc cancels and reverts",
 
 TEST_CASE("InspectorOverlay field edit: Up arrow increments by 1",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
     REQUIRE(s.overlay.handle_key_event(make_key(KeyCode::up)));
@@ -194,7 +194,7 @@ TEST_CASE("InspectorOverlay field edit: Up arrow increments by 1",
 
 TEST_CASE("InspectorOverlay field edit: Down arrow decrements by 1",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
     REQUIRE(s.overlay.handle_key_event(make_key(KeyCode::down)));
@@ -204,7 +204,7 @@ TEST_CASE("InspectorOverlay field edit: Down arrow decrements by 1",
 
 TEST_CASE("InspectorOverlay field edit: Shift+Up nudges by 10",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
     REQUIRE(s.overlay.handle_key_event(make_key(KeyCode::up, true, kModShift)));
@@ -217,7 +217,7 @@ TEST_CASE("InspectorOverlay field edit: Shift+Up nudges by 10",
 
 TEST_CASE("InspectorOverlay field edit: Cmd+Up nudges by 100 (Figma semantics)",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
 
 #ifdef __APPLE__
@@ -232,7 +232,7 @@ TEST_CASE("InspectorOverlay field edit: Cmd+Up nudges by 100 (Figma semantics)",
 
 TEST_CASE("InspectorOverlay field edit: Tab commits and moves to next field",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     // Paint once so editable_fields_ is populated with the panel's
     // tab order.
     pulp::canvas::RecordingCanvas canvas;
@@ -244,7 +244,7 @@ TEST_CASE("InspectorOverlay field edit: Tab commits and moves to next field",
     REQUIRE(s.overlay.handle_key_event(make_key(KeyCode::tab)));
     // The previous field's edit was committed (tweak in store).
     REQUIRE(s.store.count() == 1);
-    REQUIRE(s.store.lookup("figma:3b:1", "layout.padding").has_value());
+    REQUIRE(s.store.lookup("figma:field-edit:1", "layout.padding").has_value());
     // We're now editing a different field (whatever follows padding
     // in the panel's draw order).
     REQUIRE(s.overlay.is_editing());
@@ -253,7 +253,7 @@ TEST_CASE("InspectorOverlay field edit: Tab commits and moves to next field",
 
 TEST_CASE("InspectorOverlay field edit: clicking a numeric value enters edit mode",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     // Paint to populate editable_fields_ (the panel-side hit rects).
     pulp::canvas::RecordingCanvas canvas;
     s.overlay.paint(canvas);
@@ -295,7 +295,7 @@ TEST_CASE("InspectorOverlay field edit: clicking a numeric value enters edit mod
 
 TEST_CASE("InspectorOverlay field edit: editing layout.width writes to preferred_width",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.width", s.child->flex().preferred_width);
     REQUIRE(s.overlay.edit_buffer() == "80");
 
@@ -304,14 +304,14 @@ TEST_CASE("InspectorOverlay field edit: editing layout.width writes to preferred
     REQUIRE(s.child->flex().preferred_width == 805.0f);
 
     s.overlay.handle_key_event(make_key(KeyCode::enter));
-    auto v = s.store.lookup("figma:3b:1", "layout.width");
+    auto v = s.store.lookup("figma:field-edit:1", "layout.width");
     REQUIRE(v.has_value());
     REQUIRE(v->getFloat32() == 805.0f);
 }
 
 TEST_CASE("InspectorOverlay field edit: editing style.opacity round-trips",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.child->set_opacity(0.5f);
     s.overlay.begin_field_edit("style.opacity", 0.5f);
 
@@ -324,13 +324,13 @@ TEST_CASE("InspectorOverlay field edit: editing style.opacity round-trips",
     REQUIRE(s.child->opacity() == 1.0f);
     s.overlay.handle_key_event(make_key(KeyCode::enter));
 
-    auto v = s.store.lookup("figma:3b:1", "style.opacity");
+    auto v = s.store.lookup("figma:field-edit:1", "style.opacity");
     REQUIRE(v.has_value());
 }
 
 TEST_CASE("InspectorOverlay field edit: cancel_field_edit on inactive is no-op",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     REQUIRE_FALSE(s.overlay.is_editing());
     s.overlay.cancel_field_edit();  // must not crash
     REQUIRE_FALSE(s.overlay.is_editing());
@@ -340,7 +340,7 @@ TEST_CASE("InspectorOverlay field edit: cancel_field_edit on inactive is no-op",
 TEST_CASE("InspectorOverlay field edit: commit_field_edit with empty buffer "
           "exits edit without emitting tweak",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     // Backspace twice to empty the buffer ("8" → "")
     s.overlay.handle_key_event(make_key(KeyCode::backspace));
@@ -353,7 +353,7 @@ TEST_CASE("InspectorOverlay field edit: commit_field_edit with empty buffer "
 
 TEST_CASE("InspectorOverlay field edit: caret moves with Left/Right/Home/End",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 80.0f);
     REQUIRE(s.overlay.edit_buffer() == "80");
     REQUIRE(s.overlay.edit_caret_pos() == 2);
@@ -373,7 +373,7 @@ TEST_CASE("InspectorOverlay field edit: caret moves with Left/Right/Home/End",
 
 TEST_CASE("InspectorOverlay field edit: deactivating inspector cancels active edit",
           "[inspect][overlay][field-edit]") {
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     s.overlay.handle_key_event(make_key(KeyCode::num5));
     REQUIRE(s.child->flex().padding == 85.0f);
@@ -392,7 +392,7 @@ TEST_CASE("InspectorOverlay field edit: Esc while editing does NOT exit inspecto
     // with nothing selected is a NO-OP — Esc never exits the inspector (Cmd+I /
     // the window close button does that). The inspector stays active throughout
     // so hover + click keep working without a Cmd+I cycle.
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     REQUIRE(s.overlay.is_active());
     // The scene selected `child` (a direct child of root).
@@ -418,7 +418,7 @@ TEST_CASE("InspectorOverlay field edit: Tab without paint does nothing extra",
     // Tab consults the editable_fields_ list populated by the last
     // paint. If we Tab without ever painting, commit happens but no
     // next-field move occurs (gracefully).
-    Phase3bScene s;
+    FieldEditScene s;
     s.overlay.begin_field_edit("layout.padding", 8.0f);
     s.overlay.handle_key_event(make_key(KeyCode::num5));
 

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -305,7 +305,7 @@ TEST_CASE("ScanCache from_json keeps existing cache when blob is malformed",
 }
 
 TEST_CASE("ScanCache from_json keeps existing cache when entry fields have wrong types",
-          "[scan_cache][codecov][phase3]") {
+          "[scan_cache][codecov]") {
     HostScanCache cache;
     cache.put("/tmp/existing.vst3", sample_info());
 
@@ -509,7 +509,7 @@ TEST_CASE("ScanCache duplicate JSON entries keep the last valid record",
 }
 
 TEST_CASE("ScanCache JSON round-trip preserves every plugin format",
-          "[scan_cache][codecov][phase3]") {
+          "[scan_cache][codecov]") {
     HostScanCache written;
 
     const std::vector<std::pair<PluginFormat, std::string>> formats = {
@@ -612,7 +612,7 @@ TEST_CASE("ScanCache save_to creates nested parent directories",
 }
 
 TEST_CASE("ScanCache from_json loads entries without optional metadata",
-          "[scan_cache][codecov][phase3]") {
+          "[scan_cache][codecov]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,
@@ -644,7 +644,7 @@ TEST_CASE("ScanCache from_json loads entries without optional metadata",
 }
 
 TEST_CASE("ScanCache from_json keeps valid siblings around malformed records",
-          "[scan_cache][codecov][phase3]") {
+          "[scan_cache][codecov]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -111,7 +111,7 @@ TEST_CASE("JSON round-trip preserves all fields", "[scan_cache]") {
     REQUIRE(e.info.format == PluginFormat::VST3);
 }
 
-TEST_CASE("JSON round-trip preserves workstream 03 slice 3.7 metadata",
+TEST_CASE("JSON round-trip preserves rich plugin metadata",
           "[scan_cache][metadata]") {
     // Covers the additive richer-metadata fields on PluginInfo —
     // scan_cache.hpp's doc promises "older cache blobs that don't

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -93,7 +93,7 @@ NamedPipePair open_named_pipe_pair(const std::filesystem::path& path) {
 }  // namespace
 
 TEST_CASE("StreamResult helper predicates classify errors",
-          "[stream][coverage][phase3]") {
+          "[stream][coverage]") {
     auto ok = StreamResult::make(3);
     REQUIRE(ok.ok());
     REQUIRE_FALSE(ok.would_block());
@@ -112,7 +112,7 @@ TEST_CASE("StreamResult helper predicates classify errors",
 }
 
 TEST_CASE("StreamResult factory preserves explicit zero-byte success",
-          "[stream][coverage][phase3]") {
+          "[stream][coverage]") {
     auto result = StreamResult::make(0);
     REQUIRE(result.ok());
     REQUIRE_FALSE(result.would_block());
@@ -121,7 +121,7 @@ TEST_CASE("StreamResult factory preserves explicit zero-byte success",
 }
 
 TEST_CASE("StreamResult closed failure has no transferred bytes",
-          "[stream][coverage][phase3]") {
+          "[stream][coverage]") {
     auto result = StreamResult::fail(StreamError::Closed);
     REQUIRE_FALSE(result.ok());
     REQUIRE_FALSE(result.would_block());
@@ -130,7 +130,7 @@ TEST_CASE("StreamResult closed failure has no transferred bytes",
 }
 
 TEST_CASE("StreamResult closed predicate only matches closed errors",
-          "[stream][coverage][phase3]") {
+          "[stream][coverage]") {
     auto closed = StreamResult::fail(StreamError::Closed);
     REQUIRE_FALSE(closed.ok());
     REQUIRE_FALSE(closed.would_block());
@@ -164,7 +164,7 @@ TEST_CASE("MemoryStream round-trip", "[stream]") {
 }
 
 TEST_CASE("MemoryStream default starts open and empty",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream;
     REQUIRE(stream.is_open());
     REQUIRE(stream.size() == 0);
@@ -194,7 +194,7 @@ TEST_CASE("MemoryStream partial read", "[stream]") {
 }
 
 TEST_CASE("MemoryStream read cursor remains at end after EOF",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{11, 22});
     std::uint8_t out[4]{};
 
@@ -208,7 +208,7 @@ TEST_CASE("MemoryStream read cursor remains at end after EOF",
 }
 
 TEST_CASE("MemoryStream rewind after EOF allows replay",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{4, 5, 6});
     std::uint8_t out[3]{};
 
@@ -223,7 +223,7 @@ TEST_CASE("MemoryStream rewind after EOF allows replay",
 }
 
 TEST_CASE("MemoryStream close is idempotent",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{1});
     stream.close();
     stream.close();
@@ -235,7 +235,7 @@ TEST_CASE("MemoryStream close is idempotent",
 }
 
 TEST_CASE("MemoryStream write copies caller storage",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream;
     std::uint8_t payload[] = {1, 2, 3};
     REQUIRE(stream.write(payload, sizeof(payload)).bytes == sizeof(payload));
@@ -248,7 +248,7 @@ TEST_CASE("MemoryStream write copies caller storage",
 }
 
 TEST_CASE("MemoryStream write preserves existing unread prefix",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{10, 20, 30});
     std::uint8_t out[2]{};
     REQUIRE(stream.read(out, 1).bytes == 1);
@@ -263,7 +263,7 @@ TEST_CASE("MemoryStream write preserves existing unread prefix",
 }
 
 TEST_CASE("MemoryStream clear is idempotent on open streams",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     stream.clear();
     stream.clear();
@@ -274,7 +274,7 @@ TEST_CASE("MemoryStream clear is idempotent on open streams",
 }
 
 TEST_CASE("MemoryStream zero-byte write on closed stream reports closed",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream;
     stream.close();
 
@@ -338,7 +338,7 @@ TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
 }
 
 TEST_CASE("MemoryStream clear does not reopen a closed stream",
-          "[stream][coverage][phase3-large]") {
+          "[stream][coverage][large]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     stream.close();
     stream.clear();
@@ -437,7 +437,7 @@ TEST_CASE("FileStream append and move keep handle ownership correct", "[stream]"
 }
 
 TEST_CASE("FileStream read-write mode tracks position and zero-byte I/O",
-          "[stream][coverage][phase3]") {
+          "[stream][coverage]") {
     auto path = make_temp_path("pulp_stream_readwrite");
     const std::uint8_t payload[] = {'r', 'w', '0'};
 
@@ -590,7 +590,7 @@ TEST_CASE("MemoryStream clear keeps closed streams closed",
 }
 
 TEST_CASE("MemoryStream appends without rewinding the read cursor",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     std::uint8_t out[4]{};
 
@@ -615,7 +615,7 @@ TEST_CASE("MemoryStream appends without rewinding the read cursor",
 }
 
 TEST_CASE("MemoryStream clear allows fresh writes from the beginning",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{9, 8, 7});
     std::uint8_t discarded[2]{};
     REQUIRE(stream.read(discarded, sizeof(discarded)).bytes == sizeof(discarded));
@@ -637,7 +637,7 @@ TEST_CASE("MemoryStream clear allows fresh writes from the beginning",
 }
 
 TEST_CASE("MemoryStream rejects null buffers for non-empty I/O",
-          "[stream][memory][coverage][phase3]") {
+          "[stream][memory][coverage]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2});
     std::uint8_t byte = 9;
 
@@ -660,7 +660,7 @@ TEST_CASE("MemoryStream rejects null buffers for non-empty I/O",
 }
 
 TEST_CASE("MemoryStream default construction reports open empty stream",
-          "[stream][memory][coverage][phase3-large]") {
+          "[stream][memory][coverage][large]") {
     MemoryStream empty;
     REQUIRE(empty.is_open());
     REQUIRE(empty.size() == 0);
@@ -671,7 +671,7 @@ TEST_CASE("MemoryStream default construction reports open empty stream",
 }
 
 TEST_CASE("FileStream reopen closes the previous handle",
-          "[stream][file][coverage][phase3]") {
+          "[stream][file][coverage]") {
     auto first = make_temp_path("pulp_stream_reopen_first");
     auto second = make_temp_path("pulp_stream_reopen_second");
     const std::uint8_t a[] = {'a'};
@@ -704,7 +704,7 @@ TEST_CASE("FileStream reopen closes the previous handle",
 }
 
 TEST_CASE("FileStream move construction transfers open handle and closes source",
-          "[stream][file][coverage][phase3-large]") {
+          "[stream][file][coverage][large]") {
     auto path = make_temp_path("pulp_stream_move_construct");
     const std::uint8_t payload[] = {'m', 'o', 'v', 'e'};
 
@@ -727,7 +727,7 @@ TEST_CASE("FileStream move construction transfers open handle and closes source"
 }
 
 TEST_CASE("FileStream move assignment handles self and closed sources",
-          "[stream][file][coverage][phase3]") {
+          "[stream][file][coverage]") {
     auto path = make_temp_path("pulp_stream_self_move");
     const std::uint8_t payload[] = {'s', 'e', 'l', 'f'};
 
@@ -755,7 +755,7 @@ TEST_CASE("FileStream move assignment handles self and closed sources",
 }
 
 TEST_CASE("FileStream rejects null buffers for non-empty I/O",
-          "[stream][file][coverage][phase3]") {
+          "[stream][file][coverage]") {
     auto path = make_temp_path("pulp_stream_null_buffers");
     const std::uint8_t payload[] = {'o', 'k'};
 
@@ -825,7 +825,7 @@ TEST_CASE("HttpStream invalid URLs fail without external transport",
 }
 
 TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure",
-          "[stream][http][coverage][phase3]") {
+          "[stream][http][coverage]") {
     HttpStream stream;
     stream.close();
 
@@ -845,7 +845,7 @@ TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure"
 }
 
 TEST_CASE("PipeStream closed and null pipe states fail closed",
-          "[stream][pipe][coverage][phase3]") {
+          "[stream][pipe][coverage]") {
     PipeStream stream;
     std::uint8_t byte = 0;
 
@@ -885,7 +885,7 @@ TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_
 }
 
 TEST_CASE("PipeStream default and moved-empty streams fail closed",
-          "[stream][pipe][coverage][phase3]") {
+          "[stream][pipe][coverage]") {
     PipeStream stream;
     REQUIRE_FALSE(stream.is_open());
 
@@ -908,7 +908,7 @@ TEST_CASE("PipeStream default and moved-empty streams fail closed",
 }
 
 TEST_CASE("PipeStream closed streams still report closed before null-buffer checks",
-          "[stream][pipe][coverage][phase3]") {
+          "[stream][pipe][coverage]") {
     PipeStream stream;
 
     REQUIRE(stream.read(nullptr, 1).closed());
@@ -917,7 +917,7 @@ TEST_CASE("PipeStream closed streams still report closed before null-buffer chec
 
 #ifndef _WIN32
 TEST_CASE("PipeStream POSIX FIFO round-trips bytes",
-          "[stream][pipe][coverage][phase3]") {
+          "[stream][pipe][coverage]") {
     auto path = make_temp_path("pulp_pipe_stream_roundtrip");
     std::filesystem::remove(path);
 
@@ -1058,7 +1058,7 @@ TEST_CASE("NamedPipe POSIX client read waits through initial reply EOF",
 }
 
 TEST_CASE("PipeStream forwards reads and writes over a connected POSIX FIFO",
-          "[stream][pipe][coverage][phase3]") {
+          "[stream][pipe][coverage]") {
     auto path = make_temp_path("pulp_pipe_stream_roundtrip");
     std::filesystem::remove(path);
 

--- a/test/test_test_signal.cpp
+++ b/test/test_test_signal.cpp
@@ -163,7 +163,7 @@ TEST_CASE("TestSignalSource: reset clears state", "[format][test_signal]") {
 }
 
 TEST_CASE("TestSignalSource: active flag follows config type",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     REQUIRE_FALSE(src.is_active());
 
@@ -178,7 +178,7 @@ TEST_CASE("TestSignalSource: active flag follows config type",
 }
 
 TEST_CASE("TestSignalSource: config returns the last audio-thread-applied config",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     auto initial = src.config();
     REQUIRE(initial.type == TestSignalType::none);
@@ -199,7 +199,7 @@ TEST_CASE("TestSignalSource: config returns the last audio-thread-applied config
 }
 
 TEST_CASE("TestSignalSource: deterministic sine samples at quarter-cycle boundaries",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 0.75f});
@@ -215,7 +215,7 @@ TEST_CASE("TestSignalSource: deterministic sine samples at quarter-cycle boundar
 }
 
 TEST_CASE("TestSignalSource: amplitude-only config changes keep phase continuity",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 1.0f});
@@ -234,7 +234,7 @@ TEST_CASE("TestSignalSource: amplitude-only config changes keep phase continuity
 }
 
 TEST_CASE("TestSignalSource: frequency changes reset sine phase",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 1.0f});
@@ -253,7 +253,7 @@ TEST_CASE("TestSignalSource: frequency changes reset sine phase",
 }
 
 TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_sample_rate(48000.0);
     src.set_config({TestSignalType::sine, 440.0f, 0.0f});
@@ -270,7 +270,7 @@ TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
 }
 
 TEST_CASE("TestSignalSource: zero-sized fills apply pending config without writing",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 0.5f});
@@ -289,7 +289,7 @@ TEST_CASE("TestSignalSource: zero-sized fills apply pending config without writi
 }
 
 TEST_CASE("TestSignalSource: file mode without loaded data is silent and not playing",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
     REQUIRE(src.is_active());
@@ -309,7 +309,7 @@ TEST_CASE("TestSignalSource: file mode without loaded data is silent and not pla
 }
 
 TEST_CASE("TestSignalSource: loop flag toggles independently of loaded file state",
-          "[format][test_signal][coverage][phase3]") {
+          "[format][test_signal][coverage]") {
     TestSignalSource src;
     REQUIRE_FALSE(src.is_looping());
 
@@ -359,7 +359,7 @@ TEST_CASE("TestSignalSource: invalid file load and unload reset playback state",
 }
 
 TEST_CASE("TestSignalSource: loading a new file rewinds and stops existing playback",
-          "[format][test_signal][file][coverage][phase3]") {
+          "[format][test_signal][file][coverage]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
 
@@ -391,7 +391,7 @@ TEST_CASE("TestSignalSource: loading a new file rewinds and stops existing playb
 }
 
 TEST_CASE("TestSignalSource: reset stops file playback and rewinds without unloading",
-          "[format][test_signal][file][coverage][phase3]") {
+          "[format][test_signal][file][coverage]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
 

--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -214,7 +214,7 @@ TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
 }
 
 TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
-          "[host][scan-worker][coverage][phase3]") {
+          "[host][scan-worker][coverage]") {
     ScratchDir scratch("vst3-moduleinfo");
     auto bundle = scratch.path / "ModuleInfoProbe.vst3";
     fs::create_directories(bundle / "Contents" / "Resources");
@@ -244,7 +244,7 @@ TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
 }
 
 TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
-          "[host][scan-worker][coverage][phase3]") {
+          "[host][scan-worker][coverage]") {
     ScratchDir scratch("vst3-siblings");
     auto target = scratch.path / "Target.vst3";
     auto sibling = scratch.path / "Sibling.vst3";
@@ -264,7 +264,7 @@ TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
 }
 
 TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
-          "[host][scan-worker][coverage][phase3]") {
+          "[host][scan-worker][coverage]") {
     ScratchDir scratch("clap-fallback");
     auto bundle = scratch.path / "Fallback.clap";
     write_file(bundle, "not a dynamic library");
@@ -283,7 +283,7 @@ TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
 }
 
 TEST_CASE("pulp-scan-worker preserves fallback JSON fields for spaced CLAP paths",
-          "[host][scan-worker][coverage][phase3]") {
+          "[host][scan-worker][coverage]") {
     ScratchDir scratch("spaced-clap");
     auto bundle = scratch.path / "Space Name.clap";
     write_file(bundle, "not a dynamic library");

--- a/tools/scripts/sign-notarize-auv3-mac.sh
+++ b/tools/scripts/sign-notarize-auv3-mac.sh
@@ -14,8 +14,7 @@
 #   APPEX_ENTITLEMENTS  Absolute path to .appex entitlements plist
 #   HOST_ENTITLEMENTS   Absolute path to host .app entitlements plist
 #
-# This implements the macOS AU v3 packaging recipe from
-# planning/2026-05-23-auv3-macos-ui-phase35.md:
+# This implements the macOS AU v3 packaging recipe:
 #   1. Sign nested dylibs (libwgpu_native.dylib, etc.) FIRST
 #   2. Sign framework with hardened runtime
 #   3. Sign .appex with hardened runtime + sandbox entitlements


### PR DESCRIPTION
## Summary
- consolidate the queued CLI, inspector, stream/scan, ship, and Canvas2D comment-hygiene follow-ups into one PR
- replace phase/slice/PR breadcrumb wording in comments, test names, tags, and compat evidence with present-tense capability labels
- keep behavior unchanged; this is source/doc/test-label hygiene only

## Validation
- git diff --check
- stale breadcrumb grep over origin/main..HEAD
- targeted stale breadcrumb grep over the touched follow-up files
- python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- cmake --build build --target pulp-rust-cli pulp-cli -j$(sysctl -n hw.ncpu)
- cmake --build build --target pulp-import-design -j$(sysctl -n hw.ncpu)
- focused CLI, inspector, stream/scan, ship, Canvas2D, and test-signal suites passed after rebase onto origin/main@60d3d3a76
- Codex + Claude autoreview clean twice, including after final rebase

Note: a direct push accidentally started the full local diff-coverage path and was stopped after the build completed and CTest had reached 1069/10666; the branch was then pushed with PULP_SKIP_DIFF_COVER=1 so the single consolidated PR runs CI once instead of multiplying queue load.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates test/doc hygiene across CLI, Inspector, Stream/Scan, Ship, and Canvas2D. Replaces legacy phase/slice/PR breadcrumbs with present-tense capability labels and refreshes Canvas2D compat evidence. No behavior changes.

- **Refactors**
  - Merged queued follow-ups into one PR to avoid extra CI runs.
  - Standardized tags and comments by dropping phase/slice/PR breadcrumbs in test names, tags, and comments in favor of capability labels (e.g., [cli][kit], [shellout][coverage], [inspect][overlay][field-edit], [atlas-viewer]).
  - Updated Canvas2D compat anchors to `test/test_widget_bridge_wave2_cheap.cpp` with `[view][bridge][canvas][wave2-canvas2d]`; refreshed `compat.json`, `compat/canvas2d.json`, and `docs/reference/compat/canvas2d.md` (PASS 11→18; fewer SUPPORTED-NO-EVIDENCE rows).
  - Pruned stale gotcha references (e.g., removed `canvas2d/ellipse` from the “needs evidence refresh” list) and clarified inspector test wording and script comments.

<sup>Written for commit 7c2ab4cd2bc885e11346105941299527df11eca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

