### PR TITLE
docs(test): clean source test comment breadcrumbs

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1668,6 +1668,12 @@ python3 tools/import-validation/check-source-contracts.py --format markdown
 python3 -m pytest tools/import-validation/test_source_contracts.py -v
 ```
 
+When cleaning Catch2 tags in source-contract test files, update the matching
+`validation.test_tags` entry in `source-contracts.json` in the same change.
+Prefer broad stable tags such as `[view][import][designmd]` when the registry row
+represents a full validation surface; do not narrow it to one subarea tag if the
+roundtrip/contract expects parser, lint, diff, export, and recovery coverage.
+
 The checker also enforces coverage symmetry between
 `parse_design_source()` labels and the registry. When adding a source label
 such as `jsx`, add a matching row to `source-contracts.json` and reference

--- a/test/test_cli_create_targets.cpp
+++ b/test/test_cli_create_targets.cpp
@@ -67,23 +67,21 @@ TEST_CASE("CLI create targets skip empty standalone app targets",
           "[cli][create][issue-643]") {
     const auto targets = create_default_build_targets("", "app", "Standalone");
 
-    // PR #1271 — an empty class_name (the slug
-    // sanitizer can collapse names made only of separators to "")
-    // must NOT produce the malformed target `"-test"`. That string
-    // looks like a CMake CLI option to `cmake --build --target ...`
-    // and can either fail confusingly or get mistaken for an
-    // unknown option. Empty class_name → empty target list (caller's
-    // contract: "no buildable targets" rather than a guaranteed-broken
-    // build invocation).
+    // An empty class_name (the slug sanitizer can collapse names made only of
+    // separators to "") must not produce the malformed target `"-test"`.
+    // That string looks like a CMake CLI option to `cmake --build --target ...`
+    // and can either fail confusingly or get mistaken for an unknown option.
+    // Empty class_name means an empty target list: no buildable targets rather
+    // than a guaranteed-broken build invocation.
     CHECK(targets == std::vector<std::string>{});
 }
 
 TEST_CASE("CLI create targets skip malformed targets when class_name is empty across formats",
           "[cli][create][issue-643]") {
-    // Same PR #1271 case as above, generalised — none of the format
-    // suffixes should produce a "_VST3" / "_CLAP" / "_Standalone"
-    // string that starts with `_` either, for the same `cmake --build
-    // --target` reason. Empty class_name → empty target list.
+    // No format suffix should produce a "_VST3" / "_CLAP" / "_Standalone"
+    // target that starts with `_`; it has the same `cmake --build --target`
+    // ambiguity as an option-like target. Empty class_name means an empty
+    // target list.
     const auto targets = create_default_build_targets(
         "", "instrument", "VST3 CLAP AU Standalone");
     CHECK(targets == std::vector<std::string>{});
