### PR TITLE
docs(tooling): clean CLI and CMake breadcrumb comments

### DIFF
--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -42,7 +42,7 @@ void print_warn(const std::string& msg);
 
 // Phase-marker for `PULP_DEBUG=1` (stderr, timestamped). Silent otherwise.
 // Sprinkle at user-entrypoint phases that could plausibly hang so the next
-// hang report pins itself. See #682.
+// hang report identifies the last reached phase.
 void pulp_debug(const char* phase);
 
 // ── Shell Execution ─────────────────────────────────────────────────────────
@@ -122,24 +122,23 @@ fs::path sdk_cache_path(const std::string& version);
 fs::path local_sdk_cache_path(const std::string& version);
 std::string detect_platform();
 
-// pulp #1814 — sdk_tarball_filename + legacy_unversioned_sdk_tarball_filename
-// live in tools/cli/sdk_cache_paths.hpp so the matching unit test can
-// link them without the cli_common dep chain.
+// SDK tarball filename helpers live in tools/cli/sdk_cache_paths.hpp so
+// the matching unit test can link them without the cli_common dep chain.
 fs::path ensure_sdk(const std::string& version);
 fs::path ensure_checkout_sdk(const fs::path& repo_root, const std::string& version);
 int ensure_checkout_dependencies(const fs::path& repo_root);
 std::string read_pulp_toml_value(const fs::path& project_root, const std::string& key);
 // `read_sdk_version` returns the EFFECTIVE SDK version a build should use.
 // If pulp.toml pins an explicit version, that wins. If pulp.toml writes
-// `sdk_version = "latest"` (pulp #2087 floating mode — the new default
-// for `pulp create`), this returns the newest installed SDK under
+// `sdk_version = "latest"` (floating mode, the `pulp create` default),
+// this returns the newest installed SDK under
 // ~/.pulp/sdk/<x.y.z>/, falling back to PULP_SDK_VERSION when none
 // are installed. Use `read_raw_sdk_version` for the unresolved value.
 std::string read_sdk_version(const fs::path& project_root);
 std::string read_raw_sdk_version(const fs::path& project_root);
 // True when pulp.toml's sdk_version field is the floating marker
-// "latest" (pulp #2087), or absent entirely. Pinned projects (an
-// explicit x.y.z) return false. Used by `pulp upgrade` to skip
+// "latest", or absent entirely. Pinned projects (an explicit x.y.z)
+// return false. Used by `pulp upgrade` to skip
 // pinned-project SDK auto-update and by `pulp doctor --versions`
 // to render the pin status.
 bool is_floating_sdk(const fs::path& project_root);
@@ -179,7 +178,7 @@ bool enforce_project_cli_compatibility(const fs::path& project_root,
                                        const std::string& command_name,
                                        bool allow_unsupported_sdk);
 
-// FetchContent cache preflight (issue #744). Discovers the shared
+// FetchContent cache preflight. Discovers the shared
 // FetchContent source cache for the active project and renders a
 // compact remediation message to stderr if any entry is in a `[!!]`
 // state. Returns true when the caller may proceed, false when the
@@ -250,7 +249,7 @@ struct DoctorCheck {
     std::string fix;
     // Optional checks report remediation advice but don't contribute
     // to the overall doctor exit code when they fail. Used for e.g.
-    // the Google Android CLI accelerator (#355) which is a speedup,
+    // the Google Android CLI accelerator, which is a speedup,
     // not a requirement.
     bool optional = false;
 };
@@ -263,8 +262,8 @@ std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool sta
                                            const std::string& only_filter = {});
 
 // `pulp doctor android` — Android NDK / SDK / emulator checks plus
-// optional Google "Android CLI" detection (#355). Passes the host
-// platform implicitly via #ifdef in the implementation.
+// optional Google "Android CLI" detection. Passes the host platform
+// implicitly via #ifdef in the implementation.
 std::vector<DoctorCheck> run_doctor_android_checks(const std::string& only_filter = {});
 
 // `pulp doctor ios` — Xcode + iOS Simulator checks. macOS-only;

--- a/tools/cli/cli_sdk.cpp
+++ b/tools/cli/cli_sdk.cpp
@@ -56,9 +56,8 @@ fs::path local_sdk_cache_path(const std::string& version) {
     return pulp_home() / "sdk-local" / detect_platform() / version;
 }
 
