### PR TITLE
docs(ship): clarify explicit sign path

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -674,6 +674,11 @@ through for free. Conventions that kept this testable without Apple creds:
   and parser-error shellout coverage. The `share` path accepts `--output` and
   `--entitlements` in addition to credentials/dry-run; if either changes,
   update all surfaces together.
+- For `pulp ship sign --path`, describe the argument as an explicit desktop
+  artifact rather than an Apple-only `.app`/`.dmg`/bundle set. The same CLI
+  primitive dispatches to macOS `codesign` or Windows `signtool`; `.pkg`
+  installers are intentionally rejected because `package` signs them at
+  creation time.
 - A subcommand of `ship` does NOT need its own top-level slash command or a
   `commands` top-level entry — it lives under the `ship` entry's `subcommands`
   in `cli-commands.yaml` and the `/ship` slash command. `cli_sync_check.py`

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -42,7 +42,7 @@ Advisory only — never blocks. Full contract + override knobs live in the
 
 | Command | Platform | What It Does |
 |---------|----------|-------------|
-| `sign` | macOS, Windows, Android | Sign plugin bundles or APK/AAB; `--path <file>` signs one explicit `.app`/`.dmg`/bundle |
+| `sign` | macOS, Windows, Android | Sign plugin bundles or APK/AAB; `--path <file>` signs one explicit desktop artifact (macOS `.app`/`.dmg`/bundle, Windows `.exe`/bundle; not `.pkg`) |
 | `notarize` | macOS only | Submit to Apple notarization, poll, staple; `--path <file>` notarizes one explicit `.dmg`/`.pkg`/`.zip` (repeatable), not a raw `.app` |
 | `package` | All | Create .pkg/.dmg (macOS), NSIS (Windows), APK+AAB (Android) |
 | `release` | macOS only | One command: sign → package → **notarize + staple the .pkg/.dmg it builds** → verify |
@@ -167,7 +167,7 @@ it. Two defenses now exist:
   bypass it.)
 
 The composable primitives underneath:
-- `pulp ship sign --path <app|dmg|bundle>` — sign exactly one artifact.
+- `pulp ship sign --path <artifact>` — sign exactly one desktop artifact (`.pkg` installers are signed by `package`).
 - `pulp ship notarize --path <dmg|pkg|zip>` — notarize + staple one artifact (repeatable). Use `share` for a raw `.app`.
 
 **Do not confuse with the production release.** `share`/`release`/`sign`/

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.260.3",
+      "version": "0.261.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.260.3"
+  "version": "0.261.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.260.3",
+  "version": "0.261.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -62,7 +62,7 @@ bundles), so the artifact in `artifacts/` is Gatekeeper-ready.
 
 Note: `--key-pass` defaults to `--store-pass` if omitted. `sign --target android` operates on existing APK/AAB files in `artifacts/` — use `package --target android` to build from Gradle.
 
-- `pulp ship sign --path MyApp.app` — sign one explicit `.app`/`.dmg`/bundle (not the whole build dir)
+- `pulp ship sign --path MyApp.app` — sign one explicit desktop artifact (macOS `.app`/`.dmg`/bundle, Windows `.exe`/bundle; not `.pkg`)
 
 **Notarization (macOS only):**
 - `pulp ship notarize --path MyPlugin-1.0.pkg` — picks credentials up from config/env/notary.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.509.3
+    VERSION 0.509.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -901,8 +901,10 @@ pulp ship auv3-xcodeproj MyPlugin --sdk iphonesimulator --dry-run
 `doctor` materializes a dedicated signing keychain authorized for `codesign` (so the login keychain / 1Password is never consulted) and validates a file-based App Store Connect `.p8` notary key. `--check-online` also proves the `.p8` against Apple (read-only) and refreshes the optional `pulp-notary` keychain profile; `--print-env` emits resolved identity/keychain handles (no secret values). Secrets live in `~/.config/pulp/secrets/` (`keychain.env` + `notary.env`), never in the repo; same-named env vars override the files. No build directory is required.
 
 `sign` requires `--identity`. The default entitlements file is `ship/templates/entitlements.plist`.
-`--path` signs exactly one `.app`, `.dmg`, or plugin bundle instead of scanning the build dirs;
-`.pkg` installers are signed at creation time with a Developer ID **Installer** identity, not here.
+`--path` signs exactly one explicit desktop artifact instead of scanning the build dirs:
+macOS `.app`/`.dmg`/plugin bundles, or Windows `.exe`/plugin bundles. `.pkg`
+installers are signed at creation time with a Developer ID **Installer**
+identity, not here.
 
 `package` creates per-format `.pkg` files using `pkgbuild` on macOS, or `.dmg` files with `--dmg`. On Windows, it packages VST3/CLAP bundles as an NSIS `.exe` installer; `--per-user` switches plugin destinations to `%LOCALAPPDATA%\Programs\Common\...`, and plugin-only installers do not create Start Menu shortcuts. On Linux, it packages VST3/CLAP/LV2 bundles as a `.deb` using `dpkg-deb`, with a `.tar.gz` fallback when `dpkg-deb` is unavailable. If no Linux plugin bundles are present, it reports `no VST3/CLAP/LV2 plugins found` instead of creating an empty macOS-style artifact summary. For Android, `--target android` runs the Gradle package flow and copies APK/AAB outputs into `artifacts/`.
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -90,7 +90,7 @@ commands:
             required: false
           - name: --path
             required: false
