### PR TITLE
docs(test): clean phase tag breadcrumbs

### DIFF
--- a/core/host/include/pulp/host/anticipation_eligibility.hpp
+++ b/core/host/include/pulp/host/anticipation_eligibility.hpp
@@ -11,8 +11,8 @@ namespace pulp::host {
 struct GraphNode;
 struct Connection;
 
-// Why a node may NOT be rendered ahead of the audio deadline (anticipative
-// rendering, masterwork Phase 6). Anticipation pre-computes a latent subgraph's
+// Why a node may NOT be rendered ahead of the audio deadline. Anticipation
+// pre-computes a latent subgraph's
 // output into a buffer during earlier blocks' slack so a CPU spike is absorbed
 // off the critical block — but only for work whose result for a FUTURE block can
 // be computed from inputs already available, with no dependence on live or

--- a/core/host/include/pulp/host/anticipation_lane.hpp
+++ b/core/host/include/pulp/host/anticipation_lane.hpp
@@ -18,7 +18,7 @@ class PluginSlot;
 
 // Renders an anticipation sub-graph AHEAD of the audio deadline into a ring, so
 // the live graph reads the pre-computed boundary signals instead of paying the
-// sub-graph's cost on the critical block (masterwork Phase 6). Single-producer /
+// sub-graph's cost on the critical block. Single-producer /
 // single-consumer:
 //   - render_ahead() runs OFF the audio thread (a background/idle worker). It
 //     advances the interior's plugin state and pushes whole blocks into the ring.

--- a/test/integration/test_real_plugin_fixture.cpp
+++ b/test/integration/test_real_plugin_fixture.cpp
@@ -160,13 +160,13 @@ TEST_CASE("resolver: TBD entry without override never silently passes",
     REQUIRE(r.skip_reason.find("PULP_REAL_PLUGIN_CACHE") != std::string::npos);
 }
 
-// Regression (#3015): The developer-supplied lane previously
-// accepted ANY existing path, including zero-byte placeholders left over
-// from a `touch $PULP_REAL_PLUGIN_CACHE/vital/Vital.vst3` mistake.
-// `PluginSlot::load` would then hard-fail on the bogus bundle instead of
-// the resolver returning a clean SKIP with actionable guidance.
+// Regression coverage: the developer-supplied lane previously accepted ANY
+// existing path, including zero-byte placeholders left over from a
+// `touch $PULP_REAL_PLUGIN_CACHE/vital/Vital.vst3` mistake. `PluginSlot::load`
+// would then hard-fail on the bogus bundle instead of the resolver returning a
+// clean SKIP with actionable guidance.
 TEST_CASE("resolver: developer-supplied lane skips an empty-file bundle "
-          "(regression: PR #3015 review)",
+          "(regression coverage)",
           "[host][integration][real-plugins][resolver][issue-3015]") {
     TempCache cache("tbd-empty-bundle-file");
     const auto e = make_entry("vital-like", "Vital.vst3", "TBD");
@@ -178,7 +178,7 @@ TEST_CASE("resolver: developer-supplied lane skips an empty-file bundle "
 }
 
 TEST_CASE("resolver: developer-supplied lane skips an empty-directory bundle "
-          "(regression: PR #3015 review)",
+          "(regression coverage)",
           "[host][integration][real-plugins][resolver][issue-3015]") {
     TempCache cache("tbd-empty-bundle-dir");
     const auto e = make_entry("vital-like", "Vital.vst3", "TBD");

--- a/test/mac_window_harness.mm
+++ b/test/mac_window_harness.mm
@@ -89,12 +89,11 @@ NSEvent* build_event(NSWindow* window,
     }
 
     if (type == NSEventTypeScrollWheel) {
-        // Regression (PR #2009): `+[NSEvent mouseEventWithType:]` does
-        // NOT carry scrolling deltas — the produced event reports
-        // `scrollingDeltaX/Y == 0`, so the synthetic scroll falls
-        // through `PulpView::scrollWheel:` as a no-op and tests pass
-        // while exercising nothing. Build the event via a CGEvent
-        // source so `event.scrollingDeltaX/Y` reflect the requested
+        // Regression coverage: `+[NSEvent mouseEventWithType:]` does NOT carry
+        // scrolling deltas — the produced event reports `scrollingDeltaX/Y == 0`,
+        // so the synthetic scroll falls through `PulpView::scrollWheel:` as a
+        // no-op and tests pass while exercising nothing. Build the event via a
+        // CGEvent source so `event.scrollingDeltaX/Y` reflect the requested
         // deltas. Axis order: CGEventCreateScrollWheelEvent2's
         // variadic wheel args are (wheel1, wheel2) ≡ (Y, X).
         CGEventRef cge = CGEventCreateScrollWheelEvent2(
@@ -105,12 +104,12 @@ NSEvent* build_event(NSWindow* window,
             static_cast<int32_t>(ev.scroll_delta_x),
             0);
         if (!cge) return nil;
-        // Regression (PR #2015) — set the CGEvent location so
-        // `event.locationInWindow` lands at the harness-requested
-        // coordinates instead of the current OS cursor position.
-        // PulpView::scrollWheel: hit-tests from locationInWindow, so
-        // without this, scroll tests targeted at a specific subview
-        // are dropped or routed wherever the cursor happened to be.
+        // Regression coverage: set the CGEvent location so
+        // `event.locationInWindow` lands at the harness-requested coordinates
+        // instead of the current OS cursor position. PulpView::scrollWheel:
+        // hit-tests from locationInWindow, so without this, scroll tests
+        // targeted at a specific subview are dropped or routed wherever the
+        // cursor happened to be.
         // CGEvent uses screen-space; convert via the window's screen frame.
         NSPoint screen_pt = cg_screen_point_for_window_location(window, location);
         CGEventSetLocation(cge, CGPointMake(screen_pt.x, screen_pt.y));
@@ -220,14 +219,14 @@ bool simulate_mouse(pulp::view::WindowHost& host, const SimulatedMouse& event) {
         NSEvent* nsevent = build_event(window, content, event);
         if (!nsevent) return false;
 
-        // Regression (PR #2009): `build_event` correctly stamped
+        // Regression coverage: `build_event` correctly stamped
         // NSEventType{Right,Other}Mouse* based on `event.button`, but the
         // dispatch below previously routed every phase through
-        // `mouseDown:`/`mouseUp:`/`mouseDragged:`. That meant a right-
-        // click test exercised `mouseDown:` (single-click path) instead
-        // of `rightMouseDown:` (context-menu path), and middle-clicks
-        // never reached `otherMouseDown:`. Route by button so synthetic
-        // right/middle clicks hit the matching selectors on PulpView.
+        // `mouseDown:`/`mouseUp:`/`mouseDragged:`. That meant a right-click test
+        // exercised `mouseDown:` (single-click path) instead of
+        // `rightMouseDown:` (context-menu path), and middle-clicks never reached
+        // `otherMouseDown:`. Route by button so synthetic right/middle clicks hit
+        // the matching selectors on PulpView.
         switch (event.phase) {
             case SimulatedMouse::Phase::down:
                 if (event.button == pulp::view::MouseButton::right)

--- a/test/test_abstract_fifo.cpp
+++ b/test/test_abstract_fifo.cpp
@@ -138,14 +138,14 @@ TEST_CASE("AbstractFifo finish_* with non-positive args is a no-op",
     REQUIRE(fifo.free_space() == 3);
 }
 
-// Regression: PR #2985. The previous `next -= capacity_` only handled one
-// overflow span. A finish_write/finish_read advance
-// larger than one buffer span (which is a caller bug, but the header
-// promised "clamped to keep the fifo coherent") would leave the cursor
-// out of range, and the next prepare_to_* call would return invalid
-// indices into the caller-owned buffer. True modulo wrap fixes that.
+// Regression coverage: the previous `next -= capacity_` only handled one
+// overflow span. A finish_write/finish_read advance larger than one buffer span
+// (which is a caller bug, but the header promised "clamped to keep the fifo
+// coherent") would leave the cursor out of range, and the next prepare_to_* call
+// would return invalid indices into the caller-owned buffer. True modulo wrap
+// fixes that.
 TEST_CASE("AbstractFifo finish_write clamps overshoot to a valid cursor "
-          "(regression: PR #2985 review)",
+          "(regression coverage)",
           "[runtime][abstract_fifo][issue-2985]") {
     AbstractFifo fifo(8);
     // Even with a far-too-large finish, the resulting prepare must
@@ -160,7 +160,7 @@ TEST_CASE("AbstractFifo finish_write clamps overshoot to a valid cursor "
 }
 
 TEST_CASE("AbstractFifo finish_read clamps overshoot to a valid cursor "
-          "(regression: PR #2985 review)",
+          "(regression coverage)",
           "[runtime][abstract_fifo][issue-2985]") {
     AbstractFifo fifo(8);
     fifo.finish_read(/*num_read=*/100);  // 100 % 8 = 4

--- a/test/test_ble_midi.cpp
+++ b/test/test_ble_midi.cpp
@@ -87,14 +87,13 @@ TEST_CASE("BleMidiPacketDecoder rejects undersized packets", "[ble-midi]") {
     REQUIRE_FALSE(dec.decode(bogus, sizeof(bogus)));
 }
 
-// Regression: PR #3017. Running status is scoped to a single
-// BLE-MIDI packet per Apple BLE-MIDI 1.0 §3.4. Carrying it across
-// packets would fabricate events from leading data bytes in the next
-// packet. The first packet establishes 0x90 running status; the second
-// arrives with NO status byte (just timestamp + data) and must NOT emit
-// a Note On using the prior packet's 0x90.
+// Running status is scoped to a single BLE-MIDI packet per Apple BLE-MIDI
+// 1.0 §3.4. Carrying it across packets would fabricate events from leading
+// data bytes in the next packet. The first packet establishes 0x90 running
+// status; the second arrives with NO status byte (just timestamp + data) and
+// must NOT emit a Note On using the prior packet's 0x90.
 TEST_CASE("BleMidiPacketDecoder clears running status at packet boundaries "
-          "(regression: PR #3017 review)",
+          "(regression coverage)",
           "[ble-midi][issue-3017]") {
     BleMidiPacketDecoder dec;
     std::vector<DecodedMsg> received;

--- a/test/test_canvas_color.cpp
+++ b/test/test_canvas_color.cpp
@@ -26,7 +26,7 @@ void require_color_near(const Color& color,
 }  // namespace
 
 TEST_CASE("Color HSV covers primary and secondary hue sectors",
-          "[canvas][color][coverage][phase3]") {
+          "[canvas][color][coverage]") {
     struct Case {
         const char* name;
         float hue;
@@ -59,7 +59,7 @@ TEST_CASE("Color HSV covers primary and secondary hue sectors",
 }
 
 TEST_CASE("Color OKLCH covers sRGB transfer thresholds and wrapped hue",
-          "[canvas][color][coverage][phase3]") {
+          "[canvas][color][coverage]") {
     auto near_black = Color::rgba(0.003f, 0.003f, 0.003f).to_oklch();
     require_near(near_black.L, 0.06146f, 0.0002f);
     require_near(near_black.C, 0.0f, 0.0001f);
@@ -76,7 +76,7 @@ TEST_CASE("Color OKLCH covers sRGB transfer thresholds and wrapped hue",
 }
 
 TEST_CASE("Color binary encoding preserves unclamped float channels",
-          "[canvas][color][coverage][phase3]") {
+          "[canvas][color][coverage]") {
     auto original = Color::rgba(1.25f, -0.125f, 0.5f, 0.75f);
 
     uint8_t bytes[16]{};

--- a/test/test_cfrunloop_cooperation.cpp
+++ b/test/test_cfrunloop_cooperation.cpp
@@ -1,13 +1,13 @@
-// CFRunLoop cooperation in plugin-mode (item 6.4b macOS plan, post-PR-#2825).
+// CFRunLoop cooperation in plugin mode.
 //
-// PR #2825 added pulp::events::MainThreadDispatcher and registered Cocoa /
-// UIKit / SDL backends from standalone WindowHost constructors. In plugin
-// mode (AU v3 / VST3 / CLAP loaded inside a DAW), there is no Pulp window
-// and historically no backend was installed, so any code that asked
-// "please run this on the host's main thread" silently no-oped.
+// pulp::events::MainThreadDispatcher registers Cocoa / UIKit / SDL backends
+// from standalone WindowHost constructors. In plugin mode (AU v3 / VST3 /
+// CLAP loaded inside a DAW), there is no Pulp window and historically no
+// backend was installed, so any code that asked "please run this on the
+// host's main thread" silently no-oped.
 //
-// Item 6.4b ships `pulp::events::register_plugin_backend()` and wires it
-// into each adapter's init/dealloc path. These tests pin the contract:
+// `pulp::events::register_plugin_backend()` wires that dispatcher into each
+// adapter's init/dealloc path. These tests pin the contract:
 //
 //   1. The bare contract — register installs a backend, unregister tears it
 //      down, and reference-counting works across multiple "plugin instances".
@@ -35,7 +35,7 @@
 using namespace pulp::events;
 
 TEST_CASE("plugin_backend_available reports the expected platform value",
-          "[events][main_thread_dispatcher][item-6-4b]") {
+          "[events][main_thread_dispatcher][plugin-backend]") {
 #if defined(__APPLE__)
     REQUIRE(plugin_backend_available());
 #else
@@ -44,7 +44,7 @@ TEST_CASE("plugin_backend_available reports the expected platform value",
 }
 
 TEST_CASE("register_plugin_backend / unregister_plugin_backend is symmetric",
-          "[events][main_thread_dispatcher][item-6-4b]") {
+          "[events][main_thread_dispatcher][plugin-backend]") {
     REQUIRE_FALSE(MainThreadDispatcher::has_backend());
 
     auto token = register_plugin_backend();
@@ -63,7 +63,7 @@ TEST_CASE("register_plugin_backend / unregister_plugin_backend is symmetric",
 }
 
 TEST_CASE("plugin backend is reference-counted across instances",
-          "[events][main_thread_dispatcher][item-6-4b]") {
+          "[events][main_thread_dispatcher][plugin-backend]") {
     REQUIRE_FALSE(MainThreadDispatcher::has_backend());
 
     auto t1 = register_plugin_backend();
@@ -102,10 +102,10 @@ TEST_CASE("plugin backend is reference-counted across instances",
 #if defined(__APPLE__)
 // macOS-only — verify call_async dispatches work that actually runs on the
 // real main thread when the plugin backend is the only registered backend.
-// This is the "dispatcher actually executes scheduled work on the host's
-// main thread" regression the macOS plan asks for under 6.4b.
+// This pins the "dispatcher actually executes scheduled work on the host's
+// main thread" regression contract.
 TEST_CASE("plugin backend marshals call_async onto the main thread",
-          "[events][main_thread_dispatcher][item-6-4b][macos]") {
+          "[events][main_thread_dispatcher][plugin-backend][macos]") {
     auto token = register_plugin_backend();
     REQUIRE(token != 0);
 
@@ -142,7 +142,7 @@ TEST_CASE("plugin backend marshals call_async onto the main thread",
 #endif // __APPLE__
 
 TEST_CASE("call_async without a backend returns false and runs nothing",
-          "[events][main_thread_dispatcher][item-6-4b]") {
+          "[events][main_thread_dispatcher][plugin-backend]") {
     REQUIRE_FALSE(MainThreadDispatcher::has_backend());
     std::atomic<int> ran{0};
     REQUIRE_FALSE(MainThreadDispatcher::call_async([&] { ran.fetch_add(1); }));

--- a/test/test_design_import_codegen.cpp
+++ b/test/test_design_import_codegen.cpp
@@ -600,7 +600,7 @@ TEST_CASE("parse_v0_tsx preserves simple useState event contracts in baked C++ m
     REQUIRE(result.binding_manifest.find("\"event_contract\": \"range:onChange:setState\"") != std::string::npos);
 }
 
-TEST_CASE("parse_v0_tsx resolves indexed useState value bindings (PR #3128 review)",
+TEST_CASE("parse_v0_tsx resolves indexed useState value bindings",
           "[view][import][cpp-codegen]") {
     // Regression: value={params[0]} validated its base identifier but returned
     // the full "params[0]" expression as the lookup key, so the initial value

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -2611,7 +2611,7 @@ TEST_CASE("baked native materializer honors explicit hit-test metadata",
     REQUIRE(hit == root.get());
 }
 
-TEST_CASE("baked native materializer only treats display text as editor value for textarea (PR #3128 review)",
+TEST_CASE("baked native materializer only treats display text as editor value for textarea",
           "[view][import][native-materializer]") {
     // Regression: the text_value fallback used incidental node text for any
     // editor, so a label/heading captured as text_content was injected as the

--- a/test/test_document_window.cpp
+++ b/test/test_document_window.cpp
@@ -247,7 +247,7 @@ TEST_CASE("AlertWindow show forces at least one button when none added",
     REQUIRE(a.button_label(0) == "OK");
 }
 
-// ── PR #3006 regression: native close routing ──────────────────────────────
+// Native close routing regression coverage.
 //
 // On Apple platforms `WindowHost::create` ignores the registered factory
 // entirely and always returns the native NSWindow-backed host (see
@@ -307,7 +307,7 @@ struct ScopedFakeWindowFactory {
 } // namespace
 
 TEST_CASE("DocumentWindow::show() routes native closes through the "
-          "confirmation handler (regression: PR #3006 review)",
+          "confirmation handler (regression coverage)",
           "[view][window-classes][document-window][issue-3006]") {
     ScopedFakeWindowFactory factory;
     View root;
@@ -323,8 +323,8 @@ TEST_CASE("DocumentWindow::show() routes native closes through the "
     REQUIRE(doc.show());
     REQUIRE(factory.last_host != nullptr);
 
-    // Simulate a native title-bar close. The hook MUST run (otherwise the
-    // PR #3006 bug stands — close affordances bypass the hook).
+    // Simulate a native title-bar close. The hook MUST run so close affordances
+    // cannot bypass the confirmation handler.
     factory.last_host->fire_native_close();
     REQUIRE(hook_calls == 1);
 
@@ -336,7 +336,7 @@ TEST_CASE("DocumentWindow::show() routes native closes through the "
 }
 
 TEST_CASE("DialogWindow::show() emits closed via the completion handler "
-          "when the native window closes (regression: PR #3006 review)",
+          "when the native window closes (regression coverage)",
           "[view][window-classes][dialog-window][issue-3006]") {
     ScopedFakeWindowFactory factory;
     View content;

--- a/test/test_editor_bridge.cpp
+++ b/test/test_editor_bridge.cpp
@@ -237,8 +237,8 @@ TEST_CASE("EditorBridge::get_uint: clamps negatives to zero, handles type coerci
     CHECK(EditorBridge::get_uint(obj, "absent", 5) == 5u);
 }
 
-// PR #711 regression coverage: floats above SIZE_MAX must clamp, not
-// invoke undefined behavior via direct float→size_t cast.
+// Regression coverage: floats above SIZE_MAX must clamp, not invoke undefined
+// behavior via direct float→size_t cast.
 TEST_CASE("EditorBridge::get_uint: clamps floats above SIZE_MAX to size_t max",
           "[editor_bridge][issue-709]")
 {
@@ -355,7 +355,7 @@ TEST_CASE("EditorBridge::dispatch_webview_message: malformed payload_json errors
     CHECK(response_has_error(r, "malformed JSON"));
 }
 
-// ── PR #711: non-movable / non-copyable EditorBridge contract ─────────────
+// Non-movable / non-copyable EditorBridge contract.
 //
 // attach_webview installs a callback that captures a reference to the
 // bridge. Allowing moves would let an attached bridge be relocated out

--- a/test/test_effects.cpp
+++ b/test/test_effects.cpp
@@ -92,7 +92,7 @@ TEST_CASE("apply_shadow records generic canvas setup commands",
 }
 
 TEST_CASE("direct blur and color adjustment calls are generic no-ops",
-          "[canvas][effects][coverage][phase3]") {
+          "[canvas][effects][coverage]") {
     RecordingCanvas canvas;
 
     apply_blur(canvas, BlurEffect{2.0f, 5.0f});
@@ -102,7 +102,7 @@ TEST_CASE("direct blur and color adjustment calls are generic no-ops",
 }
 
 TEST_CASE("effect layers can be nested and restore in order",
-          "[canvas][effects][coverage][phase3]") {
+          "[canvas][effects][coverage]") {
     RecordingCanvas canvas;
 
     begin_effect_layer(canvas, BlurEffect{1.0f, 2.0f});

--- a/test/test_fft_backends.cpp
+++ b/test/test_fft_backends.cpp
@@ -80,7 +80,7 @@ void unset_env_var(const char* name) {
 // the variadic `b.set(...)` entry. This test pins the public surface so a
 // future refactor cannot silently reintroduce the wrong call path.
 TEST_CASE("MKL backend availability stays gated on runtime presence "
-          "(no UB call path) (regression: PR #3021 review)",
+          "(no UB call path)",
           "[fft][backend][mkl][issue-3021]") {
     // Constructing with MKL when libmkl_rt is absent MUST throw — the
     // selector helper reports availability via runtime dlopen, not a

--- a/test/test_font_aa_hinting.cpp
+++ b/test/test_font_aa_hinting.cpp
@@ -24,9 +24,9 @@ using namespace pulp::canvas;
 
 #ifdef PULP_HAS_SKIA
 
-// Regression note from PR #2186: `Default` / `PlatformDefault` resolve
-// to `std::nullopt`, signalling "caller preserves the existing
-// per-context heuristic". Explicit modes still resolve to the fixed enum.
+// `Default` / `PlatformDefault` resolve to `std::nullopt`, signalling
+// "caller preserves the existing per-context heuristic". Explicit modes still
+// resolve to the fixed enum.
 
 TEST_CASE("AA mode: Default returns nullopt (caller decides)", "[font][aa][issue-2163]") {
     REQUIRE(sk_edging_for(AntiAliasMode::Default) == std::nullopt);

--- a/test/test_frame_clock.cpp
+++ b/test/test_frame_clock.cpp
@@ -172,7 +172,7 @@ TEST_CASE("FrameClock zero dt is valid", "[view][frame_clock]") {
 }
 
 TEST_CASE("FrameClock subscriber added during tick starts on the next frame",
-          "[view][frame_clock][coverage][phase3]") {
+          "[view][frame_clock][coverage]") {
     FrameClock clock;
     int first_calls = 0;
     int added_calls = 0;
@@ -201,7 +201,7 @@ TEST_CASE("FrameClock subscriber added during tick starts on the next frame",
 }
 
 TEST_CASE("FrameClock subscriber can unsubscribe itself while returning true",
-          "[view][frame_clock][coverage][phase3]") {
+          "[view][frame_clock][coverage]") {
     FrameClock clock;
     int id = 0;
     int calls = 0;
@@ -220,7 +220,7 @@ TEST_CASE("FrameClock subscriber can unsubscribe itself while returning true",
 }
 
 TEST_CASE("FrameClock false-return compaction preserves later active subscribers",
-          "[view][frame_clock][coverage][phase3]") {
+          "[view][frame_clock][coverage]") {
     FrameClock clock;
     int first = 0;
     int second = 0;

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -427,7 +427,7 @@ TEST_CASE("GraphSerializer rejects graph migrations that do not advance versions
 }
 
 TEST_CASE("GraphSerializer rejects invalid graph migration registrations",
-          "[host][serializer][migration][coverage][phase3]") {
+          "[host][serializer][migration][coverage]") {
     REQUIRE(GraphSerializer::current_format_version() == 2);
     REQUIRE_FALSE(GraphSerializer::register_migration(
         2, 2,
@@ -452,7 +452,7 @@ TEST_CASE("GraphSerializer rejects invalid graph migration registrations",
 }
 
 TEST_CASE("GraphSerializer rejects non-integer and out-of-range graph versions",
-          "[host][serializer][migration][coverage][phase3]") {
+          "[host][serializer][migration][coverage]") {
     SignalGraph string_version;
     auto string_result = GraphSerializer::from_json(string_version, R"({
   "format_version": "2",
@@ -475,7 +475,7 @@ TEST_CASE("GraphSerializer rejects non-integer and out-of-range graph versions",
 }
 
 TEST_CASE("GraphSerializer reports broken graph migration outputs",
-          "[host][serializer][migration][coverage][phase3]") {
+          "[host][serializer][migration][coverage]") {
     REQUIRE(GraphSerializer::register_migration(
         -20, GraphSerializer::current_format_version(),
         [](const std::string&, std::string&) {
@@ -650,7 +650,7 @@ TEST_CASE("GraphSerializer tolerates missing arrays and skips stale connection i
 }
 
 TEST_CASE("GraphSerializer generated topology fuzz rejects unsafe imported edges",
-          "[host][serializer][generated][fuzz][phase3]") {
+          "[host][serializer][generated][fuzz]") {
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, R"({
   "format_version": 1,
@@ -980,7 +980,7 @@ TEST_CASE("GraphSerializer preserves opaque state for unresolved custom nodes",
 }
 
 TEST_CASE("GraphSerializer generated custom-state fuzz validates state payloads",
-          "[host][serializer][generated][state][fuzz][phase3]") {
+          "[host][serializer][generated][state][fuzz]") {
     SECTION("malformed base64 fails closed") {
         SignalGraph dst;
         auto result = GraphSerializer::from_json(dst, R"({
@@ -1039,7 +1039,7 @@ TEST_CASE("GraphSerializer generated custom-state fuzz validates state payloads"
 }
 
 TEST_CASE("GraphSerializer generated node type validation rejects invalid shapes",
-          "[host][serializer][generated][type][phase3]") {
+          "[host][serializer][generated][type]") {
     SECTION("audio input cannot declare input ports") {
         SignalGraph dst;
         auto result = GraphSerializer::from_json(dst, R"({
@@ -1201,7 +1201,7 @@ TEST_CASE("GraphSerializer resolves custom nodes by exact registry version",
 }
 
 TEST_CASE("GraphSerializer preserves unresolved custom nodes when registered ABI mismatches",
-          "[host][serializer][node-abi][coverage][phase3]") {
+          "[host][serializer][node-abi][coverage]") {
     SignalGraph src;
     REQUIRE(src.register_custom_node_type(make_custom_node_type(
         "pulp.test.mismatched-node", 7, 2, 1, "Wide Node")));
@@ -1267,7 +1267,7 @@ TEST_CASE("GraphSerializer serializes plugin formats and state blobs",
 }
 
 TEST_CASE("GraphSerializer serializes short plugin state blobs with stable padding",
-          "[host][serializer][coverage][phase3]") {
+          "[host][serializer][coverage]") {
     SignalGraph src;
     auto one_byte = make_fake_plugin_info("OneByteState", "pulp.test.state.one",
                                           PluginFormat::CLAP, 1, 1);
@@ -1407,7 +1407,7 @@ TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field err
 }
 
 TEST_CASE("GraphSerializer reports plugin nodes missing plugin payload",
-          "[host][serializer][coverage][phase3]") {
+          "[host][serializer][coverage]") {
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, R"({
   "format_version": 1,
@@ -1474,7 +1474,7 @@ TEST_CASE("GraphSerializer reports plugin nodes missing plugin payload",
 }
 
 TEST_CASE("GraphSerializer defaults missing gain and coerces non-numeric layout to zero",
-          "[host][serializer][coverage][phase3]") {
+          "[host][serializer][coverage]") {
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, R"({
   "format_version": 2,
@@ -1690,13 +1690,10 @@ TEST_CASE("GraphSerializer serializes audio-rate modulation connection fields",
     REQUIRE(dst.connections().empty());
 }
 
-// Issue #491: when graph_serializer rehydrates a graph with a
-// plugin that can't be resolved, it creates a "placeholder" Plugin node
-// with a null slot. Without an explicit branch in SignalGraph::process()
-// the node's output scratch kept stale data across blocks. The fix
-// deterministically passes input through to output (or zero-fills when
-// channel counts mismatch) so downstream AudioOutput never sees stale
-// audio.
+// When graph_serializer rehydrates a graph with an unresolved plugin, it creates
+// a placeholder Plugin node with a null slot. SignalGraph::process()
+// deterministically passes input through to output (or zero-fills when channel
+// counts mismatch) so downstream AudioOutput never sees stale audio.
 TEST_CASE("SignalGraph processes missing-plugin node as deterministic pass-through",
           "[host][serializer][issue-491]") {
     SignalGraph src;

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -1,5 +1,5 @@
-// SignalGraph tests, split out of test_host.cpp (P11-5, #2647) to bring the
-// 2,190-line parent under the 2,000-line target. Self-contained: uses
+// SignalGraph tests live separately from test_host.cpp so the host test surface
+// stays reviewable. Self-contained: uses
 // SignalGraph from pulp/host/signal_graph.hpp (in the shared host includes) and
 // carries its own interleaved helper namespaces.
 #include <catch2/catch_test_macros.hpp>
@@ -124,7 +124,7 @@ TEST_CASE("SignalGraph registers and processes custom nodes",
 }
 
 namespace {
-// A stateful custom node for the Phase 5 lifecycle tests: its opaque instance
+// A stateful custom node for lifecycle tests: its opaque instance
 // holds a `level` multiplier; process_instance scales the input by it;
 // save/load_state serialize the level as 4 little-endian bytes.
 struct StatefulLevel {
@@ -208,7 +208,7 @@ TEST_CASE("SignalGraph stateful custom node: lifecycle + state round-trip",
 }
 
 TEST_CASE("SignalGraph generated custom state changes require re-prepare",
-          "[host][graph][generated][rt-safety][phase3]") {
+          "[host][graph][generated][rt-safety]") {
     SignalGraph graph;
     REQUIRE(graph.register_custom_node_type(make_level_type()));
 
@@ -372,7 +372,7 @@ TEST_CASE("SignalGraph custom node registrations invalidate matching snapshots",
 }
 
 TEST_CASE("SignalGraph remove_node prunes edges and invalidates live graph",
-          "[host][graph][coverage][phase3]") {
+          "[host][graph][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "Input");
     auto gain = graph.add_gain_node("Gain");
@@ -506,7 +506,7 @@ TEST_CASE("SignalGraph MIDI nodes", "[host][graph]") {
 }
 
 TEST_CASE("SignalGraph routes input -> gain -> output", "[host][graph][routing]") {
-    // Validates the Phase 2 graph execution path: per-node scratch buffers,
+    // Validates the graph execution path: per-node scratch buffers,
     // inbound connection summing, gain application, and output accumulation.
     SignalGraph graph;
     auto in  = graph.add_input_node(2, "in");
@@ -866,7 +866,7 @@ TEST_CASE("SignalGraph query helpers handle non-plugin and cleared nodes",
 }
 
 TEST_CASE("SignalGraph prepare rejects graphs beyond configured limits",
-          "[host][graph][limits][phase2]") {
+          "[host][graph][limits]") {
     SECTION("node count") {
         SignalGraph graph;
         auto limits = graph.limits();
@@ -930,7 +930,7 @@ TEST_CASE("SignalGraph prepare rejects graphs beyond configured limits",
 }
 
 TEST_CASE("SignalGraph generated graph validation reports limit reasons",
-          "[host][graph][generated][limits][phase3]") {
+          "[host][graph][generated][limits]") {
     SECTION("valid graph") {
         SignalGraph graph;
         auto input = graph.add_input_node(1, "in");
@@ -1076,7 +1076,7 @@ TEST_CASE("SignalGraph generated graph validation reports limit reasons",
 }
 
 TEST_CASE("SignalGraph prepares and routes a large graph at configured limits",
-          "[host][graph][limits][scale][phase2]") {
+          "[host][graph][limits][scale]") {
     SignalGraph graph;
     constexpr int kGainNodes = 128;
     constexpr int kBlock = 16;
@@ -1134,7 +1134,7 @@ TEST_CASE("SignalGraph prepares and routes a large graph at configured limits",
 }
 
 TEST_CASE("SignalGraph exposes prepared runtime stats",
-          "[host][graph][stats][phase2]") {
+          "[host][graph][stats]") {
     SignalGraph graph;
     REQUIRE(graph.prepared_stats().node_count == 0);
 
@@ -1165,7 +1165,7 @@ TEST_CASE("SignalGraph exposes prepared runtime stats",
 }
 
 TEST_CASE("SignalGraph evaluates optional runtime budget from prepared stats",
-          "[host][graph][budget-policy][phase4]") {
+          "[host][graph][budget-policy]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto gain = graph.add_gain_node("gain");
@@ -1202,7 +1202,7 @@ TEST_CASE("SignalGraph evaluates optional runtime budget from prepared stats",
 }
 
 TEST_CASE("SignalGraph optional runtime budget reports unprepared graphs",
-          "[host][graph][budget-policy][phase4]") {
+          "[host][graph][budget-policy]") {
     SignalGraph graph;
     pulp::runtime::RuntimeBudgetFrame frame(0);
 
@@ -1216,7 +1216,7 @@ TEST_CASE("SignalGraph optional runtime budget reports unprepared graphs",
 }
 
 TEST_CASE("SignalGraph optional runtime budget has deterministic large-graph cost",
-          "[host][graph][budget-policy][scale][phase4]") {
+          "[host][graph][budget-policy][scale]") {
     SignalGraph graph;
     constexpr int kGainNodes = 128;
     constexpr int kBlock = 16;
@@ -1261,7 +1261,7 @@ TEST_CASE("SignalGraph optional runtime budget has deterministic large-graph cos
 }
 
 TEST_CASE("SignalGraph clears prepared runtime stats after failed prepare",
-          "[host][graph][stats][limits][phase2]") {
+          "[host][graph][stats][limits]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1282,7 +1282,7 @@ TEST_CASE("SignalGraph clears prepared runtime stats after failed prepare",
 
 #if defined(__unix__) || defined(__APPLE__)
 TEST_CASE("SignalGraph optional runtime budget path allocates zero times",
-          "[host][graph][budget-policy][rt-safety][phase4]") {
+          "[host][graph][budget-policy][rt-safety]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1300,7 +1300,7 @@ TEST_CASE("SignalGraph optional runtime budget path allocates zero times",
 }
 
 TEST_CASE("SignalGraph prepared runtime stats path allocates zero times",
-          "[host][graph][stats][rt-safety][phase2]") {
+          "[host][graph][stats][rt-safety]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1341,7 +1341,7 @@ TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing
 }
 
 TEST_CASE("SignalGraph rejects audio connections with invalid ports",
-          "[host][graph][routing][coverage][phase3]") {
+          "[host][graph][routing][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto gain = graph.add_gain_node("gain");
@@ -1476,7 +1476,7 @@ private:
 } // namespace
 
 TEST_CASE("SignalGraph prepare failure leaves process output silent",
-          "[host][graph][coverage][phase3]") {
+          "[host][graph][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto plugin = graph.add_plugin_node(std::make_unique<PrepareFailPlugin>(),
@@ -1503,7 +1503,7 @@ TEST_CASE("SignalGraph prepare failure leaves process output silent",
 }
 
 TEST_CASE("SignalGraph process silences oversized blocks",
-          "[host][graph][coverage][phase3]") {
+          "[host][graph][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1526,7 +1526,7 @@ TEST_CASE("SignalGraph process silences oversized blocks",
 }
 
 TEST_CASE("SignalGraph process ignores non-positive block sizes",
-          "[host][graph][coverage][phase3]") {
+          "[host][graph][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1550,7 +1550,7 @@ TEST_CASE("SignalGraph process ignores non-positive block sizes",
 }
 
 TEST_CASE("SignalGraph clears stale audio input channels",
-          "[host][graph][routing][coverage][phase3]") {
+          "[host][graph][routing][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(2, "in");
     auto gain = graph.add_gain_node("gain");
@@ -1587,7 +1587,7 @@ TEST_CASE("SignalGraph clears stale audio input channels",
 }
 
 TEST_CASE("SignalGraph placeholder plugin nodes preserve identity and clear extra outputs",
-          "[host][graph][routing][coverage][phase3]") {
+          "[host][graph][routing][coverage]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     PluginInfo missing = make_plugin_info("Missing CLAP", 1, 2);
@@ -2226,7 +2226,7 @@ TEST_CASE("SignalGraph MIDI sidecar drops are caller-visible",
 }
 
 TEST_CASE("SignalGraph MIDI injection and extraction require a live node runtime",
-          "[host][graph][midi][coverage][phase3]") {
+          "[host][graph][midi][coverage]") {
     SignalGraph graph;
     auto midi_in = graph.add_midi_input_node("keys");
     auto midi_out = graph.add_midi_output_node("thru");
@@ -2467,7 +2467,7 @@ TEST_CASE("SignalGraph live controls and MIDI handoff are TSan-clean together",
     graph.release();
 }
 
-// ── Phase 1E connect_automation test ────────────────────────────────────
+// ── connect_automation tests ─────────────────────────────────────────────
 
 namespace {
 // Plugin exposing a single automatable param and recording every
@@ -2794,7 +2794,7 @@ TEST_CASE("SignalGraph connect_automation rejects duplicate Replace edges",
 }
 
 TEST_CASE("SignalGraph connect_automation rejects invalid endpoints and params",
-          "[host][graph][automation][coverage][phase3]") {
+          "[host][graph][automation][coverage]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1);
     auto out_node = graph.add_output_node(1);
@@ -2815,7 +2815,7 @@ TEST_CASE("SignalGraph connect_automation rejects invalid endpoints and params",
 }
 
 TEST_CASE("SignalGraph automation rejects non-writable params and cycle edges",
-          "[host][graph][automation][coverage][phase3]") {
+          "[host][graph][automation][coverage]") {
     SignalGraph graph;
     auto source = graph.add_input_node(1, "source");
     auto passthrough = graph.add_gain_node("passthrough");
@@ -2846,7 +2846,7 @@ TEST_CASE("SignalGraph automation rejects non-writable params and cycle edges",
 }
 
 TEST_CASE("SignalGraph automation clamps add-mode and stored smoothing",
-          "[host][graph][automation][coverage][phase3]") {
+          "[host][graph][automation][coverage]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1, "in");
     auto slot = std::make_unique<MockAutomatable>();
@@ -2945,7 +2945,7 @@ TEST_CASE("SignalGraph connect_audio_rate_modulation gates on audio-rate params"
 }
 
 TEST_CASE("SignalGraph audio-rate modulation rejects non-writable params and cycle edges",
-          "[host][graph][automation][audio-rate][coverage][phase3]") {
+          "[host][graph][automation][audio-rate][coverage]") {
     SignalGraph graph;
     auto source = graph.add_input_node(1, "source");
     auto passthrough = graph.add_gain_node("passthrough");
@@ -3115,7 +3115,7 @@ TEST_CASE("SignalGraph audio-rate add modulation clamps independent of edge orde
 }
 
 TEST_CASE("SignalGraph audio-rate replace and add modulation clamp to parameter bounds",
-          "[host][graph][automation][audio-rate][coverage][phase3]") {
+          "[host][graph][automation][audio-rate][coverage]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1, "in");
     auto slot = std::make_unique<MockAutomatable>(
@@ -3238,7 +3238,7 @@ TEST_CASE("SignalGraph audio-rate modulation fails closed when event capacity is
 
 #if defined(__unix__) || defined(__APPLE__)
 TEST_CASE("SignalGraph plugin automation process uses prepared scratch without allocation",
-          "[host][graph][automation][rt-safety][phase2]") {
+          "[host][graph][automation][rt-safety]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1, "in");
     auto slot = std::make_unique<FixedAutomationProbe>();
@@ -3486,7 +3486,7 @@ private:
 } // namespace
 
 TEST_CASE("SignalGraph dispatches plugin nodes through ProcessBuffers",
-          "[host][graph][process-buffers][phase2]") {
+          "[host][graph][process-buffers]") {
     SignalGraph graph;
     auto in = graph.add_input_node(2, "in");
     auto slot = std::make_unique<ProcessBufferAwareSlot>();
@@ -3586,7 +3586,7 @@ private:
 } // namespace
 
 TEST_CASE("SignalGraph routes multi-output plugin ProcessBuffers to AudioOutput",
-          "[host][graph][process-buffers][phase2][multi-output]") {
+          "[host][graph][process-buffers][multi-output]") {
     SignalGraph graph;
     auto slot = std::make_unique<MultiOutputProcessBufferSlot>();
     auto* slot_ptr = slot.get();
@@ -3962,4 +3962,4 @@ TEST_CASE("SignalGraph routed_walk_fallbacks() stays zero for routed + walk-by-c
     }
 }
 
-// ── Phase 3 GraphSerializer round-trip ──────────────────────────────────
+// ── GraphSerializer round-trip ───────────────────────────────────────────

--- a/test/test_image_codecs_extended.cpp
+++ b/test/test_image_codecs_extended.cpp
@@ -189,14 +189,14 @@ TEST_CASE("TiffWriter rejects mismatched buffer sizes",
     REQUIRE(encoded.empty());
 }
 
-// Regression: PR #3017 — big-endian inline TIFF SHORT values were read as
-// low 16 bits of value_or_offset, which returns 0 in MM files
-// (where SHORT is left-justified in the 4-byte slot). This caused valid
-// big-endian baseline TIFFs to be rejected or decoded incorrectly. Build a
-// minimal 2×1 grayscale uncompressed MM TIFF by hand and prove the
-// reader extracts the right Width/Height/Compression/Photometric.
+// Regression coverage: big-endian inline TIFF SHORT values were read as low 16
+// bits of value_or_offset, which returns 0 in MM files (where SHORT is
+// left-justified in the 4-byte slot). This caused valid big-endian baseline
+// TIFFs to be rejected or decoded incorrectly. Build a minimal 2x1 grayscale
+// uncompressed MM TIFF by hand and prove the reader extracts the right
+// Width/Height/Compression/Photometric.
 TEST_CASE("TiffReader decodes big-endian inline SHORT values correctly "
-          "(regression: PR #3017 review)",
+          "(regression coverage)",
           "[image-codecs][tiff][issue-3017]") {
     // Big-endian TIFF: 'MM', magic 42, IFD at offset 8.
     // Layout chosen so IFD entries with SHORT inline values exercise the

--- a/test/test_ios_foundation.cpp
+++ b/test/test_ios_foundation.cpp
@@ -153,7 +153,7 @@ TEST_CASE("PluginViewHost::Size custom values", "[ios][view]") {
 
 // ── Platform-specific feature flags ─────────────────────────────────────────
 
-// ── AUv3 HostApp template shape (PR #3095) ─────────────────────────────────
+// AUv3 HostApp template shape regression coverage.
 //
 // Regression test for templates/ios-auv3/HostApp/ContentView.swift:99:
 // "Match the embedded component descriptor exactly". The previous template

--- a/test/test_isolated_scanner.cpp
+++ b/test/test_isolated_scanner.cpp
@@ -120,12 +120,12 @@ TEST_CASE("pulp-scan-worker command line reports usage and unsupported bundles",
     REQUIRE(rejected.stdout_output.empty());
 }
 
-// Regression for PR #3110: when a directory contains
-// multiple `.vst3` symlinks pointing at the same real bundle, the worker must
-// preserve the requested-alias identity (lexical absolute path) instead of
-// canonicalizing through symlinks. Otherwise a request for `alias.vst3` could
-// emit a descriptor for `real.vst3` and `IsolatedPluginScanner::scan` (which
-// consumes only the first JSON line) would return or blacklist a sibling.
+// Regression coverage: when a directory contains multiple `.vst3` symlinks
+// pointing at the same real bundle, the worker must preserve the requested-alias
+// identity (lexical absolute path) instead of canonicalizing through symlinks.
+// Otherwise a request for `alias.vst3` could emit a descriptor for `real.vst3`
+// and `IsolatedPluginScanner::scan` (which consumes only the first JSON line)
+// would return or blacklist a sibling.
 TEST_CASE("pulp-scan-worker preserves requested-alias identity for symlinks",
           "[tools][scan-worker][coverage][issue-3110]") {
     ScratchDir scratch("symlink-alias");

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -570,10 +570,9 @@ TEST_CASE("pulp-mcp flag-only invocations do not enter the JSON-RPC loop",
 // contain embedded `\n` or `\r` — the transport delimits messages with
 // a single newline. A response carrying a raw newline gets split and
 // the client (Claude Code, Codex CLI, etc.) reads only the first
-// fragment, then times out waiting for the rest. PR #2091 fixed this
-// by piping every wire-bound response through a `compact_for_wire`
-// strip; this test pins the contract so a future regression on the
-// strip itself surfaces immediately.
+// fragment, then times out waiting for the rest. The fix pipes every wire-bound
+// response through a `compact_for_wire` strip; this test pins the contract so a
+// future regression on the strip itself surfaces immediately.
 //
 // Pulp #2087 follow-up (B4 first cut): the bug shipped because there
 // was no protocol-shape test. The full B4 split is queued separately.

--- a/test/test_midi_buffer_sysex.cpp
+++ b/test/test_midi_buffer_sysex.cpp
@@ -11,8 +11,8 @@ using namespace pulp::midi;
 
 TEST_CASE("realtime SysEx pool recycles payloads so SysEx is never dropped across blocks",
           "[midi][buffer][sysex]") {
-    // RT contract for the pooled SysEx-copy path the VST3 adapter (PR #4564)
-    // relies on: in realtime-capacity mode add_sysex_copy() reuses a reserved
+    // RT contract for the pooled SysEx-copy path used by plugin adapters: in
+    // realtime-capacity mode add_sysex_copy() reuses a reserved
     // payload pool that is replenished by clear_sysex() each block. The critical
     // correctness property is that this never silently DROPS SysEx across blocks —
     // i.e. the pool does not deplete cycle over cycle. (Steady-state allocation

--- a/test/test_psdf_atlas.cpp
+++ b/test/test_psdf_atlas.cpp
@@ -1,4 +1,4 @@
-// Tests for PSDF atlas + vector-fallback policy (Phase 3 scaffold).
+// Tests for PSDF atlas + vector-fallback policy.
 //
 // Today PsdfAtlas inherits SdfAtlas' generator; these tests verify the
 // surface is correct and the fallback threshold behaves as documented.
@@ -33,7 +33,7 @@ TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
 }
 
 TEST_CASE("PsdfAtlas default and invalid builds leave atlas empty",
-          "[canvas][psdf][coverage][phase3]") {
+          "[canvas][psdf][coverage]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.glyph_count() == 0);
     REQUIRE(atlas.base_size() == 0);
@@ -50,7 +50,7 @@ TEST_CASE("PsdfAtlas default and invalid builds leave atlas empty",
 }
 
 TEST_CASE("PsdfAtlas packs glyph tiles and preserves metrics",
-          "[canvas][psdf][coverage][phase3]") {
+          "[canvas][psdf][coverage]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'P', U'S', U'D'}, 12, 2, 32));
     REQUIRE(atlas.width() == 32);
@@ -72,7 +72,7 @@ TEST_CASE("PsdfAtlas packs glyph tiles and preserves metrics",
 }
 
 TEST_CASE("PsdfAtlas de-duplicates and can be rebuilt",
-          "[canvas][psdf][coverage][phase3]") {
+          "[canvas][psdf][coverage]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'P', U'P', U'S'}, 16, 2, 128));
     REQUIRE(atlas.glyph_count() == 2);
@@ -88,7 +88,7 @@ TEST_CASE("PsdfAtlas de-duplicates and can be rebuilt",
 }
 
 TEST_CASE("PsdfAtlas move assignment transfers the built atlas",
-          "[canvas][psdf][coverage][phase3]") {
+          "[canvas][psdf][coverage]") {
     PsdfAtlas source;
     PsdfAtlas destination;
     REQUIRE(source.build("stub", {U'A', U'B'}, 18, 2, 128));
@@ -130,7 +130,7 @@ TEST_CASE("vector_fallback equality and negative thresholds are strict",
 }
 
 TEST_CASE("vector_fallback scales render size against the selected base",
-          "[canvas][psdf][fallback][coverage][phase3]") {
+          "[canvas][psdf][fallback][coverage]") {
     REQUIRE_FALSE(should_use_vector_fallback(63.9f, 16.0f, 4.0f));
     REQUIRE_FALSE(should_use_vector_fallback(64.0f, 16.0f, 4.0f));
     REQUIRE(should_use_vector_fallback(64.1f, 16.0f, 4.0f));

--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -91,7 +91,7 @@ TEST_CASE("RectangleList subtract handles no-op and full-cover cases",
 }
 
 TEST_CASE("RectangleList subtract emits all side bands around a center cut",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -213,7 +213,7 @@ TEST_CASE("Rect enclosing union preserves non-empty side",
 }
 
 TEST_CASE("Rect right bottom and empty semantics cover zero and negative extents",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect normal{2, 3, 4, 5};
     REQUIRE(normal.right() == Catch::Approx(6.0f));
     REQUIRE(normal.bottom() == Catch::Approx(8.0f));
@@ -226,7 +226,7 @@ TEST_CASE("Rect right bottom and empty semantics cover zero and negative extents
 }
 
 TEST_CASE("Rect contains keeps right and bottom edges exclusive",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect r{-2, -3, 5, 7};
 
     REQUIRE(r.contains(-2.0f, -3.0f));
@@ -238,7 +238,7 @@ TEST_CASE("Rect contains keeps right and bottom edges exclusive",
 }
 
 TEST_CASE("Rect intersection is commutative for overlapping rectangles",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect a{-5, 2, 12, 6};
     Rect b{0, -1, 4, 10};
 
@@ -250,7 +250,7 @@ TEST_CASE("Rect intersection is commutative for overlapping rectangles",
 }
 
 TEST_CASE("Rect intersection of contained rectangle returns contained bounds",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect outer{-10, -10, 30, 30};
     Rect inner{-2, 3, 5, 6};
 
@@ -259,7 +259,7 @@ TEST_CASE("Rect intersection of contained rectangle returns contained bounds",
 }
 
 TEST_CASE("Rect intersection treats edge and corner contact as empty",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect base{0, 0, 10, 10};
 
     REQUIRE_FALSE(base.intersects({10, 2, 3, 3}));
@@ -270,7 +270,7 @@ TEST_CASE("Rect intersection treats edge and corner contact as empty",
 }
 
 TEST_CASE("Rect enclosing union handles negative coordinates",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect a{-10, 5, 4, 5};
     Rect b{3, -2, 8, 3};
 
@@ -279,7 +279,7 @@ TEST_CASE("Rect enclosing union handles negative coordinates",
 }
 
 TEST_CASE("Rect enclosing union of two empty rectangles is empty",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     Rect a{5, 6, 0, 7};
     Rect b{-1, -2, 8, 0};
 
@@ -288,7 +288,7 @@ TEST_CASE("Rect enclosing union of two empty rectangles is empty",
 }
 
 TEST_CASE("RectangleList preserves insertion order for indexing and iteration",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({3, 0, 1, 1});
     rl.add({1, 0, 1, 1});
@@ -306,7 +306,7 @@ TEST_CASE("RectangleList preserves insertion order for indexing and iteration",
 }
 
 TEST_CASE("RectangleList contains checks negative-coordinate rectangles",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({-10, -5, 4, 8});
     rl.add({5, -2, 3, 3});
@@ -318,7 +318,7 @@ TEST_CASE("RectangleList contains checks negative-coordinate rectangles",
 }
 
 TEST_CASE("RectangleList intersects ignores empty query rectangles",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -328,7 +328,7 @@ TEST_CASE("RectangleList intersects ignores empty query rectangles",
 }
 
 TEST_CASE("RectangleList bounding box for a single rectangle is that rectangle",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({-4, 8, 6, 2});
 
@@ -336,7 +336,7 @@ TEST_CASE("RectangleList bounding box for a single rectangle is that rectangle",
 }
 
 TEST_CASE("RectangleList total_area intentionally double-counts overlaps",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({5, 5, 10, 10});
@@ -345,7 +345,7 @@ TEST_CASE("RectangleList total_area intentionally double-counts overlaps",
 }
 
 TEST_CASE("RectangleList clipped preserves source order and leaves source intact",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 20, 10, 10});
@@ -360,7 +360,7 @@ TEST_CASE("RectangleList clipped preserves source order and leaves source intact
 }
 
 TEST_CASE("RectangleList clipped against disjoint bounds returns empty list",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 20, 5, 5});
@@ -369,7 +369,7 @@ TEST_CASE("RectangleList clipped against disjoint bounds returns empty list",
 }
 
 TEST_CASE("RectangleList clipped handles negative clip coordinates",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({-10, -10, 8, 8});
     rl.add({-3, -3, 8, 8});
@@ -382,7 +382,7 @@ TEST_CASE("RectangleList clipped handles negative clip coordinates",
 }
 
 TEST_CASE("RectangleList subtract top strip keeps the lower remainder",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -393,7 +393,7 @@ TEST_CASE("RectangleList subtract top strip keeps the lower remainder",
 }
 
 TEST_CASE("RectangleList subtract bottom strip keeps the upper remainder",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -404,7 +404,7 @@ TEST_CASE("RectangleList subtract bottom strip keeps the upper remainder",
 }
 
 TEST_CASE("RectangleList subtract left strip keeps the right remainder",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -415,7 +415,7 @@ TEST_CASE("RectangleList subtract left strip keeps the right remainder",
 }
 
 TEST_CASE("RectangleList subtract right strip keeps the left remainder",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -426,7 +426,7 @@ TEST_CASE("RectangleList subtract right strip keeps the left remainder",
 }
 
 TEST_CASE("RectangleList subtract vertical middle split creates left and right pieces",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -438,7 +438,7 @@ TEST_CASE("RectangleList subtract vertical middle split creates left and right p
 }
 
 TEST_CASE("RectangleList subtract horizontal middle split creates top and bottom pieces",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -450,7 +450,7 @@ TEST_CASE("RectangleList subtract horizontal middle split creates top and bottom
 }
 
 TEST_CASE("RectangleList subtract corner overlap creates two non-overlapping pieces",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -465,7 +465,7 @@ TEST_CASE("RectangleList subtract corner overlap creates two non-overlapping pie
 }
 
 TEST_CASE("RectangleList subtract overlap extending past left edge",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -478,7 +478,7 @@ TEST_CASE("RectangleList subtract overlap extending past left edge",
 }
 
 TEST_CASE("RectangleList subtract applies independently to multiple rectangles",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 0, 10, 10});
@@ -491,7 +491,7 @@ TEST_CASE("RectangleList subtract applies independently to multiple rectangles",
 }
 
 TEST_CASE("RectangleList repeated subtracts work on previously split pieces",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 12, 12});
 
@@ -507,7 +507,7 @@ TEST_CASE("RectangleList repeated subtracts work on previously split pieces",
 }
 
 TEST_CASE("RectangleList clear allows reuse without stale bounds",
-          "[canvas][rect][coverage][phase3-large]") {
+          "[canvas][rect][coverage][large]") {
     RectangleList rl;
     rl.add({0, 0, 100, 100});
     rl.clear();

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -159,7 +159,7 @@ TEST_CASE("RenderLoop timer backend can restart with a new callback",
 // ── VBlank-locked safe-repaint additions ───────────────────────────────
 
 TEST_CASE("RenderLoop factory selects the timer backend under force-timer",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     // This test target is compiled with PULP_RENDER_LOOP_FORCE_TIMER=1, so
     // the factory must select the conscious timer fallback on every host.
     auto loop = RenderLoop::create();
@@ -182,7 +182,7 @@ TEST_CASE("RenderLoop explicit timer factory is deterministic",
 }
 
 TEST_CASE("render_loop_backend_is_vsync distinguishes real vblank sources",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     // The four native backends are real vblank sources; only the timer
     // fallback is not. constexpr so the classification is compile-checked.
     static_assert(render_loop_backend_is_vsync(RenderLoopBackend::cv_display_link));
@@ -196,7 +196,7 @@ TEST_CASE("render_loop_backend_is_vsync distinguishes real vblank sources",
 }
 
 TEST_CASE("render_loop_backend_name covers every backend",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     CHECK(std::string(render_loop_backend_name(RenderLoopBackend::cv_display_link))
           == "CVDisplayLink");
     CHECK(std::string(render_loop_backend_name(RenderLoopBackend::ca_display_link))
@@ -210,7 +210,7 @@ TEST_CASE("render_loop_backend_name covers every backend",
 }
 
 TEST_CASE("DwmBackendTracker latches to the timer fallback once a vblank wait fails",
-          "[render][loop][vblank][slice-16][issue-2580]") {
+          "[render][loop][vblank][issue-2580]") {
     // The Windows loop sleeps on a ~60 Hz timer when
     // DwmFlush() fails, but backend() must then stop claiming dwm_flush so
     // render_loop_backend_is_vsync() callers can detect the fallback.
@@ -236,7 +236,7 @@ TEST_CASE("DwmBackendTracker latches to the timer fallback once a vblank wait fa
 }
 
 TEST_CASE("RenderLoop coalesces a burst of frame requests into one callback",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     // The canonical safe-repaint contract: any number of request_frame()
     // calls between two vblanks fire the callback exactly once. This is the
     // platform-agnostic coalescing the native vsync subclasses inherit via
@@ -264,7 +264,7 @@ TEST_CASE("RenderLoop coalesces a burst of frame requests into one callback",
 }
 
 TEST_CASE("RenderLoop stays idle with no frame request",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     // Demand-driven: after the initial start() frame, an untouched loop
     // must not free-run. This is what makes vblank-locked repaint cheap
     // for an idle UI versus the legacy periodic-poll pattern.
@@ -282,7 +282,7 @@ TEST_CASE("RenderLoop stays idle with no frame request",
 }
 
 TEST_CASE("RenderLoop request_frame from inside the callback arms the next frame",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     // A callback that re-arms (e.g. an animating widget) drives a steady
     // one-callback-per-vblank cadence — the next-frame scheduling path —
     // without ever recursing within the same frame.
@@ -305,7 +305,7 @@ TEST_CASE("RenderLoop request_frame from inside the callback arms the next frame
 }
 
 TEST_CASE("RenderLoop stop suppresses callbacks for a pending request",
-          "[render][loop][vblank][slice-16]") {
+          "[render][loop][vblank]") {
     auto loop = RenderLoop::create();
     REQUIRE(loop != nullptr);
 

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -103,7 +103,7 @@ TEST_CASE("DelayLine zero max delay uses a stable single-sample buffer",
 }
 
 TEST_CASE("DelayLine fractional reads interpolate across wrapped write positions",
-          "[signal][delay][coverage][phase3-batch756]") {
+          "[signal][delay][coverage]") {
     DelayLine dl;
     dl.prepare(3);
 
@@ -991,7 +991,7 @@ TEST_CASE("WaveShaper fold", "[signal][waveshaper]") {
 }
 
 TEST_CASE("WaveShaper handles zero and negative length buffers",
-          "[signal][waveshaper][coverage][phase3-batch756]") {
+          "[signal][waveshaper][coverage]") {
     WaveShaper ws;
     ws.set_curve(WaveShaper::Curve::hard_clip);
     ws.set_drive(8.0f);
@@ -1113,7 +1113,7 @@ TEST_CASE("NoiseGate clamps range, instant timing, reset, and buffers",
 }
 
 TEST_CASE("NoiseGate ignores nonpositive buffer lengths",
-          "[signal][gate][coverage][phase3-batch756]") {
+          "[signal][gate][coverage]") {
     NoiseGate gate;
     gate.set_sample_rate(1000.0f);
     gate.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -24.0f});
@@ -1301,7 +1301,7 @@ TEST_CASE("Panner clamps and processes stereo in place",
 }
 
 TEST_CASE("Panner preserves equal-power mono energy and input sign",
-          "[signal][panner][coverage][phase3-batch756]") {
+          "[signal][panner][coverage]") {
     Panner pan;
     pan.set_pan(-0.25f);
 

--- a/test/test_signal_filters.cpp
+++ b/test/test_signal_filters.cpp
@@ -160,7 +160,7 @@ TEST_CASE("SVF covers bandpass notch buffer and reset paths",
 }
 
 TEST_CASE("SVF ignores nonpositive buffer lengths",
-          "[signal][svf][coverage][phase3-batch756]") {
+          "[signal][svf][coverage]") {
     Svf filter;
     filter.set_sample_rate(48000.0f);
     filter.set_frequency(1000.0f);
@@ -224,7 +224,7 @@ TEST_CASE("LadderFilter resets buffer state and clamps resonance inputs",
 }
 
 TEST_CASE("LadderFilter reset restores fresh-filter impulse response",
-          "[signal][ladder][coverage][phase3-batch756]") {
+          "[signal][ladder][coverage]") {
     auto impulse_response = [] {
         LadderFilter filter;
         filter.set_sample_rate(48000.0f);
@@ -256,7 +256,7 @@ TEST_CASE("LadderFilter reset restores fresh-filter impulse response",
 }
 
 TEST_CASE("LadderFilter ignores nonpositive buffer lengths",
-          "[signal][ladder][coverage][phase3-batch756]") {
+          "[signal][ladder][coverage]") {
     LadderFilter ladder;
     ladder.set_sample_rate(44100.0f);
     ladder.set_frequency(1200.0f);
@@ -352,7 +352,7 @@ TEST_CASE("LinkwitzRiley cutoff boundary processing stays finite",
 }
 
 TEST_CASE("LinkwitzRiley retuning after active history stays finite",
-          "[signal][lr][coverage][phase3-github]") {
+          "[signal][lr][coverage]") {
     LinkwitzRiley lr;
     lr.set_frequency(300.0f, 48000.0f);
     for (int i = 0; i < 32; ++i) {

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -279,7 +279,7 @@ TEST_CASE("Standalone settings callbacks skip rebind when apply fails",
 }
 
 TEST_CASE("StandaloneApp apply_config updates idle configuration without starting audio",
-          "[standalone][coverage][phase3]") {
+          "[standalone][coverage]") {
     counted_null_processor_factory_calls = 0;
     StandaloneApp app(counted_null_processor_factory);
 
@@ -305,7 +305,7 @@ TEST_CASE("StandaloneApp apply_config updates idle configuration without startin
 }
 
 TEST_CASE("StandaloneApp rejects headless editor runs without screenshot before startup",
-          "[standalone][coverage][phase3]") {
+          "[standalone][coverage]") {
     counted_null_processor_factory_calls = 0;
     StandaloneApp app(counted_null_processor_factory);
 
@@ -401,7 +401,7 @@ TEST_CASE("SettingsPanel applies audio and MIDI selections",
 }
 
 TEST_CASE("SettingsPanel set_current_config prefers explicit output over default",
-          "[standalone][settings][coverage][phase3]") {
+          "[standalone][settings][coverage]") {
     StubAudioSystem audio;
     audio.devices = {
         {.id = "builtin-out",
@@ -759,7 +759,7 @@ TEST_CASE("SettingsPanel refreshes hotplug lists and test tone callbacks",
 }
 
 TEST_CASE("SettingsPanel uses fallback rate and buffer choices without output devices",
-          "[standalone][settings][coverage][phase3]") {
+          "[standalone][settings][coverage]") {
     StubAudioSystem audio;
     audio.devices = {
         {.id = "mic-only",
@@ -846,8 +846,8 @@ TEST_CASE("Standalone editor chrome wraps editor and settings in a tab panel",
 TEST_CASE("Standalone editor chrome fills the editor tab to the design area "
           "(a fill-based editor must not collapse)",
           "[standalone][chrome][issue-45]") {
-    // Regression for the Bendr-tracker #45 standalone squish: a fill-based
-    // editor (a bare View has no intrinsic height and sets no flex on itself —
+    // Regression for standalone editor squish: a fill-based editor (a bare View
+    // has no intrinsic height and sets no flex on itself —
     // exactly like Bendr's design-viewport editor, which lays out from
     // local_bounds()) used to collapse to a thin strip inside the TabPanel.
     // TabPanel::add_tab applies no flex to tab content and FlexStyle defaults to

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -175,7 +175,7 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
 }
 
 TEST_CASE("SimpleTableModel sorts descending and guards out-of-range cells",
-          "[gui][table][coverage][phase3]") {
+          "[gui][table][coverage]") {
     SimpleTableModel model;
     model.set_data({
         {"Alpha", "3"},
@@ -195,7 +195,7 @@ TEST_CASE("SimpleTableModel sorts descending and guards out-of-range cells",
 }
 
 TEST_CASE("SimpleTableModel set_data replaces rows and sorts sparse descending",
-          "[gui][table][coverage][phase3]") {
+          "[gui][table][coverage]") {
     SimpleTableModel model;
     model.add_row({"old", "row"});
     model.set_data({
@@ -289,7 +289,7 @@ TEST_CASE("TableListBox ignores clicks outside right and bottom bounds",
 }
 
 TEST_CASE("TableListBox ignores header clicks past scaled columns",
-          "[gui][table][coverage][phase3]") {
+          "[gui][table][coverage]") {
     RecordingTableModel model({
         {"First", "A"},
         {"Second", "B"},

--- a/test/test_transport_hook.cpp
+++ b/test/test_transport_hook.cpp
@@ -135,7 +135,7 @@ TEST_CASE("exception thrown by transport hook propagates to the caller",
 }
 
 TEST_CASE("tempo hook override receives host tempo changes",
-          "[processor][transport][coverage][phase3]") {
+          "[processor][transport][coverage]") {
     TempoAwareProcessor p;
 
     p.on_host_tempo_changed(120.0);
@@ -147,7 +147,7 @@ TEST_CASE("tempo hook override receives host tempo changes",
 }
 
 TEST_CASE("default tempo hook is a no-op",
-          "[processor][transport][coverage][phase3]") {
+          "[processor][transport][coverage]") {
     PlainProcessor p;
     p.on_host_tempo_changed(60.0);
     p.on_host_tempo_changed(240.0);
@@ -155,7 +155,7 @@ TEST_CASE("default tempo hook is a no-op",
 }
 
 TEST_CASE("exception thrown by tempo hook propagates to the caller",
-          "[processor][transport][coverage][phase3]") {
+          "[processor][transport][coverage]") {
     class ThrowingTempoProcessor : public PlainProcessor {
     public:
         void on_host_tempo_changed(double) override {

--- a/test/test_wasapi_share_modes.cpp
+++ b/test/test_wasapi_share_modes.cpp
@@ -214,10 +214,10 @@ TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_EXCLUSIVE on the same "
     //   result for a probe issued while our own shared-mode device is
     //   still open.
     //
-    // Regression: PR #3004. The previous version of this
-    // test asserted `excl_hr != AUDCLNT_E_DEVICE_IN_USE`, which encodes
-    // the OPPOSITE of MSDN's contract and could fire false CI failures
-    // on perfectly healthy Windows hosts.
+    // Regression coverage: the previous version of this test asserted
+    // `excl_hr != AUDCLNT_E_DEVICE_IN_USE`, which encodes the OPPOSITE of
+    // MSDN's contract and could fire false CI failures on perfectly healthy
+    // Windows hosts.
     //
     // What this test actually proves: an independent exclusive probe
     // can be issued AT ALL while Pulp holds the endpoint shared — i.e.

--- a/test/test_webview_backend_detect.cpp
+++ b/test/test_webview_backend_detect.cpp
@@ -48,10 +48,10 @@ TEST_CASE("WebView backend availability flag matches identifier",
 // When the build option is OFF, the WebView TU is excluded entirely and
 // detect_webview_backend() MUST return "none" so callers can distinguish
 // "this build excluded WebView" from "this OS has no WebView installed"
-// (regression: PR #3016).
+// Regression coverage for that disabled-build contract.
 #if defined(PULP_BUILD_WEBVIEW) && !PULP_BUILD_WEBVIEW
 TEST_CASE("WebView backend reports none when PULP_BUILD_WEBVIEW=OFF "
-          "(regression: PR #3016 review)",
+          "(regression coverage)",
           "[webview][backend-detect][issue-3016]") {
     REQUIRE(pulp::view::detect_webview_backend() == "none");
     REQUIRE_FALSE(pulp::view::webview_backend_available());

--- a/test/test_window_host_repaint.cpp
+++ b/test/test_window_host_repaint.cpp
@@ -58,7 +58,7 @@ bool wait_for(std::atomic<int>& v, int target) {
 } // namespace
 
 TEST_CASE("WindowHost::mark_dirty falls through to repaint with no RenderLoop",
-          "[view][window-host][vblank][slice-16]") {
+          "[view][window-host][vblank]") {
     CountingWindowHost host;
     REQUIRE(host.render_loop() == nullptr);
 
@@ -71,7 +71,7 @@ TEST_CASE("WindowHost::mark_dirty falls through to repaint with no RenderLoop",
 }
 
 TEST_CASE("WindowHost::mark_dirty routes through an attached RenderLoop",
-          "[view][window-host][vblank][slice-16]") {
+          "[view][window-host][vblank]") {
     CountingWindowHost host;
     auto loop = pulp::render::RenderLoop::create_timer_loop();
     REQUIRE(loop != nullptr);
@@ -105,8 +105,8 @@ TEST_CASE("WindowHost::mark_dirty routes through an attached RenderLoop",
 }
 
 TEST_CASE("WindowHost::mark_dirty falls through to repaint when the attached loop is not running",
-          "[view][window-host][vblank][slice-16][issue-2580]") {
-    // #2580: a loop attached but not running has a no-op request_frame(), so
+          "[view][window-host][vblank][issue-2580]") {
+    // A loop attached but not running has a no-op request_frame(), so
     // routing through it would silently drop the dirty update and freeze the UI.
     // mark_dirty() must guard on is_running().
     CountingWindowHost host;
@@ -139,7 +139,7 @@ TEST_CASE("WindowHost::mark_dirty falls through to repaint when the attached loo
 }
 
 TEST_CASE("WindowHost::mark_dirty reverts to repaint after the loop detaches",
-          "[view][window-host][vblank][slice-16]") {
+          "[view][window-host][vblank]") {
     CountingWindowHost host;
     auto loop = pulp::render::RenderLoop::create_timer_loop();
     REQUIRE(loop != nullptr);
@@ -158,7 +158,7 @@ TEST_CASE("WindowHost::mark_dirty reverts to repaint after the loop detaches",
 }
 
 TEST_CASE("View::request_repaint drives the host's vblank dirty path",
-          "[view][window-host][vblank][slice-16]") {
+          "[view][window-host][vblank]") {
     // request_repaint() is the in-tree consumer of the safe-repaint
     // pattern: a widget marks itself dirty and the host coalesces to one
     // repaint on the next vsync instead of the legacy poll-on-a-timer.

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -1198,8 +1198,7 @@ int cmd_ship(const std::vector<std::string>& args) {
     // build tree ready to build the requested `<target>_AUv3` target for an
     // iOS Simulator, connected iOS device, or macOS. Picks the right SDK +
     // the right entitlements template from
-    // `tools/templates/auv3/iOS-{Simulator,Device}-Entitlements.plist.template`
-    // (shipped in PR #2938 alongside the CMake template wiring).
+    // `tools/templates/auv3/iOS-{Simulator,Device}-Entitlements.plist.template`.
     //
     // Usage:
     //   pulp ship auv3-xcodeproj <target>           # iphonesimulator (default)


### PR DESCRIPTION
## Summary
- Batch comment-hygiene cleanup across 35 source/test files.
- Remove transient phase/slice/batch/PR-review breadcrumbs from test names and comments.
- Preserve durable behavior rationale and stable machine-readable tags such as `[coverage]`, `[large]`, and `[vblank]`.

## Review / Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/hotspot_size_guard.py --require-ceiling-reduction`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- focused build/test pass for touched test surfaces
- RepoPrompt workspace loaded with the full touched-file set; AI review was quota-blocked until 5am America/Los_Angeles
- `autoreview --mode branch --base origin/main`: clean
- pre-push full local diff-cover gate: 10,690 tests passed; diff-cover OK

## Notes
This is intentionally one batched comment-hygiene PR to avoid flooding CI with dozens of tiny documentation/comment PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove transient phase/slice/batch/PR-review breadcrumbs from test names and comments to reduce noise and stabilize tags. Preserves regression rationale and stable tags (coverage/large/vblank); no runtime or test behavior changes.

- **Refactors**
  - Scrubbed phase/slice/batch markers from Catch2 test names/tags and comments across tests.
  - Normalized regression notes to "regression coverage" without PR breadcrumbs.
  - Minor comment clarifications in host anticipation headers and `tools/cli/cmd_ship.cpp` (no code paths changed).

<sup>Written for commit da91bcae4a73cb7ec89f5c8f062ddc0d1fd4b6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