-// pulp #1814 — sdk_tarball_filename / legacy_unversioned_sdk_tarball_filename
-// live in tools/cli/sdk_cache_paths.cpp so the matching unit test can
-// compile + link them standalone.
+// SDK tarball filename helpers live in tools/cli/sdk_cache_paths.cpp so
+// the matching unit test can compile + link them standalone.
 
 std::string detect_platform() {
 #ifdef __APPLE__
@@ -466,13 +465,13 @@ bool is_floating_sdk(const fs::path& project_root) {
 
 std::string read_sdk_version(const fs::path& project_root) {
     auto version = read_raw_sdk_version(project_root);
-    // Empty (no pulp.toml or no sdk_version key) preserves pre-#2087
+    // Empty (no pulp.toml or no sdk_version key) preserves legacy
     // behavior: fall back to the CLI's own SDK version. This is the
     // "no project at all" path — read_sdk_version is called from
     // contexts that have no project root, and returning newest-installed
     // there would surprise downstream code that expects PULP_SDK_VERSION.
     if (version.empty()) return PULP_SDK_VERSION;
-    // Pulp #2087 floating mode: ONLY an explicit `sdk_version = "latest"`
+    // Floating SDK mode: ONLY an explicit `sdk_version = "latest"`
     // resolves to the newest installed SDK at command time. The CLI's
     // own SDK version is the final fallback when no SDKs are installed
     // under ~/.pulp/sdk/ yet — common on a fresh `curl install.sh`

--- a/tools/cli/cmd_audio_render.cpp
+++ b/tools/cli/cmd_audio_render.cpp
@@ -240,7 +240,7 @@ int cmd_audio_render(const std::vector<std::string>& args) {
         // real offset), applying it too early and defeating the accuracy it was
         // meant to provide. set_parameter reaches every loader (CLAP/VST3 queue
         // it internally at time 0; LV2/AU set it immediately). Sample-accurate
-        // parameter automation is a follow-up; MIDI stays sample-accurate.
+        // parameter automation is not wired here; MIDI stays sample-accurate.
         for (const auto& e : pq.events())
             slot->set_parameter(e.param_id, e.value);
         slot->process(out, in, midi_in, midi_out, kEmptyQueue, n);

--- a/tools/cli/cmd_build.cpp
+++ b/tools/cli/cmd_build.cpp
@@ -13,9 +13,9 @@ namespace {
 // This helper runs the validate step before promoting bundles into
 // `~/Library/Audio/Plug-Ins/...`. It defers to `cmd_validate` for the
 // actual validator orchestration so the policy stays in exactly one
-// place — including the missing-tool advisory wording (#51 / #356).
+// place, including the missing-tool advisory wording.
 //
-// Returns the exit code from cmd_validate. Item 7.4b acceptance #3
+// Returns the exit code from cmd_validate. The missing-auval acceptance case
 // ("when auval is missing from PATH, install of an AU fails with the
 // install hint") is implemented by passing --strict, which upgrades
 // missing-tool advisories to hard failures so we never silently
@@ -141,7 +141,7 @@ int cmd_build(const std::vector<std::string>& args) {
         return 1;
     }
 
-    // FetchContent cache preflight (issue #744). Cheap (<1s on a
+    // FetchContent cache preflight. Cheap (<1s on a
     // typical cache); fails fast with a clear remediation message
     // instead of letting `cmake configure` blow up 200 lines into the
     // log on a dangling symlink. Skipped only when the user has set

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -302,7 +302,7 @@ int cmd_create(const std::vector<std::string>& args) {
     bool ci_mode = false;
     bool in_tree_mode = false;
     bool mpe_mode = false;
-    // Pulp #2087: default new projects to floating-SDK mode (track latest)
+    // Default new projects to floating-SDK mode (track latest)
     // instead of exact-pin. `--pin` opts into exact-version pinning at
     // create-time for users who want reproducibility from day one.
     bool pin_at_create = false;
@@ -471,7 +471,7 @@ int cmd_create(const std::vector<std::string>& args) {
     for (auto& c : checks) {
         if (c.passed) continue;
         // Optional checks are advisory — they surface fix advice but
-        // must not gate `pulp create`. The pulp-mcp row (#2067) is
+        // must not gate `pulp create`. The pulp-mcp row is
         // optional because the binary is only needed for the Claude
         // Code plugin's MCP server, not for creating a Pulp project.
         if (c.optional) {
@@ -743,7 +743,7 @@ int cmd_create(const std::vector<std::string>& args) {
     if (standalone_mode) {
         std::ofstream f(out_dir / "pulp.toml");
         f << "[pulp]\n";
-        // Pulp #2087: floating-SDK default. Unpinned projects track the
+        // Floating-SDK default. Unpinned projects track the
         // latest installed SDK on every rebuild, so users automatically
         // pick up framework fixes without remembering to run an
         // explicit upgrade. `--pin` writes the exact resolved version
@@ -770,7 +770,7 @@ int cmd_create(const std::vector<std::string>& args) {
         }
     }
 
-    // Android target scaffold (experimental — see issue #83)
+    // Android target scaffold (experimental).
     if (want_android) {
         auto android_tmpl_dir = templates_base / "android";
         if (!fs::exists(android_tmpl_dir) && !root.empty()) {
@@ -830,13 +830,13 @@ int cmd_create(const std::vector<std::string>& args) {
 
     // Register the new project in ~/.pulp/projects.json so
     // `pulp doctor --versions` can report per-project skew without an
-    // opt-in disk scan (#552). The registry is a best-effort
+    // opt-in disk scan. The registry is a best-effort
     // diagnostic surface — a failure here is non-fatal and logged only
     // in non-CI mode so we don't clutter CI-driven scaffold output.
     {
         auto reg = pulp::cli::projects_registry::registry_path();
-        // #563: check the write result
-        // rather than blindly printing "Registered" — otherwise a
+        // Check the write result rather than blindly printing
+        // "Registered" — otherwise a
         // failed `write_registry()` in an unwritable $PULP_HOME
         // surfaces as "registered" to the user but the project is
         // missing from the file. Scaffold itself still succeeds

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -31,7 +31,7 @@ namespace {
 // Populate a ProjectEntry for a given root by reading the project's
 // sdk_version (CMakeLists.txt for source-tree projects, pulp.toml
 // otherwise) and cli_min_version. Mirrors active-project version
-// detection for each registered/scanned entry (#552).
+// detection for each registered/scanned entry.
 pulp::cli::version_diag::ProjectEntry make_project_entry(
     const fs::path& root, const std::string& display_name,
     bool scanned)
@@ -133,17 +133,17 @@ int cmd_doctor(const std::vector<std::string>& args) {
     auto root = standalone_mode ? fs::path{} : active_root;
 
     // First positional argument selects a sub-mode for mobile dev-env
-    // checks (#8 / #355). `pulp doctor` (no positional) keeps the
+    // checks. `pulp doctor` (no positional) keeps the
     // existing universal checks; `pulp doctor android` and
     // `pulp doctor ios` are the per-mobile-target lanes.
     std::string mode;  // empty = default
     bool fix_mode = false;
     bool ci_mode = false;
     bool dry_run = false;
-    bool versions_mode = false;   // --versions: issue #499
-    bool validators_mode = false; // --validators: issue #743
-    bool scan_parents = false;    // --scan-parents: issue #552
-    bool caches_mode = false;     // --caches: issue #744
+    bool versions_mode = false;   // --versions: CLI/SDK skew report
+    bool validators_mode = false; // --validators: format-validator discovery
+    bool scan_parents = false;    // --scan-parents: ancestor project audit
+    bool caches_mode = false;     // --caches: shared FetchContent cache audit
     bool au_cache_mode = false;   // --au-cache: refresh macOS AU registrar
     bool json_mode = false;       // --json (works with --versions and --caches)
     bool list_mode = false;       // --list / `pulp doctor list`
@@ -267,7 +267,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
 #endif
     }
 
-    // `pulp doctor --caches` (issue #744) — discovery + healing for the
+    // `pulp doctor --caches` — discovery + healing for the
     // shared FetchContent cache (`~/Library/Caches/Pulp/fetchcontent-src`
     // on macOS, equivalent paths on Linux/Windows). Short-circuits the
     // rest of the doctor pipeline for the same reason --versions does:
@@ -337,7 +337,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
         return rc;
     }
 
-    // `pulp doctor --validators` (issue #743) — discover plugin-format
+    // `pulp doctor --validators` — discover plugin-format
     // validators (auval / pluginval / clap-validator), surface broken
     // copies (signature-detached, ripped from a .app bundle, etc.) and
     // optionally heal user-owned breakage with `--fix`. Mirrors the
@@ -395,7 +395,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
         return vd::compute_exit_code(reports);
     }
 
-    // `pulp doctor --versions` is a dedicated diagnostic (#499). It
+    // `pulp doctor --versions` is a dedicated version-skew diagnostic. It
     // short-circuits the rest of the doctor pipeline on purpose — skew
     // warnings are advisory and must not gate the environment-readiness
     // exit code, so mixing the two would just confuse scripts that
@@ -413,7 +413,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
         report.plugin = pulp::cli::version_diag::read_plugin_version(plugin_json);
         // Pick up the plugin's declared `min_cli_version` so the
         // diagnostic surfaces plugin ↔ CLI skew alongside the existing
-        // project ↔ CLI checks (#551).
+        // project ↔ CLI checks.
         report.plugin_min_cli =
             pulp::cli::version_diag::read_plugin_min_cli_version(plugin_json);
 
@@ -435,7 +435,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
                 pulp::cli::version_diag::read_project_cli_min_version(active_root);
         }
 
-        // Per-project registry (#552). The registry is authoritative;
+        // Per-project registry. The registry is authoritative;
         // only `pulp projects add/remove` and `pulp create` mutate it.
         // We dedupe against the active project so it isn't shown twice
         // in the diagnostic.
@@ -481,7 +481,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
             (void)pulp::cli::version_diag::render_report(report);
         }
 
-        // Pulp #2087: append local + remote SDK availability so users
+        // Append local + remote SDK availability so users
         // see at-a-glance whether they're behind. JSON consumers get
         // the same data via a stable trailing object, separate from
         // the existing report shape so older tooling that parses the
@@ -610,8 +610,8 @@ int cmd_doctor(const std::vector<std::string>& args) {
         } else {
             // Optional checks report advice but don't count toward
             // fail_count, so `pulp doctor android` returns 0 when
-            // only optional accelerators (e.g. Google Android CLI,
-            // #355) are missing.
+            // only optional accelerators (e.g. Google Android CLI)
+            // are missing.
             if (c.optional) {
                 ++optional_skipped;
                 if (!ci_mode) {

--- a/tools/cli/cmd_macos.cpp
+++ b/tools/cli/cmd_macos.cpp
@@ -2,7 +2,7 @@
 //
 // Operator surface for retargeting JUST the macOS leg of a PR's CI to a
 // different runner pool, without disturbing the matrix-bound Linux/Windows
-// legs. Backed by .github/workflows/build-macos.yml (see pulp task #20).
+// legs. Backed by .github/workflows/build-macos.yml.
 //
 // Subcommands:
 //   pulp macos retarget --pr N --to <local|namespace|github-hosted>

--- a/tools/cli/cmd_misc.cpp
+++ b/tools/cli/cmd_misc.cpp
@@ -189,7 +189,7 @@ int cmd_test(const std::vector<std::string>& args) {
 
     auto build_dir = project_root / "build";
     if (!fs::exists(build_dir / "CMakeCache.txt")) {
-        // FetchContent cache preflight (issue #744) — same gate cmd_build
+        // FetchContent cache preflight — same gate cmd_build
         // applies. Catching it here too means `pulp test` cold-starts
         // produce the same fail-fast remediation message instead of
         // tunneling through cmd_build's stdout. cmd_build runs its own
@@ -577,13 +577,13 @@ int cmd_cache(const std::vector<std::string>& args) {
         const std::string version = PULP_SDK_VERSION;
 
         // Versioned cache filename — `pulp-sdk-v<version>-<platform>.tar.gz`.
-        // The version pin in the filename is the structural fix for pulp
-        // #1814: a stale tarball from a prior release cannot silently
-        // shadow a fresh download because the filename lookup misses.
+        // The version pin in the filename means a stale tarball from a
+        // prior release cannot silently shadow a fresh download because
+        // the filename lookup misses.
         std::string sdk_tarball_name = pulp::cli::sdk_tarball_filename(version, platform);
         auto sdk_cache = cache_dir / sdk_tarball_name;
 
-        // Best-effort cleanup of the pre-#1814 unversioned tarball so it
+        // Best-effort cleanup of the legacy unversioned tarball so it
         // doesn't sit in ~/.pulp/cache/ forever eating ~20 MB. Skipped
         // silently on any error — this is purely housekeeping.
         {

--- a/tools/cli/cmd_pr.cpp
+++ b/tools/cli/cmd_pr.cpp
@@ -4,7 +4,7 @@
 // workflow is `shipyard` (the default) and Shipyard is installed.
 // Shipyard is Pulp's single-source-of-truth ship orchestrator; keeping
 // a parallel native implementation in two tools is how drift starts.
-// See issue #352.
+// Keep this wrapper thin so the Shipyard implementation remains authoritative.
 //
 // If Shipyard is unavailable while the shipyard workflow is selected,
 // print a concise install/switch guide and exit 2. `--workflow github`

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -25,7 +25,7 @@ namespace {
 
 using namespace pulp_cli::project_detail;
 
-// Pulp #2087: `pulp project unpin` removes the SDK pin from pulp.toml
+// `pulp project unpin` removes the SDK pin from pulp.toml
 // so the project goes back to floating mode and tracks the latest
 // installed SDK on every rebuild. Sibling of `pin` (= `bump`).
 //
@@ -139,7 +139,7 @@ int cmd_project(const std::vector<std::string>& args) {
     const auto& sub = args[0];
     std::vector<std::string> rest(args.begin() + 1, args.end());
 
-    // Pulp #2087: `pin` is the primary, intuitive name for what this
+    // `pin` is the primary, intuitive name for what this
     // command does. `bump` predates the rename and stays as a
     // deprecated alias so existing scripts and skill docs keep working
     // through one minor release. New docs and skill examples should

--- a/tools/cli/cmd_run.cpp
+++ b/tools/cli/cmd_run.cpp
@@ -4,7 +4,7 @@
 // path, supports headless / screenshot / frames / watch flags so any Pulp
 // plugin's standalone can be auto-validated in CI without a real window.
 //
-// Issue #914: surface --headless / --screenshot / --frames / --watch.
+// Surfaces --headless / --screenshot / --frames / --watch.
 // The standalone-side wiring (HeadlessHost, validation_harness,
 // pulp-screenshot) is already in place — this file plumbs the flags
 // through to the launched binary via both forwarded args AND env vars,

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -39,8 +39,8 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     bool check_only = false;
     bool notes_only = false;
     bool notes_json = false;
-    // Pulp #2087: `pulp upgrade` updates BOTH CLI and SDK by default.
-    // `--cli-only` keeps the pre-#2087 behavior for the rare case
+    // `pulp upgrade` updates BOTH CLI and SDK by default.
+    // `--cli-only` keeps the legacy CLI-only behavior for the rare case
     // where a user wants a newer CLI paired with their current SDK
     // (e.g., they want a CLI bug fix without touching project pins).
     bool cli_only = false;
@@ -137,7 +137,7 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     // Reports what the banner would say. Uses uc::resolve_latest_with_persist
     // so a stale or empty cache triggers a synchronous refresh. The
     // on-every-invocation detached refresh in pulp_cli.cpp gets killed when
-    // short-lived commands exit before curl completes (#1599), so we
+    // short-lived commands exit before curl completes, so we
     // cannot rely on it. The user is explicitly asking about updates here,
     // so a 1–2s blocking GitHub call is the right tradeoff.
     if (check_only) {
@@ -194,7 +194,7 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     // Resolve the latest version. resolve_latest_with_persist handles the
     // empty/stale/fresh cases and writes the cache on a successful fetch
     // so the next invocation isn't stuck behind the unreliable detached
-    // background refresh (#1599).
+    // background refresh.
     std::string latest;
     if (target_version.empty()) {
         uc::GitHubReleasesFetcher fetcher;
@@ -342,7 +342,7 @@ int cmd_upgrade(const std::vector<std::string>& args) {
                   << "` to see what changed.\n";
     }
 
-    // Pulp #2087: by default, also install the matching SDK so the
+    // By default, also install the matching SDK so the
     // CLI and SDK stay coherent. The CLI's own `sdk install` flow
     // handles caching, idempotence, and the GitHub-releases fetch.
     //

--- a/tools/cli/fetchcontent_cache.cpp
+++ b/tools/cli/fetchcontent_cache.cpp
@@ -1,6 +1,6 @@
 // fetchcontent_cache.cpp — Implementation of the discovery and healing
 // helpers powering `pulp doctor --caches[ --fix]` and the cache
-// preflight inside `pulp build` / `pulp test`. Issue #744.
+// preflight inside `pulp build` / `pulp test`.
 //
 // Pure-logic core + a small set of narrow filesystem helpers. Only
 // `make_real_env` and `apply_fixes` interact with the disk; everything

--- a/tools/cli/fetchcontent_cache.hpp
+++ b/tools/cli/fetchcontent_cache.hpp
@@ -4,7 +4,7 @@
 // on Windows). Powers `pulp doctor --caches[ --fix]` and the cache
 // preflight inside `pulp build` / `pulp test`.
 //
-// Issue #744. Mirrors the pattern used by `version_diag` and
+// Mirrors the pattern used by `version_diag` and
 // `projects_registry`: pure-logic core with an injected `DiscoveryEnv`
 // so unit tests don't need to touch the developer's real cache.
 //

--- a/tools/cli/validator_discovery.cpp
+++ b/tools/cli/validator_discovery.cpp
@@ -53,7 +53,7 @@ constexpr std::array kValidators = {
                   "cargo install clap-validator"},
 };
 
-// Build the priority list for one tool. Order matches the spec in #743:
+// Build the priority list for one tool. Order matches the validator spec:
 //   1. system binary path (e.g. /usr/bin/auval)
 //   2. cask app-bundle binary (e.g. /Applications/pluginval.app/...)
 //   3. PATH lookup (deferred to env.resolve_in_path so tests stay hermetic)
@@ -72,7 +72,7 @@ std::vector<fs::path> validator_priority_paths(const std::string& tool,
     } else if (tool == "pluginval") {
         // /usr/local/bin/pluginval is the historical Homebrew formula
         // path — it's also the path most affected by the rip-from-bundle
-        // failure mode #743 was filed for, so it stays first.
+        // failure mode, so it stays first.
         out.push_back("/usr/local/bin/pluginval");
         out.push_back("/opt/homebrew/bin/pluginval");
         out.push_back("/Applications/pluginval.app/Contents/MacOS/pluginval");
@@ -133,7 +133,7 @@ DiscoveryEnv make_default_env() {
         // Windows ownership model differs; treat everything as
         // user-owned so the safety boundary defaults to the more
         // forgiving branch. Discovery on Windows is currently
-        // out-of-scope per #743 anyway (filed-separately note).
+        // out of scope for this validator-discovery pass.
         return 0;
 #else
         struct stat st{};
@@ -156,7 +156,7 @@ DiscoveryEnv make_default_env() {
         verdict_line.clear();
 #if defined(__APPLE__)
         (void)tool_name;
-        // The failure mode this diagnostic targets (issue #743) is:
+        // The failure mode this diagnostic targets is:
         // a binary copied OUT of its .app bundle (`/usr/local/bin/pluginval`
         // copied from `/Applications/pluginval.app/Contents/MacOS/`)
         // retains a signature that references peer files inside the

--- a/tools/cli/validator_discovery.hpp
+++ b/tools/cli/validator_discovery.hpp
@@ -1,6 +1,6 @@
 // validator_discovery.hpp — Discovery + healing for plugin-format validators
 //
-// Issue #743: `pulp validate` wraps three third-party tools — auval (Xcode),
+// `pulp validate` wraps three third-party tools — auval (Xcode),
 // pluginval (Homebrew cask), and clap-validator (cargo install). One failure
 // mode observed in the wild on 2026-04-24: a validator binary copied out of
 // its `.app` bundle into `/usr/local/bin` retains a code signature that
@@ -172,7 +172,7 @@ FixOutcome apply_fixes(std::vector<ValidatorReport>& reports, bool dry_run);
 
 // Render the report set as a human-readable block. Returns the rendered
 // text (so callers can write it to stdout/stderr or capture it for tests).
-// Mirrors the format spec'd in #743:
+// Mirrors the validator-report format:
 //
 //   ✓ pluginval: /Applications/pluginval.app/... (signed, notarized)
 //   ✗ pluginval: /usr/local/bin/pluginval — broken signature (...). Auto-fixable.
@@ -190,7 +190,7 @@ std::string render_report(const std::vector<ValidatorReport>& reports,
 int compute_exit_code(const std::vector<ValidatorReport>& reports);
 
 // True iff the report set contains at least one Broken entry. Used by
-// the `pulp validate` preflight (#743) to decide whether to abort
+// the `pulp validate` preflight to decide whether to abort
 // before launching the validator and risking the SIGKILL-by-amfid
 // silent-fail mode.
 bool has_broken_validator(const std::vector<ValidatorReport>& reports);

--- a/tools/cli/version_diag.hpp
+++ b/tools/cli/version_diag.hpp
@@ -46,7 +46,7 @@ Semver read_plugin_version(const fs::path& plugin_json_path);
 
 // Parse ".claude-plugin/plugin.json" -> min_cli_version field. Returns
 // empty Semver if the field is absent — older plugin builds shipped
-// without it, so this is forward-compatible by design (#551).
+// without it, so this is forward-compatible by design.
 Semver read_plugin_min_cli_version(const fs::path& plugin_json_path);
 
 // Locate the plugin.json the diagnostic should report on, in order:
@@ -90,7 +90,7 @@ ExecutionPreflight analyze_execution_preflight(const Semver& cli,
 // skew lines in `pulp doctor --versions`. Populated by cmd_doctor from
 // `~/.pulp/projects.json` (or the `--scan-parents` ancestor walk) and
 // fed into VersionReport::analyze() so each project contributes its
-// own skew findings (#552).
+// own skew findings.
 struct ProjectEntry {
     fs::path path;               // canonical project root
     std::string name;            // display name (directory basename or custom)
@@ -106,14 +106,14 @@ struct ProjectEntry {
 struct VersionReport {
     Semver cli;                  // PULP_SDK_VERSION of the running binary
     Semver plugin;               // .claude-plugin/plugin.json "version"
-    Semver plugin_min_cli;       // .claude-plugin/plugin.json "min_cli_version" (#551)
+    Semver plugin_min_cli;       // .claude-plugin/plugin.json "min_cli_version"
     Semver project_sdk;          // project's own CMake/pulp.toml sdk_version
     Semver project_cli_min;      // project's pulp.toml cli_min_version
     fs::path project_root;       // for report lines
     fs::path plugin_json_path;   // for report lines
 
     // Other registered projects (from ~/.pulp/projects.json) plus any
-    // ancestor projects surfaced by `--scan-parents`. See issue #552.
+    // ancestor projects surfaced by `--scan-parents`.
     std::vector<ProjectEntry> projects;
 
     // Analyse and return user-visible findings. Rules:
@@ -134,7 +134,7 @@ int render_report(const VersionReport& report);
 // Render the same report as a single JSON object to stdout. The shape
 // is stable enough for scripts to parse (see docs/reference/cli.md).
 // Always returns 0 — the JSON lane is a pure data surface and mirrors
-// the human lane's advisory-only posture. Issue #552.
+// the human lane's advisory-only posture.
 int render_report_json(const VersionReport& report);
 
 }  // namespace pulp::cli::version_diag

--- a/tools/cmake/PulpDependencies.cmake
+++ b/tools/cmake/PulpDependencies.cmake
@@ -20,9 +20,9 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ${PULP_FETCHCONTENT_UPDATES_DISCONNECTED})
 # CHOC: header-only C++ utilities (ISC license)
 # Used for: JS engine abstraction, MIDI utilities, WebView (drag-and-drop)
 #
-# ⚠ INTERIM FORK PIN — see pulp #3619. Temporarily pinned to a fork tag that
-# adds WebView file drag-and-drop (window.chocStartFileDrag([...]) +
-# `chocfilesdropped` event) — the PoC from upstream Tracktion/choc#64. The fork
+# ⚠ INTERIM FORK PIN — temporarily pinned to a fork tag that adds WebView
+# file drag-and-drop (window.chocStartFileDrag([...]) + `chocfilesdropped`
+# event) — the PoC from upstream Tracktion/choc#64. The fork
 # is upstream f0f5cdf5a938 + 5 commits, 0 behind, so reverting is a one-line
 # repoint. WHEN choc#64 MERGES UPSTREAM, restore:
 #     GIT_REPOSITORY https://github.com/Tracktion/choc.git
@@ -32,7 +32,7 @@ pulp_register_fetchcontent_source(choc REF df148a41a6bc9cbd67727532c4d5c9d8aa6d5
 FetchContent_Declare(
     choc
     GIT_REPOSITORY https://github.com/danielraffel/choc.git
-    GIT_TAG pulp-webview-dnd-poc1  # df148a41 — fork of Tracktion/choc#64 PoC; see pulp #3619
+    GIT_TAG pulp-webview-dnd-poc1  # df148a41 — fork of Tracktion/choc#64 PoC
 )
 FetchContent_MakeAvailable(choc)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPatchChoc.cmake)
@@ -41,8 +41,8 @@ pulp_patch_choc_v8("${choc_SOURCE_DIR}")
 # WebGPU (Dawn) — cross-platform GPU abstraction (BSD-3-Clause)
 # Uses eliemichel/WebGPU-distribution for CMake-friendly integration
 # On Android + iOS, Dawn is bundled in Skia's pre-built libs — skip
-# FetchContent. wgpu-native doesn't publish iOS prebuilds (tracked in
-# #359); pulp's render path is Dawn-only whenever Skia is the backend
+# FetchContent. wgpu-native doesn't publish iOS prebuilds; pulp's
+# render path is Dawn-only whenever Skia is the backend
 # anyway (pulp::render::GpuSurface uses Dawn's C++ API under PULP_HAS_SKIA).
 if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     pulp_register_fetchcontent_source(webgpu REF 17dcd42a7683355e7a40ac4e97e77f36dff5b5ab)
@@ -165,8 +165,8 @@ if(PULP_ENABLE_GPU)
         # On Android + iOS, Dawn is bundled in Skia's pre-built libs.
         # Set PULP_HAS_WEBGPU so the render subsystem builds without
         # needing the desktop wgpu-native FetchContent path. iOS in
-        # particular has no wgpu-native prebuild and won't until #359
-        # is resolved — Dawn is the only viable backend, which matches
+        # particular has no wgpu-native prebuild yet — Dawn is the only
+        # viable backend, which matches
         # how pulp::render uses Dawn when PULP_HAS_SKIA is set.
         if(ANDROID OR IOS)
             set(PULP_HAS_WEBGPU TRUE)
@@ -185,7 +185,7 @@ if(PULP_ENABLE_GPU)
     endif()
 endif()
 
-# pulp-internal #62 — LOUD perf-regression guard. PULP_ENABLE_GPU=ON
+# LOUD perf-regression guard. PULP_ENABLE_GPU=ON
 # but no Skia found silently falls back to CoreGraphics CPU rendering.
 # That fallback is ~5-10× slower than Skia/Dawn for live JS-driven UIs
 # (Spectr's editor.js drag went from 7% CPU on Skia to 100% CPU on CG
@@ -222,10 +222,10 @@ if(PULP_ENABLE_GPU AND NOT PULP_HAS_SKIA)
         "  ╚══════════════════════════════════════════════════════════════════════╝")
 endif()
 
-# SDK-release safety net for pulp #1817. The release workflow turns this
-# option ON via -DPULP_REQUIRE_GPU_FOR_SDK=ON so a missing Skia tarball
-# is a hard configure error instead of a silent CG-only build that ships
-# downstream to every SDK consumer.
+# SDK-release safety net. The release workflow turns this option ON via
+# -DPULP_REQUIRE_GPU_FOR_SDK=ON so a missing Skia tarball is a hard
+# configure error instead of a silent CG-only build that ships downstream
+# to every SDK consumer.
 if(PULP_ENABLE_GPU AND PULP_REQUIRE_GPU_FOR_SDK AND NOT PULP_HAS_SKIA)
     message(FATAL_ERROR
         "PULP_REQUIRE_GPU_FOR_SDK=ON but Skia binaries were not found at "
@@ -454,7 +454,7 @@ endif()
 # `git ls-remote https://github.com/google/highway.git refs/tags/1.2.0`).
 # Pinning the SHA instead of the tag avoids intermittent
 # `fatal: invalid reference: 1.2.0` failures when GIT_SHALLOW combines
-# with tag-name resolution under load (Pulp #1930). SHA pins are also
+# with tag-name resolution under load. SHA pins are also
 # more cache-friendly: FetchContent's UPDATE_DISCONNECTED check sees a
 # stable ref and skips the re-fetch on every reconfigure.
 set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)

--- a/tools/cmake/PulpEmbedData.cmake
+++ b/tools/cmake/PulpEmbedData.cmake
@@ -1,6 +1,6 @@
 # PulpEmbedData.cmake — `pulp_add_binary_data()` extracted into a standalone
 # include so it can run *before* the Pulp targets exist (e.g. inside
-# core/canvas/CMakeLists.txt — see #932 bundled fonts).
+# core/canvas/CMakeLists.txt for bundled fonts).
 #
 # `PulpUtils.cmake` itself fails fast unless `pulp::format` already exists,
 # because most of its other helpers (pulp_add_plugin / pulp_add_app) wire
@@ -10,7 +10,7 @@
 # file as well, so the public surface is unchanged: callers continue to use
 # `pulp_add_binary_data(...)` and the function definition is identical.
 #
-# Implementation notes (issue #898):
+# Implementation notes for binary-data embedding:
 #   * The legacy implementation walked a hex-encoded file inside a CMake
 #     `while()` loop, building the C-array initializer with repeated
 #     `string(APPEND)`. CMake string append on a growing string is O(n²);

--- a/tools/cmake/PulpInstallRules.cmake
+++ b/tools/cmake/PulpInstallRules.cmake
@@ -65,7 +65,7 @@ if(TARGET pulp-inspect)
     list(APPEND PULP_SDK_TARGETS pulp-inspect)
 endif()
 
-# pulp-canvas links pulp-bundled-fonts privately when Skia is on (#932).
+# pulp-canvas links pulp-bundled-fonts privately when Skia is on.
 # CMake exports the canvas target through PulpTargets, and refuses unless
 # every PRIVATE-linked dependency is also in the export set.
 if(TARGET pulp-bundled-fonts)
@@ -181,7 +181,7 @@ endforeach()
 file(WRITE "${CMAKE_BINARY_DIR}/version.txt" "${PROJECT_VERSION}\n")
 install(FILES "${CMAKE_BINARY_DIR}/version.txt" DESTINATION ".")
 
-# SDK build-type marker (pulp-internal task #35).
+# SDK build-type marker.
 #
 # Records the CMAKE_BUILD_TYPE the SDK was built with so PulpConfig.cmake
 # can refuse — or at least loudly warn — when a downstream plugin tries
@@ -376,7 +376,7 @@ if(PULP_HAS_WEBGPU AND DEFINED WEBGPU_RUNTIME_LIB AND TARGET webgpu)
     # guard `if(DEFINED WGPU_IMPLIB ...)` always evaluated to FALSE and
     # the .lib was silently skipped from the SDK. That's why scaffolded
     # Windows plugins fail with "IMPORTED_IMPLIB not set for imported
-    # target 'webgpu'" (see #94).
+    # target 'webgpu'".
     #
     # Read the path from the imported target directly. Prefer the
     # config-specific property (some WebGPU-distribution versions only

--- a/tools/cmake/PulpSdkGuards.cmake
+++ b/tools/cmake/PulpSdkGuards.cmake
@@ -5,7 +5,7 @@
 # the fixture `test/cmake/test_debug_sdk_guard.cmake` can locate it
 # by its regex.
 
-# Debug-SDK perf-killer guard (pulp-internal task #35).
+# Debug-SDK perf-killer guard.
 #
 # A Pulp SDK that was itself BUILT with CMAKE_BUILD_TYPE=Debug ships
 # debug-mode Skia, debug-mode audio framework, and debug-mode JS

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -570,7 +570,7 @@ function(pulp_add_plugin target)
     # Plugins still pull this in via target_compile_definitions on Core,
     # so all linked format adapters see the same defs. Explicit MIN/MAX
     # args override the derived values. See processor.hpp:view_size() and
-    # the import-design skill. Issue #2784.
+    # the import-design skill.
     if(PLUGIN_DESIGN_WIDTH AND PLUGIN_DESIGN_HEIGHT)
         if(NOT PLUGIN_DESIGN_MIN_WIDTH)
             set(PLUGIN_DESIGN_MIN_WIDTH 0)

--- a/tools/cmake/PulpV8Windows.cmake
+++ b/tools/cmake/PulpV8Windows.cmake
@@ -1,5 +1,5 @@
 # PulpV8Windows.cmake — Windows V8-consumer ABI contract for the sealed
-# v8-builder drop-in (task #27-pulp).
+# v8-builder drop-in.
 #
 # The sealed Windows v8.dll (v8-builder, v8-15.1.27) is built — by deliberate,
 # documented decision in v8-builder/build-v8.py:win_gn_args() — with:


### PR DESCRIPTION
## Summary
- Cleans stale internal issue/task breadcrumbs from CLI and CMake comments in one tooling-area batch.
- Keeps behavior, runtime/user-facing strings, diagnostics, and external upstream references unchanged.
- Rebases on latest origin/main after #5036 landed.

## Scope
- 23 tooling files touched under tools/cli and tools/cmake.
- Comment-only edits: replaces old issue-number archaeology with stable rationale or removes redundant breadcrumbs.
- Intentional retained references include user-facing upgrade output/help strings and external Tracktion/choc#64 upstream notes.

## Validation
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD
- RepoPrompt selection created for all changed files; Oracle review was blocked by weekly quota reset at 5am America/Los_Angeles.
- Claude autoreview was blocked by the same quota/rate limit.
- Codex autoreview clean: no accepted/actionable findings.
- Pre-push full local diff-cover path passed before the final commit-message-only trailer amend/rebase: 10,690/10,690 tests passed, 0 failed, total real time 1341.02s.
- Final push ran skill/version/compat/node-ABI/hotspot gates clean; diff-cover rerun skipped because code tree was unchanged from the passing full local run except for commit trailers/rebase onto #5036.

## Notes
- Skill-Update skip trailers are present for cli-maintenance and upgrade because this is comment-only and does not change CLI command behavior, docs contract, or upgrade behavior.
- This PR is intentionally batched; it avoids opening per-file/per-area micro PRs for comment hygiene.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up CLI and CMake comments by removing stale issue breadcrumbs and clarifying wording. No code, behavior, or user-facing changes.

- **Refactors**
  - Comment-only edits across 23 files under `tools/cli` and `tools/cmake`.
  - Replaced issue-number breadcrumbs with stable rationale; kept external `Tracktion/choc#64` reference where relevant.
  - Left runtime behavior, help text, diagnostics, and upgrade paths unchanged.

<sup>Written for commit ee52fec315561c3ceb02c2272aee7a7300d3e02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