-            description: Sign one explicit artifact (.app/.dmg/bundle) instead of scanning build dirs
+            description: Sign one explicit desktop artifact (macOS .app/.dmg/bundle, Windows .exe/bundle; .pkg is signed at package time) instead of scanning build dirs
           - name: --entitlements
             required: false
           - name: --target

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -318,6 +318,8 @@ TEST_CASE_METHOD(ShipShelloutFixture,
         INFO("ship help missing subcommand: " << sub);
         REQUIRE(contains(r.stdout_output, sub));
     }
+    REQUIRE(contains(r.stdout_output, "--path <artifact>"));
+    REQUIRE(contains(r.stdout_output, ".pkg is signed by package"));
 }
 
 TEST_CASE_METHOD(ShipShelloutFixture,

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -58,7 +58,8 @@ static int print_ship_help() {
     std::cout << "Subcommands:\n";
     std::cout << "  sign       Sign plugin bundles or Android artifacts\n";
     std::cout << "             --identity \"Developer ID Application: ...\"  (macOS/Windows)\n";
-    std::cout << "             --path <app|dmg|bundle>  (sign one explicit artifact)\n";
+    std::cout << "             --path <artifact>  "
+                 "(sign one explicit desktop artifact; .pkg is signed by package)\n";
     std::cout << "             --target android --keystore key.jks  (Android)\n";
     std::cout << "  notarize   Submit signed bundles for Apple notarization (macOS)\n";
     std::cout << "             --api-key <p8> --api-key-id <id> --api-issuer <uuid>   (preferred)\n";
@@ -147,7 +148,7 @@ int cmd_ship(const std::vector<std::string>& args) {
     if (sub == "sign") {
         run_signing_preflight(root);  // self-heal the dedicated keychain (no prompt)
         std::string identity, target, keystore_path, key_alias, store_pass, key_pass;
-        std::string sign_path;  // --path: sign one explicit artifact (.app/.dmg/bundle)
+        std::string sign_path;  // --path: sign one explicit desktop artifact (not .pkg)
         std::string entitlements = (root / "ship" / "templates" / "entitlements.plist").string();
         for (size_t i = 1; i < args.size(); ++i) {
             if (args[i] == "--identity") {
@@ -245,7 +246,7 @@ int cmd_ship(const std::vector<std::string>& args) {
         // --path: sign exactly one artifact instead of auto-scanning the
         // build dirs. This is the composable primitive behind the one-off
         // "I built an app/DMG and want to hand it to a friend" flow — point
-        // it at a standalone `.app`, a `.dmg`, or a single plugin bundle.
+        // it at a standalone `.app`, `.dmg`, `.exe`, or a single plugin bundle.
         // `.pkg` installers are signed at creation time (`productsign` via
         // `create_pkg`'s signing_identity), not here, so reject them with a
         // pointer rather than producing a broken signature.


### PR DESCRIPTION
## Summary
- Align ship sign --path help, reference docs, command status, /ship wording, and skills with the implemented explicit desktop artifact signing primitive.
- Document that --path covers macOS .app/.dmg/plugin bundles and Windows .exe/plugin bundles, while .pkg installers are signed at package time.
- Add focused CLI shellout help assertions for the revised wording.

## Validation
- git diff --check
- python3 tools/scripts/docs_noise_lint.py docs/reference/cli.md docs/status/cli-commands.yaml .agents/skills/ship/SKILL.md .agents/skills/cli-maintenance/SKILL.md .claude/commands/ship.md
- python3 tools/docs_generate.py check
- python3 tools/scripts/cli_sync_check.py
- python3 tools/scripts/check_cli_mcp_parity.py --mode=report
- tools/check-docs.sh
- tools/scripts/gates.sh origin/main
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --target pulp-test-cli-ship-shellout -j$(sysctl -n hw.ncpu)
- cmake --build build --target pulp-cli -j$(sysctl -n hw.ncpu)
- PULP_UPDATE_CHECK_DISABLED=1 ./pulp-test-cli-ship-shellout "[cli][shellout][ship][help]"
- PULP_UPDATE_CHECK_DISABLED=1 ./pulp-test-cli-ship-shellout "[cli][shellout][ship]"
- Pre-push full local gates reached: [pre-push] gates clean.

## Notes
- shipyard pr passed skill-sync and applied the version bump, but stalled after handoff with no active Shipyard queue, no remote branch, and no PR. The branch was therefore pushed manually after the pre-push gates had already completed cleanly; the final publish used PULP_SKIP_PREPUSH=1 only to avoid rerunning the same completed suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified `pulp ship sign --path` to target one explicit desktop artifact and documented that `.pkg` installers are signed at package time. Help text, docs, and tests are now consistent across macOS and Windows.

- **Refactors**
  - Unified wording across CLI help, reference docs, status YAML, and skills to include macOS `.app`/`.dmg`/plugin bundles and Windows `.exe`/plugin bundles; exclude `.pkg`.
  - Updated CLI help output and added shellout tests asserting `--path <artifact>` and “.pkg is signed by package”.

- **Dependencies**
  - Bumped plugin version to 0.261.0 and project version to 0.509.4.

<sup>Written for commit ae362a7cc09987c7e1ffdef58044aee211165f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