@@ -118,11 +116,9 @@ TEST_CASE("CLI create targets can omit the test target for template kit builds",
 
 TEST_CASE("CLI create selects build config at build/test time for multi-config generators",
           "[cli][create][issue-2133]") {
-    // PR #2133: `pulp create` set only the configure-time
-    // CMAKE_BUILD_TYPE, so on Visual Studio / Xcode multi-config generators
-    // `cmake --build` and `ctest` defaulted to Debug regardless of --debug.
-    // The config name must flow into `cmake --build --config <cfg>` and
-    // `ctest -C <cfg>`.
+    // Multi-config generators such as Visual Studio and Xcode ignore
+    // CMAKE_BUILD_TYPE for build and test selection. The config name must flow
+    // into `cmake --build --config <cfg>` and `ctest -C <cfg>`.
     CHECK(create_build_config(false) == "Release");
     CHECK(create_build_config(true) == "Debug");
 

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -1,8 +1,8 @@
 // test_cli_fetchcontent_cache.cpp — Unit tests for the
-// `pulp doctor --caches` discovery + healing core. Issue #744.
+// `pulp doctor --caches` discovery + healing core.
 //
-// All four acceptance scenarios from the issue are covered (healthy /
-// dangling / stale-commit / root-owned). Tests inject a deterministic
+// All four accepted cache states are covered (healthy / dangling /
+// stale-commit / root-owned). Tests inject a deterministic
 // `DiscoveryEnv` so they don't touch the developer's real
 // `~/Library/Caches/Pulp/` state — that's the same isolation pattern
 // used by test_cli_version_diag and test_cli_projects_registry.
@@ -693,7 +693,7 @@ TEST_CASE("discover: FetchContent scratch dirs do not register as stale-commit",
     CHECK_FALSE(fcc::any_unhealthy(entries));
 }
 
-// ── PR #753: stale-ref entries must NOT block preflight ────────────────────
+// ── Stale-ref entries must NOT block preflight ─────────────────────────────
 //
 // CMake's pulp_register_fetchcontent_source override path keys on the
 // CURRENT sanitized ref (`<dep>-<ref>`), so leftover `<dep>-<oldref>`
@@ -708,7 +708,7 @@ TEST_CASE("discover: FetchContent scratch dirs do not register as stale-commit",
 //   - apply_fixes()         → still removes stale entries on `--fix`
 
 TEST_CASE("preflight: stale-ref-only state does NOT block build/test",
-          "[fetchcontent_cache][issue-744][pr-753]") {
+          "[fetchcontent_cache][issue-744][stale-ref][preflight]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "choc-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     MockState state;
@@ -744,7 +744,7 @@ TEST_CASE("preflight: stale-ref-only state does NOT block build/test",
 }
 
 TEST_CASE("preflight: dangling symlinks DO block build/test",
-          "[fetchcontent_cache][issue-744][pr-753]") {
+          "[fetchcontent_cache][issue-744][dangling][preflight]") {
     // Counter-test: confirm we still gate on truly broken states.
     fs::path root = "/fake/cache";
     fs::path entry = root / "threejs-077dd13c0e869d9f3dbe55875686f920367de457";
@@ -774,7 +774,7 @@ TEST_CASE("preflight: dangling symlinks DO block build/test",
 }
 
 TEST_CASE("preflight: mixed stale + dangling reports only the dangling entry",
-          "[fetchcontent_cache][issue-744][pr-753]") {
+          "[fetchcontent_cache][issue-744][stale-ref][dangling][preflight]") {
     // When both stale and blocking states are present, preflight blocks
     // (because of the dangling), but the rendered report should only
     // mention the truly blocking entries — listing stale entries here
@@ -816,7 +816,7 @@ TEST_CASE("preflight: mixed stale + dangling reports only the dangling entry",
     CHECK(s.find("choc-aaaaa") == std::string::npos);
 }
 
-// ── PR #753: --caches --json exit code reflects health ─────────────────────
+// ── --caches --json exit code reflects health ──────────────────────────────
 //
 // `render_report_json` itself always returns 0, but the cmd_doctor
 // caller is responsible for setting the exit code via any_unhealthy().
@@ -826,7 +826,7 @@ TEST_CASE("preflight: mixed stale + dangling reports only the dangling entry",
 // value for the unhealthy fixture.
 
 TEST_CASE("render_report_json: data surface always returns 0",
-          "[fetchcontent_cache][issue-744][pr-753]") {
+          "[fetchcontent_cache][issue-744][json][health]") {
     fs::path root = "/fake/cache";
     fs::path stale = root / "choc-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     MockState state;
@@ -855,7 +855,7 @@ TEST_CASE("render_report_json: data surface always returns 0",
 }
 
 TEST_CASE("render_report_json: healthy fixture reports healthy=true",
-          "[fetchcontent_cache][issue-744][pr-753]") {
+          "[fetchcontent_cache][issue-744][json][health]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "choc-f0f5cdf5a938b8b779fea6c083571cce5ccab925";
     MockState state;

--- a/test/test_cli_update_check.cpp
+++ b/test/test_cli_update_check.cpp
@@ -397,7 +397,7 @@ TEST_CASE("read_toml_key_in_section ignores commented examples",
 }
 
 TEST_CASE("read_toml_key_in_section trims quoted values before inline comments",
-          "[cli][update-check][coverage][phase3]") {
+          "[cli][update-check][toml][comments]") {
     std::string src =
         "[update]\n"
         "mode =   \"manual\"   # selected by user\n"
@@ -408,7 +408,7 @@ TEST_CASE("read_toml_key_in_section trims quoted values before inline comments",
 }
 
 TEST_CASE("write_toml_key_in_section appends into empty section before the next section",
-          "[cli][update-check][coverage][phase3]") {
+          "[cli][update-check][toml][section-insert]") {
     std::string src =
         "[update]\n"
         "\n"
@@ -495,7 +495,7 @@ TEST_CASE("refresh_cache carries forward previous on fetch failure",
     REQUIRE(next.last_check_epoch_sec == 2'000);
 }
 
-// ── resolve_latest_with_persist (#1599) ─────────────────────────────────────
+// ── resolve_latest_with_persist ────────────────────────────────────────
 //
 // Regression for the "cache permanently stuck at v0.73.0 despite v0.78.2
 // being live" trap: pulp_cli.cpp's detached background refresh gets reaped

--- a/test/test_cli_update_mode.cpp
+++ b/test/test_cli_update_mode.cpp
@@ -96,7 +96,7 @@ TEST_CASE("parse_snooze tolerates whitespace and trailing content",
 }
 
 TEST_CASE("parse_snooze starts at the first numeric run",
-          "[cli][update-mode][coverage][phase3]") {
+          "[cli][update-mode][snooze][parse]") {
     REQUIRE(um::parse_snooze("expires: 1700000000") == 1'700'000'000);
     REQUIRE(um::parse_snooze("abc -42 trailing 99") == -42);
     REQUIRE(um::parse_snooze("12 34") == 12);
@@ -268,13 +268,12 @@ TEST_CASE("pending-upgrade file round-trips through write/read/clear",
     fs::remove_all(dir);
 }
 
-// Issue #590: the auto-mode banner in pulp_cli.cpp must gate its
-// "downloaded / will complete next invocation" notice on
-// write_pending_upgrade succeeding. Exercise the underlying failure mode
-// (non-existent file as the parent path) so a regression in the return-value
-// contract surfaces immediately.
+// The auto-mode banner in pulp_cli.cpp must gate its "downloaded / will
+// complete next invocation" notice on write_pending_upgrade succeeding.
+// Exercise the underlying failure mode so the return-value contract stays
+// visible.
 TEST_CASE("write_pending_upgrade returns false when the parent cannot be created",
-          "[cli][update-mode][issue-590]") {
+          "[cli][update-mode][pending-upgrade][error]") {
     auto dir = make_tmpdir("pending-upgrade-badparent");
     // Create a plain file at what would otherwise be a directory —
     // fs::create_directories refuses to stomp on a regular file, so
@@ -293,15 +292,14 @@ TEST_CASE("write_pending_upgrade returns false when the parent cannot be created
     fs::remove_all(dir);
 }
 
-// Issue #590: the opportunistic tombstone sweep in
-// maybe_complete_pending_upgrade() runs even when no pending marker exists
-// (covers direct `pulp upgrade` flows on Windows). This test asserts the
-// contract of the piece that sweep relies on:
+// The opportunistic tombstone sweep in maybe_complete_pending_upgrade() runs
+// even when no pending marker exists, which covers direct `pulp upgrade` flows
+// on Windows. This test asserts the contract of the piece that sweep relies on:
 // cleanup_tombstone must be safe to call unconditionally, regardless
 // of marker state. The two cases already covered above (present /
 // absent) are what the unconditional call in pulp_cli.cpp depends on.
 TEST_CASE("cleanup_tombstone is safe to call after a no-marker fast path",
-          "[cli][update-mode][issue-590]") {
+          "[cli][update-mode][tombstone][windows]") {
     auto dir = make_tmpdir("tombstone-no-marker");
     auto exe = dir / "pulp";
     std::ofstream(exe) << "live";

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -134,7 +134,7 @@ TEST_CASE("read_plugin_version returns empty when manifest has no version field"
 }
 
 TEST_CASE("read_plugin_version accepts tag-style version strings",
-          "[version-diag][coverage][phase3]") {
+          "[version-diag][plugin-manifest][version-parse]") {
     TempDir tmp;
     auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
     write_file(plugin_json, R"({
@@ -348,14 +348,11 @@ TEST_CASE("read_project_cli_min_version ignores an empty project root",
     REQUIRE(v.raw.empty());
 }
 
-// Issue #546: the earlier scanner treated any line containing the
-// `cli_min_version` substring as a real config entry and grabbed the next
-// quoted value. A commented example therefore produced a false skew warning in
-// `pulp doctor --versions`. The fix strips in-line `#` comments before
-// matching, so the commented line is silently ignored and
-// `read_project_cli_min_version` returns empty.
+// Commented examples must not parse as real `cli_min_version` entries. Strip
+// inline `#` comments before matching so `pulp doctor --versions` does not
+// report false skew from documentation snippets.
 TEST_CASE("read_project_cli_min_version ignores commented-out examples",
-          "[version-diag][issue-499][issue-546]") {
+          "[version-diag][cli-min-version][comments]") {
     TempDir tmp;
     auto toml = tmp.path / "pulp.toml";
     write_file(toml,
@@ -413,7 +410,7 @@ TEST_CASE("read_project_cli_min_version ignores unquoted and malformed values",
     REQUIRE(v.raw.empty());
 }
 
-// ── Per-project skew via VersionReport.projects (#552) ─────────────
+// ── Per-project skew via VersionReport.projects ───────────────────
 
 TEST_CASE("analyze warns per-project when project[].cli_min exceeds CLI",
           "[version-diag][issue-552]") {
@@ -520,7 +517,7 @@ TEST_CASE("analyze uses the path basename when project name is empty",
     REQUIRE(saw_basename);
 }
 
-// ── Plugin ↔ CLI skew detection (#551) ─────────────────────────────
+// ── Plugin ↔ CLI skew detection ───────────────────────────────────
 
 TEST_CASE("read_plugin_min_cli_version scrapes min_cli_version field",
           "[version-diag][issue-551]") {

--- a/test/test_design_import_designmd.cpp
+++ b/test/test_design_import_designmd.cpp
@@ -1,8 +1,7 @@
 // test_design_import_designmd.cpp — DESIGN.md import test suite
 //
-// Covers the Phase 1 acceptance criteria from
-// planning/2026-05-13-designmd-integration-plan.md. Tag set:
-// [view][import][designmd][issue-1434]
+// Covers DESIGN.md import parsing, linting, diff, and export-gated behavior.
+// Tag set: [view][import][designmd]
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -61,7 +60,7 @@ pulp::import_detect::ImportsManifest load_manifest() {
 
 // (1) ── parses paws-and-paths frontmatter into populated tokens ────────
 TEST_CASE("parse_designmd populates colors/typography/rounded/spacing/components on paws-and-paths",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = upstream_fixture();
     REQUIRE_FALSE(text.empty());
 
@@ -87,7 +86,7 @@ TEST_CASE("parse_designmd populates colors/typography/rounded/spacing/components
 
 // (2) ── resolves nested color references in components section ────────
 TEST_CASE("token references inside components resolve to primitive values",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = hand_authored_fixture();
     auto result = parse_designmd(text);
     auto it = result.ir.tokens.strings.find("components.button-primary.backgroundColor");
@@ -98,7 +97,7 @@ TEST_CASE("token references inside components resolve to primitive values",
 
 // (3) ── composite typography refs inside components are preserved ─────
 TEST_CASE("composite typography refs inside components are preserved verbatim",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = hand_authored_fixture();
     auto result = parse_designmd(text);
     auto it = result.ir.tokens.strings.find("components.button-primary.typography");
@@ -109,7 +108,7 @@ TEST_CASE("composite typography refs inside components are preserved verbatim",
 
 // (4) ── group refs outside components emit a broken-ref diagnostic ────
 TEST_CASE("non-component reference to a group emits broken-ref warning",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     // colors.accent → {colors.primary}: this is a valid in-group ref to a
     // primitive, which the parser resolves. The "group-ref" rejection
     // case is exercised when a value points at a bare group name
@@ -122,7 +121,7 @@ TEST_CASE("non-component reference to a group emits broken-ref warning",
 
 // (5) ── DTCG export round-trip on paws-and-paths is non-empty + valid ─
 TEST_CASE("export_w3c_tokens emits DTCG JSON from a parsed DESIGN.md",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = upstream_fixture();
     auto result = parse_designmd(text);
     auto theme = ir_tokens_to_theme(result.ir.tokens);
@@ -134,7 +133,7 @@ TEST_CASE("export_w3c_tokens emits DTCG JSON from a parsed DESIGN.md",
 
 // (6) ── unknown section headings preserved without erroring ────────────
 TEST_CASE("unknown section headings are preserved and do not error",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = hand_authored_fixture();
     auto result = parse_designmd(text);
     bool seen_iconography = false;
@@ -152,7 +151,7 @@ TEST_CASE("unknown section headings are preserved and do not error",
 
 // (7) ── duplicate section headings reject the file ────────────────────
 TEST_CASE("duplicate ## section heading reports error-severity diagnostic",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     std::string text =
         "---\nname: Dup\ncolors:\n  primary: \"#000\"\n---\n"
         "## Colors\nFirst body.\n\n## Colors\nSecond body — duplicate!\n";
@@ -169,7 +168,7 @@ TEST_CASE("duplicate ## section heading reports error-severity diagnostic",
 
 // (8) ── detector identifies a DESIGN.md as `designmd` source ─────────
 TEST_CASE("detector recognizes upstream DESIGN.md fixture",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto manifest = load_manifest();
     auto snap = pulp::import_detect::snapshot_input(
         fs::path(PULP_REPO_ROOT) / "test/fixtures/imports/designmd/alpha/DESIGN.md");
@@ -182,7 +181,7 @@ TEST_CASE("detector recognizes upstream DESIGN.md fixture",
 
 // (9a) ── detector rejects Jekyll-style blog post ─────────────────────
 TEST_CASE("detector rejects generic Markdown frontmatter (Jekyll decoy)",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto manifest = load_manifest();
     auto snap = pulp::import_detect::snapshot_input(
         fs::path(PULP_REPO_ROOT) / "test/fixtures/imports/designmd/alpha/decoys/jekyll/blog-post.md");
@@ -192,7 +191,7 @@ TEST_CASE("detector rejects generic Markdown frontmatter (Jekyll decoy)",
 
 // (9b) ── detector rejects DESIGN.md missing `name:` key ───────────────
 TEST_CASE("detector rejects DESIGN.md without name: key (missing-name decoy)",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto manifest = load_manifest();
     auto snap = pulp::import_detect::snapshot_input(
         fs::path(PULP_REPO_ROOT) / "test/fixtures/imports/designmd/alpha/decoys/missing-name/DESIGN.md");
@@ -202,7 +201,7 @@ TEST_CASE("detector rejects DESIGN.md without name: key (missing-name decoy)",
 
 // (9c) ── detector rejects DESIGN.md without any canonical token group ─
 TEST_CASE("detector rejects DESIGN.md without token-group keys",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto manifest = load_manifest();
     auto snap = pulp::import_detect::snapshot_input(
         fs::path(PULP_REPO_ROOT) / "test/fixtures/imports/designmd/alpha/decoys/missing-token-groups/DESIGN.md");
@@ -212,7 +211,7 @@ TEST_CASE("detector rejects DESIGN.md without token-group keys",
 
 // (10) ── prose-only DESIGN.md emits empty tokens, no error ────────────
 TEST_CASE("DESIGN.md with no frontmatter produces empty tokens + info diagnostic",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     std::string text = "# Brand Notes\n\nNo frontmatter; just prose.\n";
     auto result = parse_designmd(text);
     REQUIRE_FALSE(result.had_frontmatter);
@@ -222,7 +221,7 @@ TEST_CASE("DESIGN.md with no frontmatter produces empty tokens + info diagnostic
 }
 
 TEST_CASE("parse_designmd mirrors YAML parse and shape errors into import diagnostics",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     SECTION("parser error") {
         auto result = parse_designmd(
             "---\n"
@@ -261,7 +260,7 @@ TEST_CASE("parse_designmd mirrors YAML parse and shape errors into import diagno
 
 // (11) ── fontFeature / fontVariation preserved verbatim ───────────────
 TEST_CASE("fontFeature and fontVariation typography fields survive parse",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto text = hand_authored_fixture();
     auto result = parse_designmd(text);
     auto feat = result.ir.tokens.strings.find("typography.body-md.fontFeature");
@@ -274,17 +273,17 @@ TEST_CASE("fontFeature and fontVariation typography fields survive parse",
 
 // (12) ── parse_design_source(\"designmd\") wires the enum value ──────
 TEST_CASE("parse_design_source maps \"designmd\" → DesignSource::designmd",
-          "[view][import][designmd][issue-1434]") {
+          "[view][import][designmd][parse]") {
     auto src = parse_design_source("designmd");
     REQUIRE(src.has_value());
     REQUIRE(*src == DesignSource::designmd);
     REQUIRE(std::string(design_source_name(DesignSource::designmd)) == "DESIGN.md");
 }
 
-// ── Phase 2: lint, diff, Tailwind ──────────────────────────────────────
+// ── Lint, diff, Tailwind ───────────────────────────────────────────────
 
 TEST_CASE("lint_designmd flags missing-primary when no primary color is defined",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][colors]") {
     std::string text = "---\nname: NoPrimary\ncolors:\n  secondary: \"#888\"\n---\n";
     auto parsed = parse_designmd(text);
     auto findings = lint_designmd(parsed);
@@ -294,7 +293,7 @@ TEST_CASE("lint_designmd flags missing-primary when no primary color is defined"
 }
 
 TEST_CASE("lint_designmd flags missing-typography when colors but no typography",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][typography]") {
     std::string text = "---\nname: ColorsOnly\ncolors:\n  primary: \"#000\"\n---\n";
     auto parsed = parse_designmd(text);
     auto findings = lint_designmd(parsed);
@@ -304,7 +303,7 @@ TEST_CASE("lint_designmd flags missing-typography when colors but no typography"
 }
 
 TEST_CASE("lint_designmd promotes broken-ref to error severity",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][references]") {
     std::string text =
         "---\nname: Broken\ncolors:\n  primary: \"#000\"\n  bad: \"{colors.missing}\"\n---\n";
     auto parsed = parse_designmd(text);
@@ -320,7 +319,7 @@ TEST_CASE("lint_designmd promotes broken-ref to error severity",
 }
 
 TEST_CASE("lint_designmd flags low-contrast component pairs",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][contrast]") {
     // Light gray text on white = ~2:1 contrast → below WCAG AA 4.5:1.
     std::string text =
         "---\nname: LowContrast\n"
@@ -336,7 +335,7 @@ TEST_CASE("lint_designmd flags low-contrast component pairs",
 }
 
 TEST_CASE("lint_designmd flags orphaned color tokens",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][tokens]") {
     std::string text =
         "---\nname: Orphan\n"
         "colors:\n  primary: \"#000\"\n  unused-accent: \"#f0f\"\n"
@@ -359,7 +358,7 @@ TEST_CASE("lint_designmd flags orphaned color tokens",
 // re-scanning post-resolution strings. Without the fix, `primary` would
 // be flagged as orphaned despite being used by every component.
 TEST_CASE("lint_designmd does NOT flag referenced color as orphan after resolution",
-          "[view][import][designmd][phase2][regression][issue-1434]") {
+          "[view][import][designmd][lint][tokens][regression]") {
     std::string text =
         "---\nname: ResolvedRef\n"
         "colors:\n  primary: \"#1A1C1E\"\n"
@@ -381,7 +380,7 @@ TEST_CASE("lint_designmd does NOT flag referenced color as orphan after resoluti
 }
 
 TEST_CASE("lint_designmd emits token-summary info diagnostic",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][summary]") {
     auto parsed = parse_designmd(upstream_fixture());
     auto findings = lint_designmd(parsed);
     bool found = false;
@@ -390,7 +389,7 @@ TEST_CASE("lint_designmd emits token-summary info diagnostic",
 }
 
 TEST_CASE("lint_designmd flags section-order when sections are out of canonical order",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][lint][sections]") {
     std::string text =
         "---\nname: BadOrder\ncolors:\n  primary: \"#000\"\n---\n\n"
         "## Components\nthen\n\n## Colors\nlater\n";
@@ -402,7 +401,7 @@ TEST_CASE("lint_designmd flags section-order when sections are out of canonical 
 }
 
 TEST_CASE("diff_designmd reports added, removed, and modified color tokens",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][diff][colors]") {
     auto before = parse_designmd(
         "---\nname: V1\ncolors:\n  primary: \"#000\"\n  removed: \"#fff\"\n---\n");
     auto after = parse_designmd(
@@ -417,7 +416,7 @@ TEST_CASE("diff_designmd reports added, removed, and modified color tokens",
 }
 
 TEST_CASE("diff_designmd reports regression when after has more lint findings",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][diff][lint]") {
     auto before = parse_designmd(
         "---\nname: Clean\ncolors:\n  primary: \"#000\"\ntypography:\n  body-md:\n    fontFamily: Inter\n---\n");
     auto after = parse_designmd(
@@ -427,7 +426,7 @@ TEST_CASE("diff_designmd reports regression when after has more lint findings",
 }
 
 TEST_CASE("export_tailwind_v3_json emits theme.extend-shaped JSON",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][tailwind][v3]") {
     auto parsed = parse_designmd(
         "---\nname: TW3\ncolors:\n  primary: \"#1A1C1E\"\nrounded:\n  sm: 4px\nspacing:\n  md: 16px\n---\n");
     auto json = export_tailwind_v3_json(parsed);
@@ -438,7 +437,7 @@ TEST_CASE("export_tailwind_v3_json emits theme.extend-shaped JSON",
 }
 
 TEST_CASE("export_tailwind_v4_css emits @theme block with --color/--radius/--spacing vars",
-          "[view][import][designmd][phase2][issue-1434]") {
+          "[view][import][designmd][tailwind][v4]") {
     auto parsed = parse_designmd(
         "---\nname: TW4\ncolors:\n  primary: \"#1A1C1E\"\nrounded:\n  md: 8px\nspacing:\n  lg: 24px\n---\n");
     auto css = export_tailwind_v4_css(parsed);
@@ -452,7 +451,7 @@ TEST_CASE("export_tailwind_v4_css emits @theme block with --color/--radius/--spa
 // (fontFamily, fontSize, fontWeight, lineHeight, letterSpacing).
 // Without the fix these tokens are silently dropped from the output.
 TEST_CASE("export_tailwind_v3_json includes typography fontFamily/fontSize/fontWeight/etc",
-          "[view][import][designmd][phase2][regression][issue-1434]") {
+          "[view][import][designmd][tailwind][v3][typography][regression]") {
     auto parsed = parse_designmd(
         "---\nname: TW3Typography\n"
         "colors:\n  primary: \"#000\"\n"
@@ -472,7 +471,7 @@ TEST_CASE("export_tailwind_v3_json includes typography fontFamily/fontSize/fontW
 }
 
 TEST_CASE("export_tailwind_v4_css includes --font / --text / --leading / --tracking / --font-weight vars",
-          "[view][import][designmd][phase2][regression][issue-1434]") {
+          "[view][import][designmd][tailwind][v4][typography][regression]") {
     auto parsed = parse_designmd(
         "---\nname: TW4Typography\n"
         "colors:\n  primary: \"#000\"\n"
@@ -487,10 +486,10 @@ TEST_CASE("export_tailwind_v4_css includes --font / --text / --leading / --track
     REQUIRE(css.find("--font-weight-h1: 600") != std::string::npos);
 }
 
-// ── Phase 3: signature is fixed, body gated on pulp #1307 ─────────────
+// ── DESIGN.md export remains gated until native export is implemented ───
 
-TEST_CASE("export_designmd throws std::logic_error until pulp #1307 lands",
-          "[view][import][designmd][phase3][gated-1307][issue-1434]") {
+TEST_CASE("export_designmd throws std::logic_error while export is gated",
+          "[view][import][designmd][export-gated]") {
     Theme t;
     DesignMdProseHints hints;
     REQUIRE_THROWS_AS(export_designmd(t, hints), std::logic_error);

--- a/test/test_design_import_sources.cpp
+++ b/test/test_design_import_sources.cpp
@@ -386,7 +386,7 @@ TEST_CASE("generate_pulp_js bridge_native_js mode covers fill-height and leaf fa
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Phase 3 — Pulp Library component recognition (figma-plugin lane).
+// Pulp Library knob recognition through the figma-plugin lane.
 //
 // The TypeScript extractor (tools/figma-plugin/src/extract.ts) matches an
 // INSTANCE node's `component_set_key` against `library-manifest.json`. When
@@ -398,11 +398,10 @@ TEST_CASE("generate_pulp_js bridge_native_js mode covers fill-height and leaf fa
 //
 // This test pins that contract — without it the figma-plugin extractor and
 // design_import.cpp parser can drift apart silently.
-TEST_CASE("parse_figma_plugin_json maps Phase 3 Pulp / Knob envelope onto IR widget",
-          "[view][import][figma-plugin][phase-3]") {
-    // Envelope shape mirrors what tools/figma-plugin/src/serialize.ts emits
-    // for an instance of the Pulp / Knob component-set (the file authored
-    // in Phase 0 at https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library).
+TEST_CASE("parse_figma_plugin_json maps Pulp / Knob envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][knob]") {
+    // Envelope shape mirrors what tools/figma-plugin/src/serialize.ts emits for
+    // an instance of the Pulp / Knob component-set.
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -441,8 +440,8 @@ TEST_CASE("parse_figma_plugin_json maps Phase 3 Pulp / Knob envelope onto IR wid
     REQUIRE(ir.root.attributes.at("binding") == "filter.cutoff_hz");
 }
 
-TEST_CASE("parse_figma_plugin_json handles a Phase 3 knob without optional units",
-          "[view][import][figma-plugin][phase-3]") {
+TEST_CASE("parse_figma_plugin_json handles a Pulp / Knob without optional units",
+          "[view][import][figma-plugin][pulp-library][audio-widget][knob]") {
     // An instance can leave `units` empty (the Pulp / Knob default is an
     // empty string). The extractor SHOULD omit empty units; check that the
     // parser still maps the rest of the envelope correctly without it.
@@ -475,7 +474,7 @@ TEST_CASE("parse_figma_plugin_json handles a Phase 3 knob without optional units
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// figma-plugin binding wire-up (feat/figma-plugin-binding-wireup).
+// figma-plugin audio-widget binding wire-up.
 //
 // The figma-plugin extractor emits a recognized Pulp Library control as an
 // audio widget plus a single free-form `attributes["binding"]` string. Before
@@ -670,16 +669,15 @@ TEST_CASE("figma-plugin knob with explicit pulp* binding is not overwritten",
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Phase 5 part 1 — Pulp / Fader + Pulp / Meter recognition.
+// Pulp / Fader + Pulp / Meter recognition.
 //
-// Mirrors the Phase 3 contract for the two new library widgets added in
-// Pulp Library v0.2.0:
+// Mirrors the knob contract for library widgets added in Pulp Library v0.2.0:
 //   - Pulp / Fader  (component_set_key 1c2b727f0c0e11026512725aeb546997f16042bd)
 //   - Pulp / Meter  (component_set_key 52e1636086b855cb2d20d341d4cfa15e94151eef)
 //
 // Same envelope shape as Pulp / Knob; only audio_widget enum changes.
-TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Fader envelope onto IR widget",
-          "[view][import][figma-plugin][phase-5]") {
+TEST_CASE("parse_figma_plugin_json maps Pulp / Fader envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][fader]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -725,8 +723,8 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Fader envelope onto IR wi
     REQUIRE(ir.root.attributes.at("binding") == "param.master_level");
 }
 
-TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Meter envelope onto IR widget",
-          "[view][import][figma-plugin][phase-5]") {
+TEST_CASE("parse_figma_plugin_json maps Pulp / Meter envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][meter]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -757,10 +755,10 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Meter envelope onto IR wi
     REQUIRE(ir.root.attributes.at("binding") == "meter.out_l");
 }
 
-// ── pulp #3191: codegen emits derived skin setters for fader/meter ──────────
+// ── Codegen emits derived skin setters for fader/meter ──────────────────
 
 TEST_CASE("Codegen emits setFaderSkin from derived skin attributes",
-          "[view][import][issue-3191]") {
+          "[view][import][skin][fader]") {
     DesignIR ir;
     ir.root.type = "frame";
     ir.root.name = "root";
@@ -802,7 +800,7 @@ TEST_CASE("Codegen emits setFaderSkin from derived skin attributes",
 }
 
 TEST_CASE("Codegen emits setMeterColors + normalized level from derived skin",
-          "[view][import][issue-3191]") {
+          "[view][import][skin][meter]") {
     DesignIR ir;
     ir.root.type = "frame";
     ir.root.name = "root";
@@ -838,10 +836,10 @@ TEST_CASE("Codegen emits setMeterColors + normalized level from derived skin",
     REQUIRE(plain_js.find("setMeterColors(") == std::string::npos);
 }
 
-// ── pulp #3191 width fix: derived narrow widths flow to render ───────────────
+// ── Derived narrow widths flow to render ────────────────────────────────
 
 TEST_CASE("Codegen renders fader at derived thumb width + emits thin track width",
-          "[view][import][issue-3191]") {
+          "[view][import][skin][fader][width]") {
     DesignIR ir;
     ir.root.type = "frame";
     ir.root.name = "root";
@@ -876,7 +874,7 @@ TEST_CASE("Codegen renders fader at derived thumb width + emits thin track width
 }
 
 TEST_CASE("Codegen renders meter at derived narrow bar width, centred in column",
-          "[view][import][issue-3191]") {
+          "[view][import][skin][meter][width]") {
     DesignIR ir;
     ir.root.type = "frame";
     ir.root.name = "root";
@@ -906,7 +904,7 @@ TEST_CASE("Codegen renders meter at derived narrow bar width, centred in column"
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Phase 5 part 2 — Pulp / XYPad + Pulp / Waveform + Pulp / Spectrum.
+// Pulp / XYPad + Pulp / Waveform + Pulp / Spectrum recognition.
 //
 // Library v0.3.0 adds three component-sets in
 // https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library:
@@ -918,8 +916,8 @@ TEST_CASE("Codegen renders meter at derived narrow bar width, centred in column"
 // Waveform and Spectrum's `binding` carries an audio-source path
 // (bus.master_l / bus.fft.master_l) instead of a parameter route.
 
-TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / XYPad envelope onto IR widget",
-          "[view][import][figma-plugin][phase-5]") {
+TEST_CASE("parse_figma_plugin_json maps Pulp / XYPad envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][xy-pad]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -954,8 +952,8 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / XYPad envelope ont
     REQUIRE(ir.root.attributes.at("binding_y") == "filter.resonance");
 }
 
-TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Waveform envelope onto IR widget",
-          "[view][import][figma-plugin][phase-5]") {
+TEST_CASE("parse_figma_plugin_json maps Pulp / Waveform envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][waveform]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -987,8 +985,8 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Waveform envelope 
     REQUIRE(ir.root.attributes.count("binding_y") == 0);
 }
 
-TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Spectrum envelope onto IR widget",
-          "[view][import][figma-plugin][phase-5]") {
+TEST_CASE("parse_figma_plugin_json maps Pulp / Spectrum envelope onto IR widget",
+          "[view][import][figma-plugin][pulp-library][audio-widget][spectrum]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",
@@ -1040,12 +1038,10 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Spectrum envelope 
 //   5. XYPad-specific binding_y rides on attributes.binding_y.
 //   6. Audio ranges round-trip on every widget.
 //
-// Once the library republish AND Agent A's fidelity harness both land in
-// main, we'll author a Figma file mirroring this layout via the MCP
-// connector and replace this hand-rolled envelope with one produced by
-// the real published plugin — closing the loop on Phase B5.
+// The envelope is hand-rolled so the parser contract stays deterministic and
+// does not depend on a live Figma document or plugin publish state.
 TEST_CASE("kitchen-sink envelope parses all 6 Pulp Library widgets from one root frame",
-          "[view][import][figma-plugin][phase-b5][kitchen-sink]") {
+          "[view][import][figma-plugin][pulp-library][kitchen-sink]") {
     const std::string envelope = R"JSON({
         "format_version": "v1",
         "parser_version": "0.1.0",

--- a/test/test_font_rendering_goldens.cpp
+++ b/test/test_font_rendering_goldens.cpp
@@ -51,7 +51,7 @@
 //     more dependencies than the canvas test wants) and write
 //     the PNG via Skia's `SkPngEncoder` directly.
 //
-// Tag: [golden][skia][font][issue-2257-followup]
+// Tag: [golden][skia][font]
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -258,8 +258,8 @@ constexpr Digest kHelloWorldMono12 {
 // Goldens — three small text strings, three scenarios.
 // ────────────────────────────────────────────────────────────────
 
-TEST_CASE("font v2 Slice 3.4 — golden Inter 14px 'Hello' on raster",
-          "[golden][skia][font][issue-2257-followup]") {
+TEST_CASE("font rendering golden: Inter 14px 'Hello' on raster",
+          "[golden][skia][font]") {
     SkBitmap bm = render_text_bitmap("Inter", 14.0f, "Hello");
     SkPixmap pm;
     REQUIRE(bm.peekPixels(&pm));
@@ -277,8 +277,8 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px 'Hello' on raster",
     expect_digest_matches(d, kHelloInter14, "hello-inter-14", bm);
 }
 
-TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
-          "[golden][skia][font][issue-2257-followup]") {
+TEST_CASE("font rendering golden: Inter 14px CJK 日本語 on raster",
+          "[golden][skia][font][cjk]") {
     // CJK is the *cascade* case: Inter doesn't ship CJK glyphs,
     // so the request falls through to the platform font manager.
     // On macOS that lands on Hiragino/Apple SD; on Linux without
@@ -286,10 +286,9 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
     // case so this test stays a useful guard on the platforms
     // that DO have a CJK fallback.
     //
-    // Regression for pulp #2261: use a DETERMINISTIC probe instead
-    // of the post-render `opaque_pixels < 20`
-    // threshold. The threshold approach is unsound because Skia's
-    // `fill_text` paints the `.notdef` glyph (tofu boxes) when no
+    // Use a deterministic probe instead of the post-render
+    // `opaque_pixels < 20` threshold. The threshold approach is unsound because
+    // Skia's `fill_text` paints the `.notdef` glyph (tofu boxes) when no
     // CJK face is found — those tofu pixels easily exceed 20,
     // bypassing the soft-skip and producing spurious golden
     // mismatches. Ask the resolver directly: does the cascade
@@ -321,8 +320,8 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
     expect_digest_matches(d, kCjkInter14, "cjk-inter-14", bm);
 }
 
-TEST_CASE("font v2 Slice 3.4 — golden JetBrains Mono 12px 'Hello world'",
-          "[golden][skia][font][issue-2257-followup]") {
+TEST_CASE("font rendering golden: JetBrains Mono 12px 'Hello world'",
+          "[golden][skia][font][monospace]") {
     SkBitmap bm = render_text_bitmap("JetBrains Mono", 12.0f, "Hello world");
     SkPixmap pm;
     REQUIRE(bm.peekPixels(&pm));
@@ -341,8 +340,8 @@ TEST_CASE("font v2 Slice 3.4 — golden JetBrains Mono 12px 'Hello world'",
 // non-determinism bug, NOT a golden-file rot signal.
 // ────────────────────────────────────────────────────────────────
 
-TEST_CASE("font v2 Slice 3.4 — render pipeline is deterministic in-process",
-          "[golden][skia][font][determinism][issue-2257-followup]") {
+TEST_CASE("font rendering golden: render pipeline is deterministic in-process",
+          "[golden][skia][font][determinism]") {
     SkBitmap a = render_text_bitmap("Inter", 14.0f, "Hello");
     SkBitmap b = render_text_bitmap("Inter", 14.0f, "Hello");
 
@@ -364,7 +363,7 @@ TEST_CASE("font v2 Slice 3.4 — render pipeline is deterministic in-process",
 
 #else  // !PULP_HAS_SKIA
 
-TEST_CASE("font v2 Slice 3.4 — rendering goldens require Skia",
+TEST_CASE("font rendering goldens require Skia",
           "[golden][skia][font]") {
     SUCCEED("Skia not compiled — golden harness needs SkSurfaces::Raster.");
 }

--- a/test/test_font_rendering_goldens_d3d.cpp
+++ b/test/test_font_rendering_goldens_d3d.cpp
@@ -76,7 +76,7 @@
 //      Prefer the WARP adapter for the committed values — real-GPU
 //      digests are runner-dependent.
 //
-// Tag: [golden][gpu][d3d][skia][font][issue-2257-followup][scaffold]
+// Tag: [golden][gpu][d3d][skia][font][scaffold]
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -88,8 +88,8 @@
 // raster↔D3D tolerance TEST_CASE. Tolerance for the cross-backend
 // probe is ±20 % (see header rationale).
 
-TEST_CASE("font v2 Slice 3.4 — D3D12 goldens scaffold placeholder",
-          "[golden][gpu][d3d][skia][font][scaffold][issue-2257-followup]") {
+TEST_CASE("font D3D12 rendering goldens scaffold placeholder",
+          "[golden][gpu][d3d][skia][font][scaffold]") {
     // Placeholder. The real implementation imports Skia's D3D
     // context (`GrD3DBackendContext` / `GrDirectContexts::MakeDirect3D`
     // or Graphite-D3D via Dawn), allocates a 128×32 RGBA8 surface,

--- a/test/test_font_rendering_goldens_gpu.cpp
+++ b/test/test_font_rendering_goldens_gpu.cpp
@@ -61,7 +61,7 @@
 //     time (so a CI lane without a working Dawn adapter soft-skips
 //     instead of hard-failing).
 //
-// Tag: [golden][gpu][skia][font][issue-2257-followup]
+// Tag: [golden][gpu][skia][font]
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -366,8 +366,8 @@ constexpr Digest kGpuHelloWorldMono12 {
 // Goldens — three strings, three scenarios.
 // ────────────────────────────────────────────────────────────────
 
-TEST_CASE("font v2 Slice 3.4 — GPU golden Inter 14px 'Hello'",
-          "[golden][gpu][skia][font][issue-2257-followup]") {
+TEST_CASE("font GPU rendering golden: Inter 14px 'Hello'",
+          "[golden][gpu][skia][font]") {
     auto f = make_gpu_fixture();
     if (!f.ready()) {
         SUCCEED("Dawn/Graphite unavailable on this host — GPU golden skipped.");
@@ -390,8 +390,8 @@ TEST_CASE("font v2 Slice 3.4 — GPU golden Inter 14px 'Hello'",
                           "hello-inter-14", pixels, pw, ph);
 }
 
-TEST_CASE("font v2 Slice 3.4 — GPU golden Inter 14px CJK 日本語",
-          "[golden][gpu][skia][font][issue-2257-followup]") {
+TEST_CASE("font GPU rendering golden: Inter 14px CJK 日本語",
+          "[golden][gpu][skia][font][cjk]") {
     auto f = make_gpu_fixture();
     if (!f.ready()) {
         SUCCEED("Dawn/Graphite unavailable on this host — GPU golden skipped.");
@@ -420,8 +420,8 @@ TEST_CASE("font v2 Slice 3.4 — GPU golden Inter 14px CJK 日本語",
                           "cjk-inter-14", pixels, pw, ph);
 }
 
-TEST_CASE("font v2 Slice 3.4 — GPU golden JetBrains Mono 12px 'Hello world'",
-          "[golden][gpu][skia][font][issue-2257-followup]") {
+TEST_CASE("font GPU rendering golden: JetBrains Mono 12px 'Hello world'",
+          "[golden][gpu][skia][font][monospace]") {
     auto f = make_gpu_fixture();
     if (!f.ready()) {
         SUCCEED("Dawn/Graphite unavailable on this host — GPU golden skipped.");
@@ -452,8 +452,8 @@ TEST_CASE("font v2 Slice 3.4 — GPU golden JetBrains Mono 12px 'Hello world'",
 // relax the per-string tolerance, that's the wrong fix.
 // ────────────────────────────────────────────────────────────────
 
-TEST_CASE("font v2 Slice 3.4 — GPU render pipeline is deterministic in-process",
-          "[golden][gpu][skia][font][determinism][issue-2257-followup]") {
+TEST_CASE("font GPU rendering golden: render pipeline is deterministic in-process",
+          "[golden][gpu][skia][font][determinism]") {
     auto f = make_gpu_fixture();
     if (!f.ready()) {
         SUCCEED("Dawn/Graphite unavailable on this host — determinism probe skipped.");
@@ -483,8 +483,8 @@ TEST_CASE("font v2 Slice 3.4 — GPU render pipeline is deterministic in-process
 // within ±15%. Width/height must match exactly (sanity).
 // ────────────────────────────────────────────────────────────────
 
-TEST_CASE("font v2 Slice 3.4 — raster and GPU digests agree within tolerance",
-          "[golden][gpu][skia][font][cross-backend][issue-2257-followup]") {
+TEST_CASE("font GPU rendering golden: raster and GPU digests agree within tolerance",
+          "[golden][gpu][skia][font][cross-backend]") {
     auto f = make_gpu_fixture();
     if (!f.ready()) {
         SUCCEED("Dawn/Graphite unavailable on this host — cross-backend probe skipped.");
@@ -531,7 +531,7 @@ TEST_CASE("font v2 Slice 3.4 — raster and GPU digests agree within tolerance",
 
 #else  // !(PULP_HAS_SKIA && __APPLE__)
 
-TEST_CASE("font v2 Slice 3.4 — GPU rendering goldens require Skia on macOS",
+TEST_CASE("font GPU rendering goldens require Skia on macOS",
           "[golden][gpu][skia][font]") {
     // Two reasons we end up here:
     //  1. Skia not linked (Namespace macOS overflow runner, Linux/Win CI).

--- a/test/test_font_rendering_goldens_vulkan.cpp
+++ b/test/test_font_rendering_goldens_vulkan.cpp
@@ -77,7 +77,7 @@
 //   4. Commit observed-actual digests as the new constants
 //      (`kVkHelloInter14`, …) once the first green run lands.
 //
-// Tag: [golden][gpu][vulkan][skia][font][issue-2257-followup][scaffold]
+// Tag: [golden][gpu][vulkan][skia][font][scaffold]
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -89,8 +89,8 @@
 // raster↔Vulkan tolerance TEST_CASE. Tolerance for the cross-backend
 // probe is ±20 % (see header rationale).
 
-TEST_CASE("font v2 Slice 3.4 — Vulkan goldens scaffold placeholder",
-          "[golden][gpu][vulkan][skia][font][scaffold][issue-2257-followup]") {
+TEST_CASE("font Vulkan rendering goldens scaffold placeholder",
+          "[golden][gpu][vulkan][skia][font][scaffold]") {
     // Placeholder. The real implementation imports Skia's Vulkan
     // context (`GrVkBackendContext` / `GrDirectContexts::MakeVulkan`
     // or Graphite-Vulkan via Dawn), allocates a 128×32 RGBA8 surface,

--- a/test/test_inspector_domain_helpers.cpp
+++ b/test/test_inspector_domain_helpers.cpp
@@ -111,7 +111,7 @@ TEST_CASE("AudioInspector MIDI and underrun histories keep newest entries",
 }
 
 TEST_CASE("AudioInspector stores runtime telemetry as latest-value snapshot",
-          "[inspect][audio][telemetry][phase2]") {
+          "[inspect][audio][telemetry][snapshot]") {
     AudioInspector audio;
 
     auto empty = audio.runtime_telemetry();
@@ -149,7 +149,7 @@ TEST_CASE("AudioInspector stores runtime telemetry as latest-value snapshot",
 }
 
 TEST_CASE("AudioInspector consumes AudioDeviceManager runtime telemetry",
-          "[inspect][audio][telemetry][phase2]") {
+          "[inspect][audio][telemetry][device-manager]") {
     pulp::audio::AudioDeviceManager manager;
     AudioInspector audio;
 

--- a/test/test_scroll_view.cpp
+++ b/test/test_scroll_view.cpp
@@ -168,14 +168,14 @@ TEST_CASE("ScrollView: hit testing follows scrolled content", "[scrollview]") {
     REQUIRE(hit == label_ptr);
 }
 
-// ── pulp #1170: ScrollView honors React Native pointerEvents ───────────────
+// ── ScrollView honors React Native pointerEvents ────────────────────────
 //
-// Regression for #1044 / #1170: ScrollView::hit_test shadowed View::hit_test
-// without honoring pointer_events(), so setPointerEvents("box-only"/"box-none"
-// /"none") was a silent no-op for any scrollable container.
+// ScrollView::hit_test must honor pointer_events() so
+// setPointerEvents("box-only"/"box-none"/"none") works for scrollable
+// containers.
 
-TEST_CASE("ScrollView::hit_test honors pointerEvents == none (#1170)",
-          "[scrollview][hit_test][issue-1170]") {
+TEST_CASE("ScrollView::hit_test honors pointerEvents == none",
+          "[scrollview][hit_test][pointer-events]") {
     ScrollView sv;
     sv.set_bounds({0, 0, 200, 200});
     sv.set_content_size({200, 200});
@@ -189,8 +189,8 @@ TEST_CASE("ScrollView::hit_test honors pointerEvents == none (#1170)",
     REQUIRE(sv.hit_test({10, 10}) == nullptr);
 }
 
-TEST_CASE("ScrollView::hit_test honors pointerEvents == box-only (#1170)",
-          "[scrollview][hit_test][issue-1170]") {
+TEST_CASE("ScrollView::hit_test honors pointerEvents == box-only",
+          "[scrollview][hit_test][pointer-events]") {
     ScrollView sv;
     sv.set_bounds({0, 0, 200, 200});
     sv.set_content_size({200, 200});
@@ -206,8 +206,8 @@ TEST_CASE("ScrollView::hit_test honors pointerEvents == box-only (#1170)",
     REQUIRE(sv.hit_test({10, 10}) == &sv);
 }
 
-TEST_CASE("ScrollView::hit_test honors pointerEvents == box-none (#1170)",
-          "[scrollview][hit_test][issue-1170]") {
+TEST_CASE("ScrollView::hit_test honors pointerEvents == box-none",
+          "[scrollview][hit_test][pointer-events]") {
     ScrollView sv;
     sv.set_bounds({0, 0, 200, 200});
     sv.set_content_size({200, 200});
@@ -224,8 +224,8 @@ TEST_CASE("ScrollView::hit_test honors pointerEvents == box-none (#1170)",
     REQUIRE(sv.hit_test({10, 10}) == nullptr);
 }
 
-TEST_CASE("ScrollView::hit_test box-none also suppresses scrollbar self-target (#1170)",
-          "[scrollview][hit_test][issue-1170]") {
+TEST_CASE("ScrollView::hit_test box-none also suppresses scrollbar self-target",
+          "[scrollview][hit_test][pointer-events]") {
     ScrollView sv;
     sv.set_bounds({0, 0, 200, 100});
     // Content taller than view → vertical scrollbar appears at the right edge.
@@ -237,7 +237,7 @@ TEST_CASE("ScrollView::hit_test box-none also suppresses scrollbar self-target (
     REQUIRE(sv.hit_test({195, 50}) == nullptr);
 }
 
-// ── pulp #1148 slice (a) — symmetric overflow:visible hit-test extension ──
+// ── Symmetric overflow:visible hit-test extension ───────────────────────
 //
 // ScrollView::hit_test had the same right/down-only asymmetry as
 // View::hit_test. Lock the symmetric ±500px slack here too so left- or
@@ -271,31 +271,31 @@ struct ScrollPopoverFixture {
 } // namespace
 
 TEST_CASE("ScrollView::hit_test extends overflow:visible 500px to the LEFT",
-          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+          "[scrollview][hit_test][overflow-symmetric]") {
     ScrollPopoverFixture f(-200, 25);
     REQUIRE(f.sv.hit_test({425, 650}) == f.popover);
 }
 
 TEST_CASE("ScrollView::hit_test extends overflow:visible 500px to the RIGHT",
-          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+          "[scrollview][hit_test][overflow-symmetric]") {
     ScrollPopoverFixture f(200, 25);
     REQUIRE(f.sv.hit_test({825, 650}) == f.popover);
 }
 
 TEST_CASE("ScrollView::hit_test extends overflow:visible 500px UPWARD",
-          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+          "[scrollview][hit_test][overflow-symmetric]") {
     ScrollPopoverFixture f(25, -200);
     REQUIRE(f.sv.hit_test({650, 425}) == f.popover);
 }
 
 TEST_CASE("ScrollView::hit_test extends overflow:visible 500px DOWNWARD",
-          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+          "[scrollview][hit_test][overflow-symmetric]") {
     ScrollPopoverFixture f(25, 200);
     REQUIRE(f.sv.hit_test({650, 825}) == f.popover);
 }
 
 TEST_CASE("ScrollView::hit_test does NOT extend overflow:visible past 500px LEFT",
-          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+          "[scrollview][hit_test][overflow-symmetric]") {
     ScrollPopoverFixture f(-650, 25);
     REQUIRE(f.sv.hit_test({0, 650}) != f.popover);
 }

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1647,12 +1647,11 @@ TEST_CASE("Tokens survive StateStore destruction without crashing",
     REQUIRE_FALSE(static_cast<bool>(orphan));
 }
 
-TEST_CASE("Queued Main callback is cancelled by token reset (PR#2270)",
+TEST_CASE("Queued Main callback is cancelled by token reset",
           "[state][listener][token][thread]") {
-    // Regression for PR #2270: a Main listener dispatched through the
-    // EventLoop must NOT fire if the token is destroyed/reset between
-    // enqueue and drain. The dispatch lambda re-looks-up the entry by id
-    // at drain time, so removal cancels it.
+    // A Main listener dispatched through the EventLoop must not fire if the
+    // token is destroyed or reset between enqueue and drain. The dispatch
+    // lambda re-looks-up the entry by id at drain time, so removal cancels it.
     pulp::events::EventLoop loop;
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));

--- a/test/test_view_core_link.cpp
+++ b/test/test_view_core_link.cpp
@@ -10,7 +10,7 @@
 using namespace pulp::view;
 
 TEST_CASE("view core target links baked design import without script runtime",
-          "[view][import][core-link][phase-9]") {
+          "[view][import][core-link][baked-ui]") {
     DesignIR ir;
     ir.source = DesignSource::figma;
     ir.root.type = "frame";
@@ -39,7 +39,7 @@ TEST_CASE("view core target links baked design import without script runtime",
 }
 
 TEST_CASE("view core classname extraction reads bundled template styles",
-          "[view][import][core-link][phase-9]") {
+          "[view][import][core-link][template-styles]") {
     const std::string html =
         R"HTML(<html><head><script type="__bundler/template">)HTML"
         R"JSON("<html><head><style>.panel { color: #abcdef; background-color: #123456; }</style></head><body></body></html>")JSON"

--- a/test/test_view_design_viewport.cpp
+++ b/test/test_view_design_viewport.cpp
@@ -1,4 +1,4 @@
-// pulp #59/#63/#64/#65 — WindowHost::compute_design_viewport_transform.
+// WindowHost::compute_design_viewport_transform.
 //
 // Unit-tests the pure math behind set_design_viewport so the
 // scale + letterbox math is locked down independent of any platform
@@ -6,8 +6,7 @@
 // so a regression here would silently break proportional resize for
 // every fixed-design import.
 //
-// Tag [issue-pulp-design-viewport] so the coverage harness can
-// attribute these to the slice that introduced them.
+// Tag [design-viewport] so the coverage harness can attribute these cases.
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -34,7 +33,7 @@ constexpr float kEps = 1e-4f;
 
 } // namespace
 
-TEST_CASE("design viewport: 1:1 match yields identity", "[view][design-viewport][issue-pulp-design-viewport]") {
+TEST_CASE("design viewport: 1:1 match yields identity", "[view][design-viewport]") {
     auto t = xform(1320, 860, 1320, 860);
     REQUIRE(t.ok);
     REQUIRE_THAT(t.sx, WithinAbs(1.0f, kEps));
@@ -43,7 +42,7 @@ TEST_CASE("design viewport: 1:1 match yields identity", "[view][design-viewport]
     REQUIRE_THAT(t.ty, WithinAbs(0.0f, kEps));
 }
 
-TEST_CASE("design viewport: proportional shrink keeps aspect", "[view][design-viewport][issue-pulp-design-viewport]") {
+TEST_CASE("design viewport: proportional shrink keeps aspect", "[view][design-viewport]") {
     // Half-size window at the design aspect — uniform 0.5x scale,
     // no letterboxing because aspect matches.
     auto t = xform(660, 430, 1320, 860);
@@ -55,7 +54,7 @@ TEST_CASE("design viewport: proportional shrink keeps aspect", "[view][design-vi
     REQUIRE_THAT(t.ty, WithinAbs(0.0f, kEps));
 }
 
-TEST_CASE("design viewport: wider window letterboxes horizontally", "[view][design-viewport][issue-pulp-design-viewport]") {
+TEST_CASE("design viewport: wider window letterboxes horizontally", "[view][design-viewport]") {
     // 1600x860 window, 1320x860 design — height is the limiting axis
     // (1.0x), letterbox bars appear on left+right.
     auto t = xform(1600, 860, 1320, 860);
@@ -67,7 +66,7 @@ TEST_CASE("design viewport: wider window letterboxes horizontally", "[view][desi
     REQUIRE_THAT(t.ty, WithinAbs(0.0f, kEps));
 }
 
-TEST_CASE("design viewport: taller window letterboxes vertically", "[view][design-viewport][issue-pulp-design-viewport]") {
+TEST_CASE("design viewport: taller window letterboxes vertically", "[view][design-viewport]") {
     // 1320x1000 window — width is the limiting axis (1.0x), letterbox
     // bars appear on top+bottom.
     auto t = xform(1320, 1000, 1320, 860);
@@ -80,7 +79,7 @@ TEST_CASE("design viewport: taller window letterboxes vertically", "[view][desig
 }
 
 TEST_CASE("design viewport: input inverse round-trips a known point",
-          "[view][design-viewport][issue-pulp-design-viewport]") {
+          "[view][design-viewport]") {
     // Mouse at the centre of a wider-than-design window should map to
     // the centre of the design surface, not the centre of the window.
     const float ww = 1600.0f, wh = 860.0f, dw = 1320.0f, dh = 860.0f;
@@ -112,7 +111,7 @@ TEST_CASE("design viewport: input inverse round-trips a known point",
 }
 
 TEST_CASE("design viewport: rejects degenerate inputs",
-          "[view][design-viewport][issue-pulp-design-viewport]") {
+          "[view][design-viewport]") {
     REQUIRE_FALSE(xform(0, 860, 1320, 860).ok);
     REQUIRE_FALSE(xform(1320, 0, 1320, 860).ok);
     REQUIRE_FALSE(xform(1320, 860, 0, 860).ok);
@@ -126,7 +125,7 @@ TEST_CASE("design viewport: rejects degenerate inputs",
 // between two bands, matching CLAP/VST3. Horizontal centering + scale unchanged;
 // must equal centered behavior when there is no vertical slack.
 TEST_CASE("design viewport: top_align anchors to top in a taller pane",
-          "[view][design-viewport][issue-pulp-design-viewport]") {
+          "[view][design-viewport]") {
     // 1320-wide design in a much taller 1320x1200 pane → fits to width (1.0x),
     // 340px of vertical slack.
     float sx, sy, tx, ty;
@@ -146,7 +145,7 @@ TEST_CASE("design viewport: top_align anchors to top in a taller pane",
 }
 
 TEST_CASE("design viewport: top_align is a no-op when no vertical slack",
-          "[view][design-viewport][issue-pulp-design-viewport]") {
+          "[view][design-viewport]") {
     // Matching aspect → ty is 0 with or without top_align (no behavior change
     // for CLAP/VST3/standalone, whose windows are aspect-constrained).
     float sx, sy, tx, ty, sx2, sy2, tx2, ty2;
@@ -170,7 +169,7 @@ TEST_CASE("design viewport: top_align is a no-op when no vertical slack",
 //     canvas transform) WITHOUT double-counting;
 //   - OS input arrives in physical pixels on Win/Linux, so a host divides by
 //     scale before the logical-space design-viewport inverse.
-// Tag with [hidpi] so the coverage harness can attribute these to the slice.
+// Tag with [hidpi] so the coverage harness can attribute these cases.
 
 namespace {
 
@@ -191,7 +190,7 @@ float dpi_to_scale(unsigned dpi) {
 } // namespace
 
 TEST_CASE("hidpi: dpi maps to scale (dpi/96, 0 floors to 1.0)",
-          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+          "[view][design-viewport][hidpi]") {
     REQUIRE_THAT(dpi_to_scale(96),  WithinAbs(1.0f, kEps));   // 1×
     REQUIRE_THAT(dpi_to_scale(144), WithinAbs(1.5f, kEps));   // 1.5×
     REQUIRE_THAT(dpi_to_scale(192), WithinAbs(2.0f, kEps));   // 2×
@@ -199,7 +198,7 @@ TEST_CASE("hidpi: dpi maps to scale (dpi/96, 0 floors to 1.0)",
 }
 
 TEST_CASE("hidpi: logical size times scale yields pixel surface size",
-          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+          "[view][design-viewport][hidpi]") {
     // A 400x300 editor at 2× must allocate an 800x600 pixel surface; the view
     // tree stays 400x300 logical.
     REQUIRE(pixel_dim(400, 2.0f) == 800u);
@@ -214,7 +213,7 @@ TEST_CASE("hidpi: logical size times scale yields pixel surface size",
 }
 
 TEST_CASE("hidpi: design-viewport transform is independent of DPI scale",
-          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+          "[view][design-viewport][hidpi]") {
     // The host computes the design-viewport transform from LOGICAL host size,
     // and the DPI scale is applied SEPARATELY by SkiaSurface. So at a fixed
     // logical host size the transform must NOT change with the DPI scale — the
@@ -239,7 +238,7 @@ TEST_CASE("hidpi: design-viewport transform is independent of DPI scale",
 }
 
 TEST_CASE("hidpi: pixel input divides by scale before the logical inverse",
-          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+          "[view][design-viewport][hidpi]") {
     // Win/Linux deliver pointer coords in PHYSICAL pixels. The host divides by
     // scale to get logical host coords, THEN applies the design-viewport
     // inverse. With a design viewport set, the centre of the physical surface

--- a/test/test_view_mask_overflow.cpp
+++ b/test/test_view_mask_overflow.cpp
@@ -1,13 +1,12 @@
 // View mask and overflow tests for two coherent paint/hit-test surfaces:
 //
-//   1. pulp #1148 slice (a) — symmetric overflow:visible hit-test
-//      extension. PR #1297 added a 500px-radius extension so that
-//      absolutely-positioned popovers / dropdowns / menus protrude
-//      past their parent and still receive pointer hits.
+//   1. Symmetric overflow:visible hit-test extension. A 500px-radius
+//      extension allows absolutely-positioned popovers / dropdowns / menus
+//      to protrude past their parent and still receive pointer hits.
 //      View::hit_test extends overflow:visible 500px to LEFT / RIGHT
 //      / UP / DOWN; does NOT extend past 500px LEFT.
 //
-//   2. pulp #1737 / #1515 — CSS mask-image + mask-size paint slice.
+//   2. CSS mask-image + mask-size paint coverage.
 //      View::paint_all routes through save_layer_with_mask when
 //      mask-image is set; does NOT route through when mask-image is
 //      empty or set to 'none'.
@@ -25,14 +24,11 @@
 using namespace pulp::view;
 using Catch::Matchers::WithinAbs;
 
-// ── pulp #1148 slice (a) — symmetric overflow:visible hit-test extension ──
+// ── Symmetric overflow:visible hit-test extension ───────────────────────
 //
-// PR #1297 added overflow:visible hit-test extension so that absolutely-
-// positioned popovers / dropdowns whose content escapes their bounds box
-// still receive clicks. The original implementation only extended the box
-// 500px DOWNWARD, which broke left-extending popovers (e.g. Spectr's bands
-// picker that opens to the left of its trigger). This suite locks the
-// extension to ±500px on all four sides.
+// Overflow:visible hit-test extension lets absolutely-positioned popovers /
+// dropdowns whose content escapes their bounds box still receive clicks. This
+// suite locks the extension to ±500px on all four sides.
 //
 // Each direction places a "popover" grandchild positioned outside its
 // overflow:visible parent in the tested direction — overflow:visible
@@ -65,7 +61,7 @@ struct PopoverFixture {
 } // namespace
 
 TEST_CASE("View::hit_test extends overflow:visible 500px to the LEFT",
-          "[view][hit_test][issue-1148][overflow-symmetric]") {
+          "[view][hit_test][overflow-symmetric]") {
     // Popover at container-local (-200, 25) → root-space (400..450, 625..675).
     // 100px to the LEFT of container.x=600 covers root.x = 425.
     PopoverFixture f(-200, 25);
@@ -73,7 +69,7 @@ TEST_CASE("View::hit_test extends overflow:visible 500px to the LEFT",
 }
 
 TEST_CASE("View::hit_test extends overflow:visible 500px to the RIGHT",
-          "[view][hit_test][issue-1148][overflow-symmetric]") {
+          "[view][hit_test][overflow-symmetric]") {
     // Popover at container-local (200, 25) → root-space (800..850, 625..675).
     // 100px to the RIGHT of container.right=700 covers root.x = 825.
     PopoverFixture f(200, 25);
@@ -81,7 +77,7 @@ TEST_CASE("View::hit_test extends overflow:visible 500px to the RIGHT",
 }
 
 TEST_CASE("View::hit_test extends overflow:visible 500px UPWARD",
-          "[view][hit_test][issue-1148][overflow-symmetric]") {
+          "[view][hit_test][overflow-symmetric]") {
     // Popover at container-local (25, -200) → root-space (625..675, 400..450).
     // 100px ABOVE container.y=600 covers root.y = 425.
     PopoverFixture f(25, -200);
@@ -89,16 +85,16 @@ TEST_CASE("View::hit_test extends overflow:visible 500px UPWARD",
 }
 
 TEST_CASE("View::hit_test extends overflow:visible 500px DOWNWARD",
-          "[view][hit_test][issue-1148][overflow-symmetric]") {
+          "[view][hit_test][overflow-symmetric]") {
     // Popover at container-local (25, 200) → root-space (625..675, 800..850).
     // 100px BELOW container.bottom=700 covers root.y = 825.
-    // This direction was already supported pre-#1148 — guards regression.
+    // This direction was already supported before the symmetric extension.
     PopoverFixture f(25, 200);
     REQUIRE(f.root.hit_test({650, 825}) == f.popover);
 }
 
 TEST_CASE("View::hit_test does NOT extend overflow:visible past 500px LEFT",
-          "[view][hit_test][issue-1148][overflow-symmetric]") {
+          "[view][hit_test][overflow-symmetric]") {
     // Popover anchored 600px LEFT of container — outside the symmetric
     // ±500px slack, so the click must miss the popover entirely. With
     // container x=600, popover at container-local x=-650 lands at
@@ -108,13 +104,13 @@ TEST_CASE("View::hit_test does NOT extend overflow:visible past 500px LEFT",
     REQUIRE(f.root.hit_test({0, 650}) != f.popover);
 }
 
-// ── pulp #1737 / #1515 — CSS mask-image + mask-size paint slice ─────────
+// ── CSS mask-image + mask-size paint coverage ───────────────────────────
 //
-// Phase 1 ships linear-gradient mask shapes through the new
-// Canvas::save_layer_with_mask virtual + SkiaCanvas's 2-saveLayer +
-// kDstIn composite at restore() time. RecordingCanvas spy captures
-// the API dispatch so we can pin the wiring without depending on Skia
-// (which is the only backend that actually composites the mask alpha).
+// Linear-gradient mask shapes route through the Canvas::save_layer_with_mask
+// virtual + SkiaCanvas's 2-saveLayer + kDstIn composite at restore() time.
+// RecordingCanvas spy captures the API dispatch so we can pin the wiring
+// without depending on Skia (which is the only backend that actually composites
+// the mask alpha).
 // Visual output is verified separately against the SkiaCanvas raster
 // path in the [skia] tests below.
 
@@ -139,7 +135,7 @@ struct MaskSpyCanvas : pulp::canvas::RecordingCanvas {
 }
 
 TEST_CASE("View::paint_all routes through save_layer_with_mask when mask-image is set",
-          "[view][issue-1515][issue-1737]") {
+          "[view][mask-image]") {
     pulp::view::View v;
     v.set_bounds({0, 0, 100, 50});
     v.set_mask_image("linear-gradient(to bottom, black, transparent)");
@@ -159,7 +155,7 @@ TEST_CASE("View::paint_all routes through save_layer_with_mask when mask-image i
 }
 
 TEST_CASE("View::paint_all does NOT route through save_layer_with_mask when mask-image is empty",
-          "[view][issue-1515][issue-1737]") {
+          "[view][mask-image]") {
     pulp::view::View v;
     v.set_bounds({0, 0, 100, 50});
     // No mask_image set — paint_all should use the legacy path
@@ -172,7 +168,7 @@ TEST_CASE("View::paint_all does NOT route through save_layer_with_mask when mask
 }
 
 TEST_CASE("View::paint_all does NOT route through save_layer_with_mask when mask-image is 'none'",
-          "[view][issue-1515][issue-1737]") {
+          "[view][mask-image]") {
     pulp::view::View v;
     v.set_bounds({0, 0, 100, 50});
     v.set_mask_image("none");

--- a/test/test_view_zindex_overflow.cpp
+++ b/test/test_view_zindex_overflow.cpp
@@ -1,6 +1,6 @@
 // View z-index and overflow tests for two coherent paint-order surfaces:
 //
-//   1. pulp #972 — z-index paint order
+//   1. z-index paint order
 //      `sorted_children_by_z_index` returns insertion order at default
 //      z=0, sorts ascending so higher-z comes last, and is stable for
 //      equal z. `View::paint_all` and `View::hit_test` honour the
@@ -8,9 +8,8 @@
 //      pointer-hit at overlapping bounds, with insertion-order
 //      fallback at equal z.
 //
-//   2. pulp #972 — overflow:visible default for absolute-positioned
-//      popovers + pulp #1148 slice (a) — symmetric overflow:visible
-//      hit-test extension.
+//   2. overflow:visible default for absolute-positioned popovers plus
+//      symmetric overflow:visible hit-test extension.
 //      Default overflow is visible (matches CSS); `View::paint_all`
 //      only emits `clip_rect` when overflow is explicitly hidden;
 //      absolute children positioned outside parent bounds still paint;
@@ -30,10 +29,10 @@
 using namespace pulp::view;
 using Catch::Matchers::WithinAbs;
 
-// ── pulp #972 — z-index paint-order ──────────────────────────────────────────
+// ── Z-index paint order ─────────────────────────────────────────────────
 
 TEST_CASE("sorted_children_by_z_index returns insertion order at default z=0",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     View parent;
     auto a = std::make_unique<View>(); auto* a_ptr = a.get();
     auto b = std::make_unique<View>(); auto* b_ptr = b.get();
@@ -50,7 +49,7 @@ TEST_CASE("sorted_children_by_z_index returns insertion order at default z=0",
 }
 
 TEST_CASE("sorted_children_by_z_index sorts ascending — higher z comes last",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     // Spectr's bandsMenu repro: insertion order is content, content, popover,
     // but popover has zIndex=20. Sorted order must paint popover last.
     View parent;
@@ -71,7 +70,7 @@ TEST_CASE("sorted_children_by_z_index sorts ascending — higher z comes last",
 }
 
 TEST_CASE("sorted_children_by_z_index is stable for equal z (insertion order)",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     View parent;
     auto a = std::make_unique<View>(); auto* a_ptr = a.get();
     auto b = std::make_unique<View>(); auto* b_ptr = b.get();
@@ -90,13 +89,13 @@ TEST_CASE("sorted_children_by_z_index is stable for equal z (insertion order)",
 }
 
 TEST_CASE("View::paint_all paints higher-z child last so it lands on top",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     using namespace pulp::canvas;
 
     // Three siblings stacked at the same bounds with distinct backgrounds.
     // Popover sits in the MIDDLE of insertion order with z_index=10. The
     // last full-bounds fill in the recorded stream must be popover's
-    // colour — without #972 it would be content_b's (last by insertion).
+    // colour; otherwise it would be content_b's (last by insertion).
     View parent;
     parent.set_bounds({0, 0, 100, 100});
 
@@ -245,7 +244,7 @@ TEST_CASE("paint_all fast path preserves insertion order for default-z children"
 }
 
 TEST_CASE("View::hit_test returns the highest-z child for overlapping bounds",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     // Three siblings at the same bounds: content (z=0, inserted last),
     // popover (z=10, inserted middle), content (z=0, inserted first).
     // Click in the middle should hit the popover, not whichever content
@@ -277,7 +276,7 @@ TEST_CASE("View::hit_test returns the highest-z child for overlapping bounds",
 }
 
 TEST_CASE("View::hit_test falls back to insertion-order topmost at equal z",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     // All siblings at same z=0 (default) — last inserted is visually topmost,
     // matching legacy behaviour. This locks in the no-regression contract.
     View parent;
@@ -329,7 +328,7 @@ TEST_CASE("hit_test z-order fast path matches the sorted path on both branches",
     }
 }
 
-// ── pulp #972 — overflow:visible default for absolute-positioned popovers ────
+// ── Overflow:visible default for absolute-positioned popovers ───────────
 // Symptom on Spectr's bandsMenu: a `position:absolute; top:28; right:0`
 // popover declared inside a 24px-tall flex parent renders nowhere because
 // Pulp previously defaulted overflow to hidden and clipped paint to the
@@ -339,13 +338,13 @@ TEST_CASE("hit_test z-order fast path matches the sorted path on both branches",
 // popover's fill regardless of paint order.
 
 TEST_CASE("View default overflow is visible (matches CSS default)",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     View v;
     REQUIRE(v.overflow() == View::Overflow::visible);
 }
 
 TEST_CASE("View::paint_all does not emit clip_rect when overflow is visible",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     using namespace pulp::canvas;
     View v;
     v.set_bounds({0, 0, 100, 24});
@@ -370,7 +369,7 @@ TEST_CASE("View::paint_all does not emit clip_rect when overflow is visible",
 }
 
 TEST_CASE("View::paint_all emits clip_rect when overflow is explicitly hidden",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     using namespace pulp::canvas;
     View v;
     v.set_bounds({0, 0, 100, 24});
@@ -392,7 +391,7 @@ TEST_CASE("View::paint_all emits clip_rect when overflow is explicitly hidden",
 }
 
 TEST_CASE("Absolute child positioned outside parent's bounds still paints",
-          "[view][issue-972]") {
+          "[view][z-index]") {
     // Spectr bandsMenu repro: 24px-tall parent with a popover-like child
     // at top:50, left:50 — completely outside the parent's content rect.
     // With overflow:visible default, the child's translate-from-bounds.x/y
@@ -437,14 +436,13 @@ TEST_CASE("Absolute child positioned outside parent's bounds still paints",
     REQUIRE_FALSE(saw_parent_clip);
 }
 
-// pulp #1409 paint-time probe series — empirical answer to the Spectr
-// [I] "preset items render outside overlay" report. The framework
-// already pushes a parent clip_rect before children paint when the
-// parent has overflow:hidden, so the symptom is consumer-side, not
-// framework-side. These tests stand as a regression guard — if any of
-// them flips to a fail, paint-time clipping has regressed.
+// Paint-time probe series for the Spectr "preset items render outside overlay"
+// report. The framework already pushes a parent clip_rect before children paint
+// when the parent has overflow:hidden, so the symptom is consumer-side, not
+// framework-side. These tests stand as a regression guard: if any of them flips
+// to a fail, paint-time clipping has regressed.
 TEST_CASE("Probe: overflow:hidden parent clip-rect precedes child paint",
-          "[view][probe][issue-overlay-clip]") {
+          "[view][probe][overlay-clip]") {
     using namespace pulp::canvas;
 
     View parent;
@@ -485,14 +483,13 @@ TEST_CASE("Probe: overflow:hidden parent clip-rect precedes child paint",
     REQUIRE(parent_clip_idx < child_fill_idx);
 }
 
-// pulp #1409 paint-time probe — absolutely-positioned child translated
-// past the parent's right edge. Mirrors a Spectr preset-menu item
-// scenario where a row's `position: absolute; left: 80px` puts it past
-// a 100×40 dropdown's content rect. The clip must STILL precede the
-// child's paint command in the recording — translates do not reset the
-// active clip.
+// Paint-time probe: an absolutely-positioned child translated past the parent's
+// right edge. Mirrors a Spectr preset-menu item scenario where a row's
+// `position: absolute; left: 80px` puts it past a 100×40 dropdown's content
+// rect. The clip must STILL precede the child's paint command in the recording;
+// translates do not reset the active clip.
 TEST_CASE("Probe: overflow:hidden parent clips translated absolute child too",
-          "[view][probe][issue-overlay-clip]") {
+          "[view][probe][overlay-clip]") {
     using namespace pulp::canvas;
 
     View parent;

--- a/tools/import-validation/source-contracts.json
+++ b/tools/import-validation/source-contracts.json
@@ -260,7 +260,7 @@
           "test/test_design_import_designmd.cpp"
         ],
         "test_tags": [
-          "[view][import][designmd][issue-1434]"
+          "[view][import][designmd]"
         ],
         "pulp_render_reference": {
           "status": "not-applicable",

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -52,8 +52,8 @@
     },
     {
       "path": "test/test_design_import_sources.cpp",
-      "max_loc": 1203,
-      "note": "design-import source parser test split"
+      "max_loc": 1199,
+      "note": "design-import source parser test split; lowered after comment-hygiene cleanup"
     },
     {
       "path": "test/test_renderer3d_shared.hpp",


### PR DESCRIPTION
## Summary
- Clean transient source-comment hygiene breadcrumbs across CLI/runtime/view/import test coverage without changing behavior.
- Keep source-contract metadata aligned with the DESIGN.md tag cleanup and add import-design skill guidance for future tag edits.
- Lower the hotspot ceiling for `test/test_design_import_sources.cpp` after the cleanup shrank that tracked hotspot.

## Validation
- Focused Release builds and test binaries passed for the touched CLI, design-import, font/rendering, inspector, scroll, state, and view tests.
- `python3 tools/import-validation/check-source-contracts.py --format text`
- `git diff --check`
- `python3 tools/scripts/hotspot_size_guard.py --require-ceiling-reduction`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- Pre-push local diff-coverage gate: full coverage build, `10683/10683` CTest cases passed, diff coverage OK.

## Review
- RepoPrompt workspace/selection was prepared for this batch, but `rp-cli review` could not run because the account hit the weekly provider quota.
- Claude bridge review was attempted and also hit the same weekly quota.
- Local autoreview was run until clean; earlier findings about source-contract tag drift were fixed before opening this PR.

## Queue policy
This is one consolidated comment-hygiene batch, not per-file micro PRs. Follow-up areas are tracked in `planning/2026-06-27-comment-hygiene-status.md` on the planning repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and standardized test comments, names, and Catch2 tags across CLI, runtime, view, import, and rendering suites; no behavior changes. Synced DESIGN.md import tagging across tests and `tools/import-validation/source-contracts.json`, and ratcheted the hotspot guard after shrink.

- **Refactors**
  - Replaced issue/PR breadcrumbs with scoped tags (e.g. [view][import][designmd], [stale-ref][dangling][preflight], [toml][comments], [pending-upgrade], [plugin-manifest][version-parse], [pointer-events], [design-viewport][hidpi], [z-index], [mask-image], [cjk]/[monospace], [gpu]/[d3d]/[vulkan]/[scaffold], [skin][fader]/[meter], [pulp-library][audio-widget][knob|fader|meter|xy-pad|waveform|spectrum]).
  - Clarified comments and test titles in CLI (create/update/fetchcontent/version), DESIGN.md import and source parser (including Pulp Library widgets and kitchen-sink), font rendering goldens (raster/GPU/D3D/Vulkan), inspector telemetry, ScrollView pointerEvents and overflow, view z-index and mask-image, design viewport math and HiDPI, state event loop, and core-link.
  - Updated `tools/import-validation/source-contracts.json` to `[view][import][designmd]` and added tag-sync guidance in `.agents/skills/import-design/SKILL.md` to keep `validation.test_tags` aligned and prefer broad stable tags.
  - Lowered `test/test_design_import_sources.cpp` ceiling in `tools/scripts/hotspot_size_guard.json` to 1199 LOC.

<sup>Written for commit ba25897caebe50804063a11e3d767db4285d7271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

