### PR TITLE
docs(test): clean format adapter hygiene breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/detail/standalone_audio_capture_wav.hpp
+++ b/core/format/include/pulp/format/detail/standalone_audio_capture_wav.hpp
@@ -26,8 +26,8 @@ constexpr int kMaxCaptureWindowSamples = 16384;
 // drop-on-full, so this holds the EARLIEST ~window samples after the stream
 // starts, not a rolling "last N", and `write_wav_file` quantizes to int16. That
 // is robust for `summarize`/`assert` (presence / level / clip / NaN), but it is
-// the wrong window for steady-state `doctor` (THD/response) and is
-// quantization-limited for `compare` — those wait on the rolling-ring follow-up.
+// the wrong source for steady-state `doctor` (THD/response) and is
+// quantization-limited for `compare`.
 inline bool write_audio_capture_wav_file(const std::string& path,
                                          audio::AudioProbe& probe,
                                          const StandaloneConfig& config) {

--- a/core/format/include/pulp/format/graph_runtime_worker_pool.hpp
+++ b/core/format/include/pulp/format/graph_runtime_worker_pool.hpp
@@ -19,8 +19,8 @@ namespace pulp::format {
 ///
 /// Tasks are claimed cooperatively via an atomic cursor, so a task is a small
 /// index the caller maps to a unit of work (e.g. a node in the current level).
-/// The same pool is reused across blocks. Idle workers spin with a yield-backoff
-/// (a refinement to OS-park / device-workgroup join is left to a later slice).
+/// The same pool is reused across blocks. Idle workers spin with a yield-backoff;
+/// OS-park / device-workgroup joins are outside the current pool contract.
 ///
 /// Lifetime: start()/stop() are control-thread only. run() is audio-thread only
 /// and must not overlap a stop(). A run_fn must be RT-safe (no alloc/lock) — the

--- a/core/format/include/pulp/format/processor_node_adapter.hpp
+++ b/core/format/include/pulp/format/processor_node_adapter.hpp
@@ -17,7 +17,7 @@ namespace pulp::format {
 /// is no second routing path — a ProcessorNode is wired into a snapshot exactly
 /// like any other GraphRuntimeNodeBinding.
 ///
-/// Scope (audio-only first slice): one Main mono audio input and one Main mono
+/// Current scope: one Main mono audio input and one Main mono
 /// audio output. Parameters, MIDI, latency, and state are deliberately out of
 /// scope; the binding presents no EventBlock to the processor, so a processor
 /// that emits MIDI on this path sees the bridge's discard sink.

--- a/core/format/src/processor_node_adapter.cpp
+++ b/core/format/src/processor_node_adapter.cpp
@@ -7,7 +7,7 @@ bool ProcessorNode::prepare(const PrepareContext& context) {
     processor_->prepare(context);
     // Pre-size the discard MIDI sinks so the per-block clear() the bridge runs
     // on the unused fallback buffers never reallocates on the RT thread. The
-    // audio-only slice presents no real events, so a small reservation is
+    // audio-only binding presents no real events, so a small reservation is
     // enough to keep capacity stable across blocks.
     const int midi_hint = context.resource_limits.max_midi_events;
     const auto reserve = static_cast<std::size_t>(midi_hint > 0 ? midi_hint : 1);
@@ -44,7 +44,7 @@ bool ProcessorNode::process_binding(ProcessBlock& block,
     local_block.block_index = block.block_index;
     local_block.transport = block.transport;
     local_block.buses = &local_buses;
-    // Audio-only slice: no EventBlock, no BlockScratch. The bridge falls back to
+    // Audio-only binding: no EventBlock, no BlockScratch. The bridge falls back to
     // its scratch MIDI sinks and a null parameter queue.
     if (!local_block.validate()) return false;
 

--- a/docs/reference/node-abi.md
+++ b/docs/reference/node-abi.md
@@ -60,8 +60,8 @@ oriented:
 `pulp_node_v1` is the language-neutral C ABI for custom `SignalGraph` nodes. It
 ships as a real header —
 `core/native-components/include/pulp/native_components/pulp_node_v1.h` (module
-`pulp::native-components`) — derived from the Phase 5 source-level
-`CustomNodeType` lifecycle/state experience. Its `PULP_NODE_V1_ABI_MAJOR` tracks
+`pulp::native-components`) — derived from the source-level `CustomNodeType`
+lifecycle/state contract. Its `PULP_NODE_V1_ABI_MAJOR` tracks
 `PULP_NODE_ABI_VERSION` (the cross-module equality is asserted in
 `test/test_pulp_node_v1.cpp`).
 
@@ -359,7 +359,7 @@ preserve that identity even when the target graph has not registered a matching
 factory. Multiple versions of the same custom `type_id` can be registered at
 once; deserialization resolves by exact `(type_id, version)`.
 
-### Stateful custom nodes (Phase 5)
+### Stateful custom nodes
 
 `CustomNodeType` is additively extended with an optional **stateful lifecycle**.
 When `create` is set, the graph owns one opaque instance per node (RAII via

--- a/docs/reference/streams.md
+++ b/docs/reference/streams.md
@@ -78,7 +78,7 @@ if (stream->status_code() == 200) {
 }
 ```
 
-HTTPS is inherited from `cpp-httplib`, which ships with mbedTLS. `HttpStream` is currently read-only: calling `write()` returns `StreamError::Invalid`. Request-body streaming is Phase 4 of the streams feature plan.
+HTTPS is inherited from `cpp-httplib`, which ships with mbedTLS. `HttpStream` is currently read-only: calling `write()` returns `StreamError::Invalid`. Request-body streaming is not part of the shipped stream contract yet.
 
 ## `AsyncStream` — non-blocking with backpressure
 
@@ -124,7 +124,7 @@ The `stream-demo` example in `examples/stream-demo/` exercises all three layers:
 ./build/examples/stream-demo/pulp-stream-demo --http https://example.com
 ```
 
-## Message channels (Phase 4)
+## Message channels
 
 Bytewise transports stay in `Stream`. Structured messages — where one `send` matches one delivered message — live behind `pulp::runtime::MessageChannel`:
 
@@ -140,7 +140,7 @@ class MessageChannel {
 };
 ```
 
-Four implementations ship with this phase:
+Four message-channel implementations ship today:
 
 | Channel | Header | Transport |
 |---------|--------|-----------|

--- a/inspect/INSPECT_MODULE_MAP.md
+++ b/inspect/INSPECT_MODULE_MAP.md
@@ -1,6 +1,6 @@
 # Inspect Module Map
 
-This is the Phase 1 ownership map for shrinking the Pulp inspector surface under
+This is the ownership map for shrinking the Pulp inspector surface under
 `inspect/`. It documents the current seams, target extraction modules, and
 invariants that must survive future refactors. It is not a claim that the split
 has already happened.
@@ -8,7 +8,7 @@ has already happened.
 The inspector already builds as a dedicated `pulp-inspect` target from
 `inspect/CMakeLists.txt` and exposes the `pulp::inspect` alias. That umbrella
 target links view/render/state/events/audio, but several inspector translation
-units are pure protocol or CPU-side helpers. The strongest Phase 1 seam is to
+units are pure protocol or CPU-side helpers. The strongest current seam is to
 make those low-dependency leaves explicit before taking on riskier overlay or
 domain-handler splits.
 

--- a/test/test_ara_types.cpp
+++ b/test/test_ara_types.cpp
@@ -20,7 +20,7 @@ TEST_CASE("AudioSourceContentChange is a bitset", "[ara][types]") {
 }
 
 TEST_CASE("AudioSourceContentChange supports combined invalidation masks",
-          "[ara][types][coverage][phase3]") {
+          "[ara][types][coverage]") {
     auto flags = AudioSourceContentChange::Notes
                | AudioSourceContentChange::Tempo
                | AudioSourceContentChange::Tuning

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -424,7 +424,7 @@ TEST_CASE("AU v2 instrument SaveState/RestoreState round-trips plugin-owned payl
 }
 
 TEST_CASE("AU v2 latency and tail report processor runtime contract",
-          "[au][auv2][latency][tail][phase2]") {
+          "[au][auv2][latency][tail]") {
     constexpr int kTailSamples = 24000;
 
     REQUIRE_THAT(pulp::format::au::tail_samples_to_seconds(kTailSamples, 48000.0),
@@ -451,7 +451,7 @@ TEST_CASE("AU v2 latency and tail report processor runtime contract",
 }
 
 TEST_CASE("AU v2 host callbacks mark transport jumps for processor reset",
-          "[au][auv2][transport][reset][phase2]") {
+          "[au][auv2][transport][reset]") {
     ScopedFactoryRegistration registration(create_effect_processor);
 
     pulp::format::au::PulpAUEffect effect(nullptr);
@@ -877,7 +877,7 @@ TEST_CASE("AU v3 render events drop past realtime parameter capacity without gro
 }
 
 TEST_CASE("AU v3 transport jumps request processor reset through ProcessContext",
-          "[au][auv3][transport][reset][phase2]") {
+          "[au][auv3][transport][reset]") {
     @autoreleasepool {
         AudioComponentDescription desc{};
         desc.componentType = kAudioUnitType_Effect;
@@ -1740,7 +1740,7 @@ TEST_CASE("current_auv3_wrapper_identifier — Apple bundle inspection",
     REQUIRE((id.empty() || !id.empty()));  // tautology — pins no-throw.
 }
 
-// Regression: #2967 — main_is_extension used to test
+// Regression coverage: main_is_extension used to test
 // `[bundleIdentifier hasSuffix:@".appex"]`, but bundle IDENTIFIERS are
 // reverse-DNS strings and never carry `.appex`. The check was always false
 // inside real AUv3 extension processes, so detect_host_type() leaked the
@@ -1752,7 +1752,7 @@ TEST_CASE("current_auv3_wrapper_identifier — Apple bundle inspection",
 // AU_HOST_BUNDLE_ID env-var channel always wins regardless of bundle
 // state — that protects the documented override contract that downstream
 // hosts rely on.
-TEST_CASE("current_auv3_wrapper_identifier — AU_HOST_BUNDLE_ID env wins (#2967)",
+TEST_CASE("current_auv3_wrapper_identifier — AU_HOST_BUNDLE_ID env wins",
           "[au][auv3][host-detection][issue-2967]") {
     const char* prior = std::getenv("AU_HOST_BUNDLE_ID");
     setenv("AU_HOST_BUNDLE_ID", "com.test.fake-host-2967", /*overwrite=*/1);

--- a/test/test_au_v2_effect.cpp
+++ b/test/test_au_v2_effect.cpp
@@ -167,11 +167,10 @@ TEST_CASE("AU v2 effect: System message status byte reassembles SDK split",
     // decoder as inStatus=0xF0, inChannel=0x08; the decoder must
     // reassemble (top | low) = 0xF8.
     //
-    // The previous fixture passed `inStatus=0xF8` directly (the wire-
-    // format byte, NOT the post-split top nibble), so the buggy "is_system
-    // → return inStatus unchanged" branch ALSO returned 0xF8 and the
-    // test passed by coincidence. PR #638 review caught that the fixture
-    // didn't model the SDK contract; this version does.
+    // A regression fixture that passes the wire-format byte directly would
+    // also return 0xF8 from a buggy "is_system -> return inStatus unchanged"
+    // branch. Model the SDK contract instead: the status arrives split into
+    // the 0xF0 top nibble plus the low-nibble channel field.
     SECTION("0xF8 — timing clock") {
         const auto ev = decode_midi_event(/*inStatus=*/0xF0,
                                           /*inChannel=*/0x08,
@@ -214,7 +213,7 @@ TEST_CASE("AU v2 effect: sysex routing lands in MidiBuffer's sysex sidecar",
 }
 
 TEST_CASE("AU v2 render context is explicit realtime for effects and instruments",
-          "[au][au-v2][runtime-mode][phase2]")
+          "[au][au-v2][runtime-mode]")
 {
     const auto ctx = pulp::format::au::make_render_process_context(
         /*sample_rate=*/48000.0, /*num_samples=*/128);

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -855,7 +855,7 @@ TEST_CASE("CLAP lifecycle forwards prepare/release and handles no-op callbacks",
 }
 
 TEST_CASE("CLAP latency and tail extensions report processor runtime contract",
-          "[clap][latency][tail][phase2]") {
+          "[clap][latency][tail]") {
     g_pending_latency_samples = 256;
     g_pending_tail_samples = 4096;
     Harness finite(make_latency_tail);
@@ -983,7 +983,7 @@ TEST_CASE("CLAP parameter modulation applies for one block then resets",
 }
 
 TEST_CASE("CLAP parameter modulation projects to the typed global lane",
-          "[clap][params][modulation][lane][phase3]") {
+          "[clap][params][modulation][lane]") {
     g_pending_opts_mpe = false;
     g_pending_opts_ump = false;
     Harness h(make_capturing);
@@ -1082,7 +1082,7 @@ TEST_CASE("CLAP routes sidechain input and clears secondary output buses",
 }
 
 TEST_CASE("CLAP supplies ProcessBuffers to processors that override the richer surface",
-          "[clap][audio][process-buffers][phase2]") {
+          "[clap][audio][process-buffers]") {
     g_pending_opts_mpe = false;
     g_pending_opts_ump = false;
     Harness h(make_process_buffers_capturing);
@@ -1186,7 +1186,7 @@ TEST_CASE("CLAP transport state maps into ProcessContext",
 }
 
 TEST_CASE("CLAP transport jumps request processor reset through ProcessContext",
-          "[clap][transport][reset][phase2]") {
+          "[clap][transport][reset]") {
     g_pending_opts_mpe = false;
     g_pending_opts_ump = false;
     Harness h(make_capturing);
@@ -1267,12 +1267,12 @@ TEST_CASE("CLAP item-1.3 transport extensions land on ProcessContext",
     REQUIRE_FALSE(ctx.transport_changed);
 }
 
-// Regression: #2963 — the CLAP adapter never
-// reset `self->playhead_prev` across lifecycle transitions, so the first
+// Regression coverage: the CLAP adapter must reset `self->playhead_prev` across
+// lifecycle transitions, so the first
 // block after a deactivate / reactivate (or reset) diff'd against stale
 // transport data from the previous activation and spuriously raised
 // tempo_changed / time_sig_changed / transport_changed.
-TEST_CASE("CLAP playhead snapshot is reset on activate / deactivate / reset (#2963)",
+TEST_CASE("CLAP playhead snapshot is reset on activate / deactivate / reset",
           "[clap][transport][item-13][issue-2963]") {
     g_pending_opts_mpe = false;
     g_pending_opts_ump = false;
@@ -2153,8 +2153,8 @@ TEST_CASE("Mixed CLAP_EVENT_MIDI2 + NOTE_ON: both reach UMP sidecar",
     // a separate co-delivered CLAP_EVENT_NOTE_ON on a different note.
     // Both must appear in the UMP sidecar after process() returns. An
     // earlier shape of this test asserted the synthesis was skipped, but
-    // the assumption from PR #627 silently dropped real-world note streams.
-    // Inverted to pin the corrected behaviour.
+    // assuming synthesis could be skipped silently dropped real-world note
+    // streams. This pins the corrected behaviour.
     g_pending_opts_mpe = false;
     g_pending_opts_ump = true;
     Harness h(make_capturing);
@@ -2401,7 +2401,6 @@ TEST_CASE("midi_out empty sysex payload is skipped on CLAP out_events",
 
 TEST_CASE("midi_out shorts + sysex interleave by sample_offset on out_events",
           "[clap][midi][issue-pending]") {
-    // Covers the PR #627 two-cursor merge for ordered out_events.
     // CLAP's out_events contract requires events pushed in ascending
     // sample-time order across event types; the earlier two-pass shape
     // (all shorts, then all sysex) violated it whenever a sysex

--- a/test/test_clap_webview.cpp
+++ b/test/test_clap_webview.cpp
@@ -45,7 +45,7 @@ TEST_CASE("WebviewProvider message callback", "[format][webview]") {
 }
 
 TEST_CASE("WebviewProvider defaults and outbound callback are stable",
-          "[format][webview][coverage][phase3]") {
+          "[format][webview][coverage]") {
     class TestProvider : public WebviewProvider {
     public:
         WebviewContent get_webview_content() const override {

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -85,7 +85,7 @@ TEST_CASE("DescriptorValidation: non-reverse-DNS bundle_id produces a warning on
 }
 
 TEST_CASE("DescriptorValidation: reverse-DNS bundle_id requires at least three segments",
-          "[format][descriptor-validation][coverage][phase3]") {
+          "[format][descriptor-validation][coverage]") {
     auto d = well_formed_effect();
     d.bundle_id = "com.plugin";
 
@@ -232,7 +232,7 @@ TEST_CASE("DescriptorValidation: supports_mpe without accepts_midi warns",
 }
 
 TEST_CASE("DescriptorValidation: MPE and UMP sidecars share one warning on audio effects",
-          "[format][descriptor-validation][coverage][phase3]") {
+          "[format][descriptor-validation][coverage]") {
     auto d = well_formed_effect();
     d.supports_mpe = true;
     d.supports_ump = true;
@@ -308,7 +308,7 @@ TEST_CASE("DescriptorValidation: MidiEffect without audio output is valid",
 }
 
 TEST_CASE("DescriptorValidation: MidiEffect ignores zero-channel audio output",
-          "[format][descriptor-validation][coverage][phase3]") {
+          "[format][descriptor-validation][coverage]") {
     auto d = well_formed_effect();
     d.category = PluginCategory::MidiEffect;
     d.accepts_midi = true;
@@ -372,7 +372,7 @@ TEST_CASE("DescriptorValidation: MIDI sidecar capabilities are warning-only with
 }
 
 TEST_CASE("descriptor_is_valid treats warnings as valid and any error as invalid",
-          "[format][descriptor-validation][coverage][phase3]") {
+          "[format][descriptor-validation][coverage]") {
     REQUIRE(descriptor_is_valid({}));
     REQUIRE(descriptor_is_valid({
         {DescriptorIssueSeverity::Warning, "bundle_id", "warning"},

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -123,7 +123,7 @@ TEST_CASE("DiagnosticReporter captures parameter values", "[format][diagnostic]"
 }
 
 TEST_CASE("DiagnosticReporter renders unitless parameters without a unit suffix",
-          "[format][diagnostic][coverage][phase3]") {
+          "[format][diagnostic][coverage]") {
     DiagnosticReporter diag;
     auto desc = make_desc();
     StateStore store;
@@ -193,7 +193,7 @@ TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter
 }
 
 TEST_CASE("DiagnosticReporter JSON escapes string fields",
-          "[format][diagnostic][coverage][phase3]") {
+          "[format][diagnostic][coverage]") {
     DiagnosticReporter diag;
     PluginDescriptor desc;
     desc.name = R"(Quote "Synth")";
@@ -214,7 +214,7 @@ TEST_CASE("DiagnosticReporter JSON escapes string fields",
 }
 
 TEST_CASE("DiagnosticReporter replacing plugin info clears stale parameter snapshot",
-          "[format][diagnostic][coverage][phase3]") {
+          "[format][diagnostic][coverage]") {
     DiagnosticReporter diag;
 
     auto first_desc = make_desc();
@@ -263,7 +263,7 @@ TEST_CASE("HostType names and feature heuristics cover fixed-size and no-sidecha
 }
 
 TEST_CASE("HostType names cover every declared host enum",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE(host_type_name(HostType::LogicPro) == "Logic Pro");
     REQUIRE(host_type_name(HostType::GarageBand) == "GarageBand");
     REQUIRE(host_type_name(HostType::AbletonLive) == "Ableton Live");
@@ -282,7 +282,7 @@ TEST_CASE("HostType names cover every declared host enum",
 }
 
 TEST_CASE("HostType feature heuristics default permissive for modern hosts",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     for (auto host : {HostType::LogicPro,
                       HostType::AbletonLive,
                       HostType::Reaper,
@@ -302,7 +302,7 @@ TEST_CASE("HostType feature heuristics default permissive for modern hosts",
 }
 
 TEST_CASE("HostType process-name classifier covers DAW executable aliases",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE(host_type_from_process_name("/Applications/Logic Pro.app/Contents/MacOS/Logic Pro") == HostType::LogicPro);
     REQUIRE(host_type_from_process_name("GARAGEBAND") == HostType::GarageBand);
     REQUIRE(host_type_from_process_name("/Applications/Ableton Live 12 Suite.app/Live") == HostType::AbletonLive);
@@ -328,7 +328,7 @@ TEST_CASE("HostType process-name classifier covers DAW executable aliases",
 }
 
 TEST_CASE("HostType process-name classifier is substring ordered",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE(host_type_from_process_name("logic-live-helper") == HostType::LogicPro);
     REQUIRE(host_type_from_process_name("garageband-live-helper") == HostType::GarageBand);
     REQUIRE(host_type_from_process_name("ableton-reaper-bridge") == HostType::AbletonLive);
@@ -340,7 +340,7 @@ TEST_CASE("HostType process-name classifier is substring ordered",
 }
 
 TEST_CASE("HostType process-name classifier handles empty and path-like unknown names",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE(host_type_from_process_name("") == HostType::Unknown);
     REQUIRE(host_type_from_process_name("/usr/bin/pluginval") == HostType::Unknown);
     REQUIRE(host_type_from_process_name("/tmp/not-a-daw") == HostType::Unknown);
@@ -348,7 +348,7 @@ TEST_CASE("HostType process-name classifier handles empty and path-like unknown 
 }
 
 TEST_CASE("HostType process-name classifier feeds the feature policy",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE_FALSE(host_supports_resize(host_type_from_process_name("Pro Tools")));
     REQUIRE_FALSE(host_supports_resize(host_type_from_process_name("GarageBand")));
     REQUIRE_FALSE(host_supports_sidechain(host_type_from_process_name("Tenacity")));
@@ -356,6 +356,6 @@ TEST_CASE("HostType process-name classifier feeds the feature policy",
 }
 
 TEST_CASE("HostType process detection delegates through the classifier",
-          "[format][host-type][coverage][phase3]") {
+          "[format][host-type][coverage]") {
     REQUIRE_FALSE(host_type_name(detect_host_type()).empty());
 }

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -173,7 +173,7 @@ TEST_CASE("HeadlessHost creates processor", "[headless]") {
 }
 
 TEST_CASE("format registry stores and replaces the processor factory",
-          "[format][registry][coverage][phase3]") {
+          "[format][registry][coverage]") {
     const auto previous = pulp::format::registered_factory();
     {
         ScopedFactoryRegistration scoped(create_test_gain);
@@ -249,7 +249,7 @@ TEST_CASE("HeadlessHost forwards prepare context and release",
 }
 
 TEST_CASE("HeadlessHost try_prepare enforces processor resource budgets",
-          "[headless][prepare-budget][phase2]") {
+          "[headless][prepare-budget]") {
     pulp::format::HeadlessHost host(create_test_gain);
     REQUIRE(last_processor != nullptr);
     auto* processor = last_processor;
@@ -284,7 +284,7 @@ TEST_CASE("HeadlessHost try_prepare enforces processor resource budgets",
 }
 
 TEST_CASE("HeadlessHost failed budget prepare preserves active render context",
-          "[headless][prepare-budget][phase2]") {
+          "[headless][prepare-budget]") {
     pulp::format::HeadlessHost host(create_test_gain);
     REQUIRE(last_processor != nullptr);
     auto* processor = last_processor;
@@ -319,7 +319,7 @@ TEST_CASE("HeadlessHost failed budget prepare preserves active render context",
 }
 
 TEST_CASE("HeadlessHost try_prepare reports channel and voice budget failures",
-          "[headless][prepare-budget][phase2]") {
+          "[headless][prepare-budget]") {
     pulp::format::HeadlessHost host(create_test_gain);
     REQUIRE(last_processor != nullptr);
     auto* processor = last_processor;
@@ -364,7 +364,7 @@ TEST_CASE("HeadlessHost fills default process context",
 }
 
 TEST_CASE("HeadlessHost defaults non-positive context fields",
-          "[headless][coverage][phase3]") {
+          "[headless][coverage]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(88200.0, 512);
 
@@ -427,7 +427,7 @@ TEST_CASE("HeadlessHost applies parameter changes", "[headless]") {
                  Catch::Matchers::WithinRel(static_cast<double>(expected), 0.01));
 }
 
-TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping", "[headless][phase12]") {
+TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping", "[headless]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
 
@@ -458,7 +458,7 @@ TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping"
 }
 
 TEST_CASE("HeadlessHost forwards explicit runtime mode maintenance flags",
-          "[headless][runtime-mode][phase2]") {
+          "[headless][runtime-mode]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
 
@@ -495,7 +495,7 @@ TEST_CASE("HeadlessHost forwards explicit runtime mode maintenance flags",
 }
 
 TEST_CASE("HeadlessHost renders deterministic offline AudioFileData blocks",
-          "[headless][offline][advanced][phase3]") {
+          "[headless][offline][advanced]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 4);
     host.state().set_value(1, 6.0f);
@@ -536,7 +536,7 @@ TEST_CASE("HeadlessHost renders deterministic offline AudioFileData blocks",
 }
 
 TEST_CASE("HeadlessHost offline render matches direct process for stateless effects",
-          "[headless][offline][parity][advanced][phase3]") {
+          "[headless][offline][parity][advanced]") {
     pulp::format::HeadlessHost direct_host(create_test_gain);
     direct_host.prepare(48000.0, 3);
     direct_host.state().set_value(1, -3.0f);
@@ -696,7 +696,7 @@ TEST_CASE("HeadlessHost forwards explicit parameter-event queues",
 }
 
 TEST_CASE("HeadlessHost forwards MIDI, parameter events, and explicit context together",
-          "[headless][params][coverage][phase3]") {
+          "[headless][params][coverage]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
     REQUIRE(last_processor != nullptr);

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -228,7 +228,7 @@ TEST_CASE("plugin_state_io round-trips parameter and plugin-owned state",
 }
 
 TEST_CASE("plugin_state_io envelope encodes payload sizes and CRC",
-          "[format][plugin-state][coverage][phase3]") {
+          "[format][plugin-state][coverage]") {
     TestRig source;
     source.store.set_value(1, -2.5f);
     source.processor.plugin_state = "layout=full";
@@ -263,7 +263,7 @@ TEST_CASE("plugin_state_io envelope encodes payload sizes and CRC",
 }
 
 TEST_CASE("plugin_state_io preserves binary plugin-owned payload bytes",
-          "[format][plugin-state][coverage][phase3]") {
+          "[format][plugin-state][coverage]") {
     TestRig source;
     source.store.set_value(1, -3.0f);
     source.processor.plugin_state.assign(
@@ -487,7 +487,7 @@ TEST_CASE("plugin_state_io migrates old envelopes before parsing payloads",
 }
 
 TEST_CASE("plugin_state_io rejects invalid envelope migration registrations",
-          "[format][plugin-state][coverage][phase3]") {
+          "[format][plugin-state][coverage]") {
     using pulp::format::plugin_state_io::current_envelope_version;
     using pulp::format::plugin_state_io::register_envelope_migration;
 

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -251,7 +251,7 @@ TEST_CASE("PluginDescriptor bus helpers read only the first bus",
 }
 
 TEST_CASE("ProcessBuffers treats inactive buses as disconnected",
-          "[format][processor-defaults][process-buffers][phase2]") {
+          "[format][processor-defaults][process-buffers]") {
     std::array<ProcessBusBufferView<const float>, 2> inputs{{
         {
             .info = {
@@ -311,7 +311,7 @@ TEST_CASE("ProcessBuffers treats inactive buses as disconnected",
 }
 
 TEST_CASE("ProcessBuffers rejects active null channel pointers",
-          "[format][processor-defaults][process-buffers][phase2]") {
+          "[format][processor-defaults][process-buffers]") {
     std::array<float, 4> left{};
     const float* active_input_channels[] = {left.data(), nullptr};
 
@@ -345,7 +345,7 @@ TEST_CASE("ProcessBuffers rejects active null channel pointers",
 }
 
 TEST_CASE("ProcessBuffers requires inactive buses to carry empty views",
-          "[format][processor-defaults][process-buffers][phase2]") {
+          "[format][processor-defaults][process-buffers]") {
     std::array<float, 4> sidechain{};
     const float* sidechain_channels[] = {sidechain.data()};
 
@@ -381,7 +381,7 @@ TEST_CASE("ProcessBuffers requires inactive buses to carry empty views",
 }
 
 TEST_CASE("ProcessBuffers models surround instruments with auxiliary outputs",
-          "[format][processor-defaults][process-buffers][phase2][instrument][multi-output]") {
+          "[format][processor-defaults][process-buffers][instrument][multi-output]") {
     std::array<float, 8> main_front_left{};
     std::array<float, 8> main_front_right{};
     std::array<float, 8> main_center{};
@@ -465,7 +465,7 @@ TEST_CASE("ProcessBuffers models surround instruments with auxiliary outputs",
 }
 
 TEST_CASE("Processor rich process renders multi-output instrument buses",
-          "[format][processor-defaults][process-buffers][phase3][instrument][multi-output]") {
+          "[format][processor-defaults][process-buffers][instrument][multi-output]") {
     MultiOutputInstrumentProcessor processor;
     const auto desc = processor.descriptor();
     REQUIRE(desc.category == PluginCategory::Instrument);
@@ -610,7 +610,7 @@ TEST_CASE("PluginDescriptor effective_capabilities ORs legacy and node fields",
 }
 
 TEST_CASE("PluginDescriptor preserves optional vendor contact metadata",
-          "[format][processor-defaults][metadata][coverage][phase3]") {
+          "[format][processor-defaults][metadata][coverage]") {
     PluginDescriptor d;
     d.vendor_url = "https://example.test/pulp";
     d.vendor_email = "support@example.test";
@@ -640,7 +640,7 @@ TEST_CASE("PrepareContext defaults match the headless stereo render path",
 }
 
 TEST_CASE("Prepare resource usage totals persistent and block scratch bytes",
-          "[format][processor-defaults][prepare-budget][phase2]") {
+          "[format][processor-defaults][prepare-budget]") {
     PrepareResourceUsage usage;
     usage.persistent_bytes = 1024;
     usage.block_scratch_bytes = 256;
@@ -649,7 +649,7 @@ TEST_CASE("Prepare resource usage totals persistent and block scratch bytes",
 }
 
 TEST_CASE("Prepare resource limits default to unlimited",
-          "[format][processor-defaults][prepare-budget][phase2]") {
+          "[format][processor-defaults][prepare-budget]") {
     PrepareResourceUsage usage;
     usage.persistent_bytes = 1'000'000;
     usage.block_scratch_bytes = 2'000'000;
@@ -665,7 +665,7 @@ TEST_CASE("Prepare resource limits default to unlimited",
 }
 
 TEST_CASE("Prepare resource helper reports the first exceeded budget",
-          "[format][processor-defaults][prepare-budget][phase2]") {
+          "[format][processor-defaults][prepare-budget]") {
     PrepareResourceUsage usage;
     usage.persistent_bytes = 2048;
     usage.block_scratch_bytes = 1024;
@@ -727,7 +727,7 @@ TEST_CASE("Prepare resource helper reports the first exceeded budget",
 }
 
 TEST_CASE("Processor prepare resource estimates can be checked against host limits",
-          "[format][processor-defaults][prepare-budget][phase2]") {
+          "[format][processor-defaults][prepare-budget]") {
     ResourceReportingProcessor p;
     p.persistent_bytes = 4096;
     p.block_scratch_bytes = 1024;
@@ -763,7 +763,7 @@ TEST_CASE("Processor prepare resource estimates can be checked against host limi
 }
 
 TEST_CASE("Processor memory pressure can shrink rebuildable prepare caches",
-          "[format][processor-defaults][prepare-budget][memory-pressure][phase2]") {
+          "[format][processor-defaults][prepare-budget][memory-pressure]") {
     MemoryPressureReportingProcessor p;
     p.prepared_core_bytes = 4096;
     p.advisory_cache_bytes = 2048;
@@ -921,7 +921,7 @@ TEST_CASE("Processor default view_size reflects an overridden editor_size",
 }
 
 TEST_CASE("Processor custom view_size can provide resize bounds and aspect ratio",
-          "[format][processor-defaults][editor][coverage][phase3]") {
+          "[format][processor-defaults][editor][coverage]") {
     CustomViewSizeProcessor p;
     const auto hints = p.view_size();
 
@@ -971,7 +971,7 @@ TEST_CASE("view_size_from_design derives sensible bounds + aspect from preferred
 }
 
 TEST_CASE("Processor has_editor override can disable default editor contract",
-          "[format][processor-defaults][editor][coverage][phase3]") {
+          "[format][processor-defaults][editor][coverage]") {
     EditorlessProcessor p;
 
     REQUIRE_FALSE(p.has_editor());
@@ -993,7 +993,7 @@ TEST_CASE("Processor default latency and plugin-owned state hooks are inert",
 }
 
 TEST_CASE("Processor default lifecycle hooks are callable no-ops",
-          "[format][processor-defaults][lifecycle][coverage][phase3]") {
+          "[format][processor-defaults][lifecycle][coverage]") {
     PlainProcessor p;
     pulp::view::View view;
 
@@ -1011,7 +1011,7 @@ TEST_CASE("Processor default lifecycle hooks are callable no-ops",
 }
 
 TEST_CASE("Processor prepare receives the exact host context",
-          "[format][processor-defaults][context][coverage][phase3]") {
+          "[format][processor-defaults][context][coverage]") {
     PlainProcessor p;
     PrepareContext context;
     context.sample_rate = 96000.0;
@@ -1029,7 +1029,7 @@ TEST_CASE("Processor prepare receives the exact host context",
 }
 
 TEST_CASE("Processor process receives the exact transport context",
-          "[format][processor-defaults][context][coverage][phase3]") {
+          "[format][processor-defaults][context][coverage]") {
     PlainProcessor p;
     float out_samples[4] = {};
     float* out_channels[1] = {out_samples};
@@ -1276,7 +1276,7 @@ TEST_CASE("for_each_subblock invokes one full block for null or empty queues",
 }
 
 TEST_CASE("for_each_subblock skips zero-sample buffers",
-          "[format][params][subblock][coverage][phase3]") {
+          "[format][params][subblock][coverage]") {
     pulp::state::StateStore store;
     store.add_parameter({
         .id = 3,
@@ -1307,7 +1307,7 @@ TEST_CASE("for_each_subblock skips zero-sample buffers",
 }
 
 TEST_CASE("for_each_subblock ignores boundary events and slices input with output",
-          "[format][params][subblock][coverage][phase3]") {
+          "[format][params][subblock][coverage]") {
     pulp::state::StateStore store;
     store.add_parameter({
         .id = 9,
@@ -1462,7 +1462,7 @@ TEST_CASE("ControlRateParamSmoother is bit-exact off and ramps when opted in",
 }
 
 TEST_CASE("ControlRateParamSmoother handles invalid rates reset and skip",
-          "[format][params][smoothing][coverage][phase3]") {
+          "[format][params][smoothing][coverage]") {
     pulp::state::ParamInfo info;
     info.smoothing_ramp_seconds = 0.004f;
 

--- a/test/test_wam_wclap.cpp
+++ b/test/test_wam_wclap.cpp
@@ -107,7 +107,7 @@ TEST_CASE("WamDescriptorData to_json", "[format][wam]") {
 }
 
 TEST_CASE("WamDescriptorData defaults serialize every advertised capability",
-          "[format][wam][coverage][phase3]") {
+          "[format][wam][coverage]") {
     WamDescriptorData desc;
     desc.name = "Default";
     auto json = desc.to_json();
@@ -136,7 +136,7 @@ TEST_CASE("WamProcessorBridge initialization", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge handles uninitialized and null-factory states",
-          "[format][wam][coverage][phase3]") {
+          "[format][wam][coverage]") {
     WamProcessorBridge uninitialized(create_test_wam);
     auto empty_desc = uninitialized.descriptor();
     REQUIRE(empty_desc.name.empty());
@@ -199,7 +199,7 @@ TEST_CASE("WamProcessorBridge audio processing", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge clamps processing to prepared channel count",
-          "[format][wam][coverage][phase3]") {
+          "[format][wam][coverage]") {
     WamProcessorBridge bridge(create_test_wam);
     bridge.initialize(48000.0, 128);
 
@@ -234,7 +234,7 @@ TEST_CASE("WamProcessorBridge MIDI scheduling", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge ignores unsupported MIDI statuses",
-          "[format][wam][coverage][phase3]") {
+          "[format][wam][coverage]") {
     WamProcessorBridge bridge(create_test_wam);
     bridge.initialize(48000.0, 128);
 

--- a/tools/import/README.md
+++ b/tools/import/README.md
@@ -30,7 +30,7 @@ a vendor token leaks into the schema or fixtures.
 
 Run the test: `python3 -m unittest tools.import.test_project_import_ir_schema -v`
 
-## Design notes (grounded by the Phase 0 extractor spike)
+## Design notes
 
 The IR is shaped to be **honest by construction**: a fact the importer can't
 statically resolve becomes a low-confidence value plus a first-class `constructs`
@@ -50,7 +50,7 @@ entry plus a diagnostic — never a silent drop or a guess. Key choices:
 - **`dsp.reachability_scope`** is explicit so portable-core confidence is never
   read from a shallow scan.
 
-## Roadmap (Phase 1 substrate, narrowed)
+## Roadmap
 
 - [x] `ProjectImportIR` schema + conformance test.
 - [x] SPI **contract** (`detect`/`analyze`/`plan`/`emit`, JSON-over-stdio,


### PR DESCRIPTION
## Summary
- removes stale phase/slice/PR breadcrumbs from format/adapter-adjacent tests and docs while preserving protocol selectors and behavior caveats
- refreshes Node ABI, Streams, inspector module-map, import-tool, processor-node, and capture-WAV wording to describe current behavior
- removes bare #2963/#2967 references from touched tests while preserving durable issue tags

## Validation
- `cmake --build build --target pulp-test-ara-types pulp-test-clap-midi-events pulp-test-clap-webview pulp-test-wam-wclap pulp-test-diagnostic pulp-test-descriptor-validation pulp-test-plugin-state-io pulp-test-processor-defaults pulp-test-headless -j$(sysctl -n hw.ncpu)`
- direct runs: `pulp-test-ara-types`, `pulp-test-clap-midi-events`, `pulp-test-clap-webview`, `pulp-test-wam-wclap`, `pulp-test-diagnostic`, `pulp-test-descriptor-validation`, `pulp-test-plugin-state-io`, `pulp-test-processor-defaults`, `pulp-test-headless`
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- targeted stale-breadcrumb grep over all touched files
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `autoreview --mode branch --base origin/main --reviewers codex,claude --thinking codex=high --thinking claude=max` -> clean, 0 findings

## Notes
- Local Release configure did not build AU v2/AU plugin-state targets because `AudioUnitSDK` is absent in this worktree; those touched AU files are comment/test-name/tag-only changes.
- Tip commit includes the `auv2` skill-sync skip trailer for that comment-only touch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale “phase/slice/PR” breadcrumbs across format/adapter tests and docs, and updated wording to reflect the current contracts. No code or runtime behavior changes.

- **Refactors**
  - Standardized test tags: dropped phase labels, kept selectors and durable issue tags (e.g., [issue-2963], [issue-2967]).
  - Clarified comments/APIs: “audio‑only binding” wording in processor adapter, worker‑pool contract notes, and WAV capture caveats.
  - Updated docs to current behavior: Node ABI (stateful lifecycle wording), Streams (`HttpStream` stays read‑only; message channels not labeled by phase), inspector module map, and import tool roadmap.

<sup>Written for commit bbe8c5b7ab2d374dbd1051174c41319ab386aa91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

