### PR TITLE
docs(test): clean coverage phase tag breadcrumbs

### DIFF
--- a/test/test_background_scanner.cpp
+++ b/test/test_background_scanner.cpp
@@ -89,7 +89,7 @@ TEST_CASE("BackgroundScanner: empty worker still completes",
 }
 
 TEST_CASE("BackgroundScanner: worker may finish without completion callback",
-          "[host][bg-scan][coverage][phase3]") {
+          "[host][bg-scan][coverage]") {
     BackgroundScanner bs;
     std::atomic<bool> worker_ran{false};
     std::atomic<int> progress_calls{0};
@@ -124,7 +124,7 @@ TEST_CASE("BackgroundScanner: idle cancel and join are no-ops",
 }
 
 TEST_CASE("BackgroundScanner: destructor requests cancel and joins active worker",
-          "[host][bg-scan][coverage][phase3]") {
+          "[host][bg-scan][coverage]") {
     std::atomic<bool> started{false};
     std::atomic<bool> worker_saw_cancel{false};
     std::atomic<bool> completed{false};

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -314,7 +314,7 @@ TEST_CASE("RecordingCanvas transforms", "[canvas]") {
 }
 
 TEST_CASE("RecordingCanvas restores save stack and transform snapshots",
-          "[canvas][coverage][phase3-canvas]") {
+          "[canvas][coverage]") {
     RecordingCanvas canvas;
 
     canvas.translate(5.0f, 7.0f);
@@ -346,7 +346,7 @@ TEST_CASE("RecordingCanvas restores save stack and transform snapshots",
 }
 
 TEST_CASE("RecordingCanvas captures Canvas2D state and media command payloads",
-          "[canvas][coverage][phase3-canvas]") {
+          "[canvas][coverage]") {
     RecordingCanvas canvas;
     const float dash[] = {2.0f, 4.0f, 6.0f};
     const uint8_t pixels[] = {
@@ -414,7 +414,7 @@ TEST_CASE("RecordingCanvas captures Canvas2D state and media command payloads",
 }
 
 TEST_CASE("RecordingCanvas captures remaining path primitive payloads",
-          "[canvas][coverage][phase3-canvas]") {
+          "[canvas][coverage]") {
     RecordingCanvas canvas;
 
     canvas.begin_path();

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -109,7 +109,7 @@ TEST_CASE("CodeEditor insert appends in read-only fallback mode",
 }
 
 TEST_CASE("CodeEditor marker API is a stable no-op in native fallback mode",
-          "[gui][code-editor][coverage][phase3]") {
+          "[gui][code-editor][coverage]") {
     CodeEditor editor;
     editor.set_text("alpha\nbeta");
     editor.set_markers({{1, "warn"}, {2, "error"}});

--- a/test/test_gpu_render_time.cpp
+++ b/test/test_gpu_render_time.cpp
@@ -153,7 +153,7 @@ TEST_CASE("RenderPassManager frame GPU time is independent of per-pass GPU time"
 }
 
 TEST_CASE("RenderPassManager handles empty pass endings and disabled budgets",
-          "[render][gpu-render-time][render-pass][coverage][phase3-large]") {
+          "[render][gpu-render-time][render-pass][coverage]") {
     RenderPassManager rpm;
     REQUIRE(rpm.budget() == 16.67f);
     REQUIRE(rpm.frame_count() == 0);

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -322,7 +322,7 @@ TEST_CASE("set_pass_gpu_time rejects a negative duration",
 }
 
 TEST_CASE("RenderPassManager begin_frame clears stale frame state",
-          "[render][gpu-timestamps][coverage][phase3]") {
+          "[render][gpu-timestamps][coverage]") {
     RenderPassManager rpm;
     rpm.set_budget(1.0f);
     rpm.begin_frame();

--- a/test/test_host_regression.cpp
+++ b/test/test_host_regression.cpp
@@ -333,7 +333,7 @@ TEST_CASE("PluginScanner VST3 bundle with well-formed moduleinfo.json yields FUI
 }
 
 TEST_CASE("PluginScanner VST3 moduleinfo raw CID bytes normalize to lowercase hex",
-          "[host][scanner][regression][codecov][phase3]") {
+          "[host][scanner][regression][codecov]") {
     ScratchDir scratch("vst3-raw-cid");
 
     const std::string body = R"({
@@ -370,7 +370,7 @@ TEST_CASE("PluginScanner VST3 moduleinfo raw CID bytes normalize to lowercase he
 }
 
 TEST_CASE("PluginScanner VST3 moduleinfo skips unusable class records",
-          "[host][scanner][regression][codecov][phase3]") {
+          "[host][scanner][regression][codecov]") {
     ScratchDir scratch("vst3-unusable-classes");
 
     const std::string body = R"({
@@ -638,7 +638,7 @@ TEST_CASE("ScanOptions progress callback fires at least once per format lane",
 }
 
 TEST_CASE("PluginScanner progress callback reports hermetic extra-path lanes",
-          "[host][scanner][coverage][phase3]") {
+          "[host][scanner][coverage]") {
     ScratchDir scratch("scan-progress-hermetic");
 
     const std::string ttl_body =
@@ -849,7 +849,7 @@ TEST_CASE("ParameterEventQueue has fixed capacity and drops overflow without all
 }
 
 TEST_CASE("ParameterEventQueue accepts rvalue pushes and exposes const iteration",
-          "[host][automation][coverage][phase3]") {
+          "[host][automation][coverage]") {
     pulp::host::ParameterEventQueue queue;
     queue.push(pulp::host::ParameterEvent{0x10, 5, 0.5f});
     queue.push(pulp::host::ParameterEvent{0x11, 5, 0.6f});

--- a/test/test_hosted_editor.cpp
+++ b/test/test_hosted_editor.cpp
@@ -122,7 +122,7 @@ TEST_CASE("legacy slot is wrapped through the compat path",
 }
 
 TEST_CASE("legacy compat path handles null editor handles and null destroys",
-          "[host][hosted-editor][coverage][phase3]") {
+          "[host][hosted-editor][coverage]") {
     BrokenLegacySlot broken;
     auto ed = broken.create_hosted_editor(nullptr);
     REQUIRE(ed == nullptr);

--- a/test/test_image_convolution.cpp
+++ b/test/test_image_convolution.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Identity kernel supports explicit row stride", "[canvas][convolution]
 }
 
 TEST_CASE("Convolution preserves padded row stride bytes",
-          "[canvas][convolution][coverage][phase3-large]") {
+          "[canvas][convolution][coverage]") {
     ImageConvolutionKernel identity(1);
     identity.set(0, 0, 1.0f);
 
@@ -218,7 +218,7 @@ TEST_CASE("Standard kernel weights cover blur edge and emboss paths",
 }
 
 TEST_CASE("Standard kernels process a single pixel via edge clamping",
-          "[canvas][convolution][coverage][phase3-github]") {
+          "[canvas][convolution][coverage]") {
     auto pixel = make_solid_image(1, 1, 20, 40, 60);
     ImageConvolutionKernel::gaussian_blur_3().apply(pixel.data(), 1, 1);
     REQUIRE(pixel[0] == 20);
@@ -234,7 +234,7 @@ TEST_CASE("Standard kernels process a single pixel via edge clamping",
 }
 
 TEST_CASE("Single-pixel convolution clamps repeated edge samples",
-          "[canvas][convolution][coverage][phase3-large]") {
+          "[canvas][convolution][coverage]") {
     uint8_t sharpened[4] = {40, 80, 120, 77};
     auto sharpen = ImageConvolutionKernel::sharpen();
     sharpen.apply(sharpened, 1, 1);

--- a/test/test_image_view_cache.cpp
+++ b/test/test_image_view_cache.cpp
@@ -255,7 +255,7 @@ TEST_CASE("object-position: percentage offsets the centred dst",
 }
 
 TEST_CASE("object-fit unknown keyword falls back to fill",
-          "[widgets][image][object-fit][coverage][phase3]") {
+          "[widgets][image][object-fit][coverage]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 100, "stretchy");
@@ -274,7 +274,7 @@ TEST_CASE("object-fit unknown keyword falls back to fill",
 }
 
 TEST_CASE("object-position: length tokens offset by slack",
-          "[widgets][image][object-position][coverage][phase3]") {
+          "[widgets][image][object-position][coverage]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "25px 10px");
@@ -291,7 +291,7 @@ TEST_CASE("object-position: length tokens offset by slack",
 }
 
 TEST_CASE("object-position: malformed numeric tokens fall back to center",
-          "[widgets][image][object-position][coverage][phase3]") {
+          "[widgets][image][object-position][coverage]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "25pxjunk 10em");
@@ -308,7 +308,7 @@ TEST_CASE("object-position: malformed numeric tokens fall back to center",
 }
 
 TEST_CASE("object-position: non-finite numeric tokens fall back to center",
-          "[widgets][image][object-position][coverage][phase3]") {
+          "[widgets][image][object-position][coverage]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "1e999% 25%");

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Interpolator hermite impulse response spans adjacent samples", "[sign
 }
 
 TEST_CASE("Interpolator hermite preserves affine sample ramps",
-          "[signal][interp][coverage][phase3]") {
+          "[signal][interp][coverage]") {
     REQUIRE_THAT(Interpolator::hermite(0.25f, -1.0f, 1.0f, 3.0f, 5.0f),
                  WithinAbs(1.5f, 0.001f));
     REQUIRE_THAT(Interpolator::hermite(0.75f, -1.0f, 1.0f, 3.0f, 5.0f),
@@ -67,7 +67,7 @@ TEST_CASE("Interpolator lagrange for linear data", "[signal][interp]") {
 }
 
 TEST_CASE("Interpolator lagrange preserves quadratic curves",
-          "[signal][interp][coverage][phase3]") {
+          "[signal][interp][coverage]") {
     // Samples from f(x) = x^2 at x=-1,0,1,2.
     REQUIRE_THAT(Interpolator::lagrange(0.25f, 1.0f, 0.0f, 1.0f, 4.0f),
                  WithinAbs(0.0625f, 0.001f));

--- a/test/test_lock_to_source.cpp
+++ b/test/test_lock_to_source.cpp
@@ -676,7 +676,7 @@ TEST_CASE("lock_tweak_into_source fails gracefully on unknown anchor", "[lock-to
 }
 
 TEST_CASE("lock_tweak_into_source rejects an empty anchor id",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string gen = make_generated_source();
 
     LockResult r = lock_tweak_into_source(gen, {"", "paint.backgroundColor", "#000000"});
@@ -714,7 +714,7 @@ TEST_CASE("lock_tweak_into_source escapes single quotes in the value", "[lock-to
 }
 
 TEST_CASE("lock_tweak_into_source escapes backslashes in inserted values",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string gen = make_generated_source();
     const std::string anchor = first_child_anchor();
 
@@ -743,7 +743,7 @@ TEST_CASE("lock_tweak_into_source escapes JS control characters in values",
 }
 
 TEST_CASE("lock_tweak_into_source preserves missing trailing newline",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string src =
         "// @pulp-anchor solo\n"
         "const solo = document.createElement('div');\n"
@@ -759,7 +759,7 @@ TEST_CASE("lock_tweak_into_source preserves missing trailing newline",
 }
 
 TEST_CASE("lock_tweak_into_source stops a block at the next anchor",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string src =
         "// @pulp-anchor first\n"
         "const first = document.createElement('div');\n"
@@ -782,7 +782,7 @@ TEST_CASE("lock_tweak_into_source stops a block at the next anchor",
 }
 
 TEST_CASE("lock_tweak_into_source falls back to el when declaration is missing",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string src =
         "// @pulp-anchor orphan\n"
         "setAnchor(orphan._id, 'orphan');\n";
@@ -795,7 +795,7 @@ TEST_CASE("lock_tweak_into_source falls back to el when declaration is missing",
 }
 
 TEST_CASE("lock_tweak_into_source appends when no tail call is present",
-          "[lock-to-source][coverage][phase3]") {
+          "[lock-to-source][coverage]") {
     const std::string src =
         "// @pulp-anchor solo\n"
         "const solo = document.createElement('div');\n"

--- a/test/test_lv2_host_discovery.cpp
+++ b/test/test_lv2_host_discovery.cpp
@@ -244,7 +244,7 @@ TEST_CASE("LV2 host discovery resolves shared objects from bundle roots",
 }
 
 TEST_CASE("LV2 host discovery tolerates sparse bundles and dylib modules",
-          "[host][lv2][coverage][phase3]") {
+          "[host][lv2][coverage]") {
     ScratchDir scratch("sparse");
     const auto missing = scratch.path / "Missing.lv2";
 

--- a/test/test_midi_buffer_sysex.cpp
+++ b/test/test_midi_buffer_sysex.cpp
@@ -298,7 +298,7 @@ TEST_CASE("MidiBuffer copies sysex sidecar independently",
 }
 
 TEST_CASE("MidiBuffer move construction preserves sidecar contents",
-          "[midi][buffer][sysex][coverage][phase3]") {
+          "[midi][buffer][sysex][coverage]") {
     MidiBuffer original;
     original.add(MidiEvent::note_on(0, 72, 100));
     original.add_sysex({0xF0, 0x7D, 0x05, 0xF7}, 96, 1.25);
@@ -314,7 +314,7 @@ TEST_CASE("MidiBuffer move construction preserves sidecar contents",
 }
 
 TEST_CASE("MidiBuffer moves sysex sidecar with short messages",
-          "[midi][buffer][sysex][coverage][phase3]") {
+          "[midi][buffer][sysex][coverage]") {
     MidiBuffer original;
     auto note = MidiEvent::note_on(1, 72, 110);
     note.sample_offset = 24;

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -43,7 +43,7 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
 }
 
 TEST_CASE("UmpBuffer sorts, iterates, and clears sample-accurate events",
-          "[midi][buffer][ump][coverage][phase3-large]") {
+          "[midi][buffer][ump][coverage]") {
     UmpBuffer ump;
     ump.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 96);
     ump.add(UmpEvent{UmpPacket::note_off_2(0, 1, 60, 0), 12});
@@ -91,7 +91,7 @@ TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits
 }
 
 TEST_CASE("MidiBuffer move assignment preserves attached UMP sidecar pointer",
-          "[midi][buffer][ump][coverage][phase3]") {
+          "[midi][buffer][ump][coverage]") {
     UmpBuffer sidecar;
     sidecar.add(UmpPacket::cc_2(0, 3, 74, 0x80000000u), 24);
 

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -51,7 +51,7 @@ std::vector<uint8_t> read_bytes(const fs::path& path) {
 } // namespace
 
 TEST_CASE("MidiFileData aggregates empty and multi-track metadata",
-          "[midi][file][coverage][phase3]") {
+          "[midi][file][coverage]") {
     MidiFileData empty;
     REQUIRE(empty.duration_seconds() == Approx(0.0).margin(1e-9));
     REQUIRE(empty.total_events() == 0);
@@ -72,7 +72,7 @@ TEST_CASE("MidiFileData aggregates empty and multi-track metadata",
 }
 
 TEST_CASE("MidiFileData aggregates duration and event counts across tracks",
-          "[midi][file][coverage][phase3]") {
+          "[midi][file][coverage]") {
     MidiFileData data;
     REQUIRE(data.total_events() == 0);
     REQUIRE(data.duration_seconds() == Approx(0.0).margin(1e-9));
@@ -199,7 +199,7 @@ TEST_CASE("read_midi_file rejects truncated track chunks",
 }
 
 TEST_CASE("midi file helpers report missing and unwritable paths",
-          "[midi][file][coverage][phase3]") {
+          "[midi][file][coverage]") {
     TempDir tmp;
 
     REQUIRE_FALSE(read_midi_file((tmp.path / "missing.mid").string()).has_value());
@@ -373,7 +373,7 @@ TEST_CASE("write_midi_file preserves mixed short messages across tracks",
 }
 
 TEST_CASE("write_midi_file rejects missing parent directories",
-          "[midi][file][coverage][phase3]") {
+          "[midi][file][coverage]") {
     TempDir tmp;
     MidiFileData data;
     MidiTrack track;
@@ -386,7 +386,7 @@ TEST_CASE("write_midi_file rejects missing parent directories",
 }
 
 TEST_CASE("write_midi_file rejects directory destinations",
-          "[midi][file][coverage][phase3]") {
+          "[midi][file][coverage]") {
     TempDir tmp;
     MidiFileData data;
     MidiTrack track;

--- a/test/test_modulation_matrix.cpp
+++ b/test/test_modulation_matrix.cpp
@@ -97,7 +97,7 @@ TEST_CASE("empty matrix round-trips", "[view][mod-matrix]") {
 }
 
 TEST_CASE("typed modulation lanes accept compatible scoped routes",
-          "[state][modulation][lane][phase3]") {
+          "[state][modulation][lane]") {
     ModulationLane lane{
         .source = {
             .id = 1,
@@ -121,7 +121,7 @@ TEST_CASE("typed modulation lanes accept compatible scoped routes",
 }
 
 TEST_CASE("typed modulation lanes reject invalid source and target metadata",
-          "[state][modulation][lane][phase3]") {
+          "[state][modulation][lane]") {
     ModulationLane lane{
         .source = {.id = 1},
         .target = {.param_id = 100},
@@ -152,7 +152,7 @@ TEST_CASE("typed modulation lanes reject invalid source and target metadata",
 }
 
 TEST_CASE("typed modulation lanes validate source and target scope",
-          "[state][modulation][lane][scope][phase3]") {
+          "[state][modulation][lane][scope]") {
     ModulationLane lane{
         .source = {
             .id = 10,
@@ -176,7 +176,7 @@ TEST_CASE("typed modulation lanes validate source and target scope",
 }
 
 TEST_CASE("typed modulation lanes reject audio-rate sources for control-rate targets",
-          "[state][modulation][lane][rate][phase3]") {
+          "[state][modulation][lane][rate]") {
     ModulationLane lane{
         .source = {
             .id = 77,
@@ -199,7 +199,7 @@ TEST_CASE("typed modulation lanes reject audio-rate sources for control-rate tar
 }
 
 TEST_CASE("typed modulation lanes accept per-voice expression routes",
-          "[state][modulation][lane][voice][phase3]") {
+          "[state][modulation][lane][voice]") {
     ModulationLane lane{
         .source = {
             .id = 11,

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -136,7 +136,7 @@ TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
 }
 
 TEST_CASE("MotionPreferences policy callback may re-enter preferences",
-          "[motion-preferences][coverage][phase3]") {
+          "[motion-preferences][coverage]") {
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();
     prefs.set_override(MotionPolicy::Full);
@@ -175,7 +175,7 @@ TEST_CASE("motion_policy_to_string / from_string round-trip",
 }
 
 TEST_CASE("apply_motion_policy_to_duration follows override and scale",
-          "[motion-preferences][coverage][phase3]") {
+          "[motion-preferences][coverage]") {
     using namespace pulp::view;
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -1514,7 +1514,7 @@ TEST_CASE("OSC encode is deterministic for identical messages",
 }
 
 TEST_CASE("OSC encode preserves moved string and blob arguments",
-          "[osc][codec][coverage][phase3-github]") {
+          "[osc][codec][coverage]") {
     std::string label = "moved-label";
     std::vector<uint8_t> payload{0x10, 0x20, 0x30, 0x40};
 
@@ -1643,7 +1643,7 @@ TEST_CASE("OSC decode tolerates extra trailing padding bytes", "[osc][codec][iss
 }
 
 TEST_CASE("OSC decode keeps explicit defaults for out-of-range access",
-          "[osc][message][coverage][phase3-github]") {
+          "[osc][message][coverage]") {
     Message msg("/defaults");
     msg.add(12).add(std::string("name"));
 

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -542,7 +542,7 @@ TEST_CASE("Malformed address patterns fail closed",
 }
 
 TEST_CASE("Address pattern alternatives reject empty branches",
-          "[osc][bundle][pattern][coverage][phase3-github]") {
+          "[osc][bundle][pattern][coverage]") {
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixSuffix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixOther"));

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -268,7 +268,7 @@ TEST_CASE("OscChannel close uses the latest registered closed callback",
 }
 
 TEST_CASE("OscChannel routes close callbacks through custom executor",
-          "[osc_channel][lifecycle][coverage][phase3]") {
+          "[osc_channel][lifecycle][coverage]") {
     std::vector<std::function<void()>> queued;
     OscChannelOptions options;
     options.executor = [&](std::function<void()> fn) {
@@ -401,7 +401,7 @@ TEST_CASE("OscChannel message callback replacement uses latest callback",
 }
 
 TEST_CASE("OscChannel routes received messages through custom executor",
-          "[osc_channel][raw][coverage][phase3]") {
+          "[osc_channel][raw][coverage]") {
     std::mutex queue_mu;
     std::vector<std::function<void()>> queued;
     OscChannelOptions options;

--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -196,7 +196,7 @@ TEST_CASE("PluginFormat enum covers the 5 shipping formats",
 }
 
 TEST_CASE("PluginScanner default paths match platform format support",
-          "[host][plugin-info][format][coverage][phase3]") {
+          "[host][plugin-info][format][coverage]") {
 #if defined(__APPLE__)
     auto vst3 = PluginScanner::default_paths(PluginFormat::VST3);
     auto au = PluginScanner::default_paths(PluginFormat::AudioUnit);
@@ -254,7 +254,7 @@ TEST_CASE("PluginScanner identifies bundle suffixes for each host format",
 }
 
 TEST_CASE("PluginScanner honors disabled format flags without progress callbacks",
-          "[host][scanner][coverage][phase3]") {
+          "[host][scanner][coverage]") {
     PluginScanner scanner;
     ScanOptions opts;
     opts.scan_vst3 = false;
@@ -275,7 +275,7 @@ TEST_CASE("PluginScanner honors disabled format flags without progress callbacks
 }
 
 TEST_CASE("PluginScanner only_extra_paths reports each enabled format path",
-          "[host][scanner][coverage][phase3]") {
+          "[host][scanner][coverage]") {
     ScannerScratchDir scratch("empty-extra-paths");
 
     PluginScanner scanner;
@@ -304,7 +304,7 @@ TEST_CASE("PluginScanner only_extra_paths reports each enabled format path",
 }
 
 TEST_CASE("PluginScanner scans only supplied hermetic VST3 and LV2 directories",
-          "[host][scanner][coverage][phase3]") {
+          "[host][scanner][coverage]") {
     ScannerScratchDir scratch("synthetic-bundles");
     fs::create_directories(scratch.path / "BetaSynth.vst3" / "Contents" / "Resources");
     fs::create_directories(scratch.path / "AlphaVerb.lv2");
@@ -336,7 +336,7 @@ TEST_CASE("PluginScanner scans only supplied hermetic VST3 and LV2 directories",
 }
 
 TEST_CASE("PluginScanner skips missing and non-directory extra paths",
-          "[host][scanner][coverage][phase3]") {
+          "[host][scanner][coverage]") {
     ScannerScratchDir scratch("bad-extra-paths");
     const auto plain_file = scratch.path / "plain-file.vst3";
     write_text(plain_file, "not a directory");
@@ -366,7 +366,7 @@ TEST_CASE("PluginScanner skips missing and non-directory extra paths",
 }
 
 TEST_CASE("VST3 moduleinfo FUID reader normalizes valid CIDs and rejects malformed metadata",
-          "[host][scanner][vst3][coverage][phase3]") {
+          "[host][scanner][vst3][coverage]") {
     ScannerScratchDir scratch("vst3-moduleinfo");
     const auto bundle = scratch.path / "ModuleCase.vst3";
 
@@ -403,7 +403,7 @@ TEST_CASE("VST3 moduleinfo FUID reader normalizes valid CIDs and rejects malform
 }
 
 TEST_CASE("PluginScanner uses VST3 moduleinfo IDs while preserving blacklist short-circuiting",
-          "[host][scanner][vst3][blacklist][coverage][phase3]") {
+          "[host][scanner][vst3][blacklist][coverage]") {
     ScannerScratchDir scratch("vst3-scan-blacklist");
     const auto blocked = scratch.path / "BlockedSynth.vst3";
     const auto allowed = scratch.path / "AllowedFx.vst3";
@@ -438,7 +438,7 @@ TEST_CASE("PluginScanner uses VST3 moduleinfo IDs while preserving blacklist sho
 }
 
 TEST_CASE("PluginScanner LV2 URI extraction handles manifest variants and safe fallbacks",
-          "[host][scanner][lv2][coverage][phase3]") {
+          "[host][scanner][lv2][coverage]") {
     ScannerScratchDir scratch("lv2-manifest-variants");
     const auto canonical = scratch.path / "Canonical.lv2";
     const auto compound = scratch.path / "Compound.lv2";

--- a/test/test_resizable_shell.cpp
+++ b/test/test_resizable_shell.cpp
@@ -86,7 +86,7 @@ TEST_CASE("serialize + deserialize round-trip", "[ui][resizable-shell]") {
 }
 
 TEST_CASE("serialize stores little-endian width and height bytes",
-          "[ui][resizable-shell][coverage][phase3]") {
+          "[ui][resizable-shell][coverage]") {
     ResizableShell s({.initial_size = {0x0304u, 0x020Du}});
 
     const auto blob = s.serialize();
@@ -103,7 +103,7 @@ TEST_CASE("serialize stores little-endian width and height bytes",
 }
 
 TEST_CASE("deserialize ignores trailing bytes after the size payload",
-          "[ui][resizable-shell][coverage][phase3]") {
+          "[ui][resizable-shell][coverage]") {
     uint8_t blob[] = {
         0x2Cu, 0x01u, 0x00u, 0x00u, // 300
         0xC8u, 0x00u, 0x00u, 0x00u, // 200
@@ -160,7 +160,7 @@ TEST_CASE("constructor normalizes initial size through negotiate",
 }
 
 TEST_CASE("non-positive aspect ratio uses plain min max clamping",
-          "[ui][resizable-shell][coverage][phase3]") {
+          "[ui][resizable-shell][coverage]") {
     ResizableShell zero({.min_size = {100, 80},
                          .max_size = {500, 400},
                          .initial_size = {300, 300},

--- a/test/test_screenshot_capture.cpp
+++ b/test/test_screenshot_capture.cpp
@@ -140,7 +140,7 @@ TEST_CASE("ScreenshotCapture default delay (30) honored when caller leaves field
 }
 
 TEST_CASE("ScreenshotCapture handles missing capture callback as empty bytes",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto path = tmp_screenshot_path("missing_capture");
     std::filesystem::remove(path);
@@ -160,7 +160,7 @@ TEST_CASE("ScreenshotCapture handles missing capture callback as empty bytes",
 }
 
 TEST_CASE("ScreenshotCapture reports empty screenshot path before writing",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto cap = h.make("", 1);
 
@@ -173,7 +173,7 @@ TEST_CASE("ScreenshotCapture reports empty screenshot path before writing",
 }
 
 TEST_CASE("ScreenshotCapture tolerates missing error callback for bad inputs",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto cap = h.make("", 1);
     cap.on_error = {};
@@ -186,7 +186,7 @@ TEST_CASE("ScreenshotCapture tolerates missing error callback for bad inputs",
 }
 
 TEST_CASE("ScreenshotCapture reports failed file writes and still closes",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto missing_dir = std::filesystem::temp_directory_path() /
                        "pulp_test_screenshot_missing_dir" /
@@ -204,7 +204,7 @@ TEST_CASE("ScreenshotCapture reports failed file writes and still closes",
 }
 
 TEST_CASE("ScreenshotCapture skips write error reporting when no handler is set",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto missing_dir = std::filesystem::temp_directory_path() /
                        "pulp_test_screenshot_missing_dir_no_error" /
@@ -221,7 +221,7 @@ TEST_CASE("ScreenshotCapture skips write error reporting when no handler is set"
 }
 
 TEST_CASE("ScreenshotCapture permits missing close callback after a successful write",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness h;
     auto path = tmp_screenshot_path("missing_close");
     std::filesystem::remove(path);
@@ -242,7 +242,7 @@ TEST_CASE("ScreenshotCapture permits missing close callback after a successful w
 }
 
 TEST_CASE("ScreenshotCapture captures immediately for non-positive delays",
-          "[issue-468][screenshot][coverage][phase3]") {
+          "[issue-468][screenshot][coverage]") {
     CaptureHarness zero_delay;
     auto zero_path = tmp_screenshot_path("zero_delay");
     std::filesystem::remove(zero_path);

--- a/test/test_screenshot_compare.cpp
+++ b/test/test_screenshot_compare.cpp
@@ -291,7 +291,7 @@ TEST_CASE("analyze_screenshot_content accepts non-empty UI captures",
 }
 
 TEST_CASE("compare_screenshots reports rendered decode failure",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto png = render_label_png("Reference", Theme::dark());
     REQUIRE_FALSE(png.empty());
 
@@ -302,7 +302,7 @@ TEST_CASE("compare_screenshots reports rendered decode failure",
 }
 
 TEST_CASE("compare_screenshots penalizes size mismatch",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto small = render_label_png("Same", Theme::dark(), 40, 20);
     auto large = render_label_png("Same", Theme::dark(), 80, 40);
     REQUIRE_FALSE(small.empty());
@@ -316,7 +316,7 @@ TEST_CASE("compare_screenshots penalizes size mismatch",
 }
 
 TEST_CASE("compare_screenshot_files covers file IO success and failures",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto ref_png = render_label_png("File A", Theme::dark());
     auto ren_png = render_label_png("File A", Theme::dark());
     REQUIRE_FALSE(ref_png.empty());
@@ -383,7 +383,7 @@ TEST_CASE("generate_diff_image rejects oversized combined canvas",
 }
 
 TEST_CASE("generate_diff_image handles invalid changed and size mismatch inputs",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto dark = render_label_png("Diff", Theme::dark(), 80, 40);
     auto light = render_label_png("Diff", Theme::light(), 80, 40);
     auto small = render_label_png("Diff", Theme::dark(), 40, 20);
@@ -439,7 +439,7 @@ TEST_CASE("crop_png clamps regions to image bounds", "[view][compare]") {
 }
 
 TEST_CASE("crop_png rejects invalid and non-intersecting regions",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto png = render_label_png("Crop guards", Theme::dark(), 80, 40);
     REQUIRE_FALSE(png.empty());
 
@@ -478,7 +478,7 @@ TEST_CASE("diff_bounds locates changed pixels", "[view][compare]") {
 }
 
 TEST_CASE("diff_bounds is invalid for identical or undecodable images",
-          "[view][compare][coverage][phase3]") {
+          "[view][compare][coverage]") {
     auto png = render_label_png("Same", Theme::dark(), 80, 40);
     REQUIRE_FALSE(png.empty());
 

--- a/test/test_simd.cpp
+++ b/test/test_simd.cpp
@@ -214,7 +214,7 @@ TEST_CASE("simd operations handle empty input", "[simd]") {
 }
 
 TEST_CASE("simd reductions return zero for empty max and min",
-          "[simd][coverage][phase3]") {
+          "[simd][coverage]") {
     float dummy = 42.0f;
     REQUIRE(simd_reduce_max(&dummy, 0) == 0.0f);
     REQUIRE(simd_reduce_min(&dummy, 0) == 0.0f);

--- a/test/test_uia_mapping.cpp
+++ b/test/test_uia_mapping.cpp
@@ -21,7 +21,7 @@ TEST_CASE("role_to_control_type returns stable UIA IDs", "[a11y][uia]") {
 }
 
 TEST_CASE("UIA mapping falls back for unknown role values",
-          "[a11y][uia][coverage][phase3]") {
+          "[a11y][uia][coverage]") {
     auto unknown = static_cast<View::AccessRole>(999);
     REQUIRE(role_to_control_type(unknown) == kControlTypeCustom);
     REQUIRE(patterns_for_role(unknown).count == 0);
@@ -95,7 +95,7 @@ TEST_CASE("mapping tables are constexpr-usable", "[a11y][uia]") {
 // rest of this file pins for the mapping table.
 
 TEST_CASE("range-value patterns gate the IRangeValueProvider fragment",
-          "[a11y][uia][phase3]") {
+          "[a11y][uia]") {
     // Slider + meter advertise RangeValue; everything else does not.
     REQUIRE(role_supports_range_value(View::AccessRole::slider));
     REQUIRE(role_supports_range_value(View::AccessRole::meter));
@@ -107,7 +107,7 @@ TEST_CASE("range-value patterns gate the IRangeValueProvider fragment",
 }
 
 TEST_CASE("value pattern gates the IValueProvider fragment (writable range)",
-          "[a11y][uia][phase3]") {
+          "[a11y][uia]") {
     // Slider is writable (Value + RangeValue); meter is read-only progress
     // (RangeValue only). This is the IsReadOnly discriminator.
     REQUIRE(role_supports_value(View::AccessRole::slider));
@@ -117,7 +117,7 @@ TEST_CASE("value pattern gates the IValueProvider fragment (writable range)",
 }
 
 TEST_CASE("runtime ids are unique, stable, and append-id prefixed",
-          "[a11y][uia][phase3]") {
+          "[a11y][uia]") {
     // First element is the documented UiaAppendRuntimeId (3); the key is
     // 1 + index so it is strictly positive and distinct per fragment.
     constexpr auto a = runtime_id_for_index(0);
@@ -132,7 +132,7 @@ TEST_CASE("runtime ids are unique, stable, and append-id prefixed",
 }
 
 TEST_CASE("normalized value fraction clamps and maps to [0,1]",
-          "[a11y][uia][phase3]") {
+          "[a11y][uia]") {
     REQUIRE(normalized_value_fraction(0.0, 0.0, 1.0) == Catch::Approx(0.0));
     REQUIRE(normalized_value_fraction(0.5, 0.0, 1.0) == Catch::Approx(0.5));
     REQUIRE(normalized_value_fraction(1.0, 0.0, 1.0) == Catch::Approx(1.0));

--- a/test/test_vendor_url.cpp
+++ b/test/test_vendor_url.cpp
@@ -34,7 +34,7 @@ TEST_CASE("copy preserves url + email", "[format][vendor-url]") {
 }
 
 TEST_CASE("PluginDescriptor bus helpers follow first bus and empty bus lists",
-          "[format][descriptor][coverage][phase3]") {
+          "[format][descriptor][coverage]") {
     PluginDescriptor d;
     REQUIRE(d.default_input_channels() == 2);
     REQUIRE(d.default_output_channels() == 2);
@@ -56,7 +56,7 @@ TEST_CASE("PluginDescriptor bus helpers follow first bus and empty bus lists",
 }
 
 TEST_CASE("PluginDescriptor modern capability flags default off",
-          "[format][vendor-url][coverage][phase3-large]") {
+          "[format][vendor-url][coverage]") {
     PluginDescriptor d;
     REQUIRE_FALSE(d.supports_mpe);
     REQUIRE_FALSE(d.supports_ump);

--- a/test/test_view_layout_widgets.cpp
+++ b/test/test_view_layout_widgets.cpp
@@ -67,7 +67,7 @@ TEST_CASE("SplitView lays out horizontal and vertical panes around divider",
 }
 
 TEST_CASE("SplitView clamps split fraction and supports pane replacement",
-          "[view][split_view][coverage][phase3]") {
+          "[view][split_view][coverage]") {
     SplitView split;
     auto first = std::make_unique<View>();
     auto second = std::make_unique<View>();

--- a/test/test_widget_bridge_css_animations.cpp
+++ b/test/test_widget_bridge_css_animations.cpp
@@ -84,7 +84,7 @@ TEST_CASE("parse_transition_shorthand: steps(N, end|start)",
 }
 
 TEST_CASE("parse_transition_shorthand rejects partial easing numbers",
-          "[view][bridge][css][coverage][phase3]") {
+          "[view][bridge][css][coverage]") {
     auto bezier = parse_transition_shorthand(
         "opacity 200ms cubic-bezier(0.42junk, 0, 0.58, 1)");
     REQUIRE(bezier.size() == 1);

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -1222,7 +1222,7 @@ TEST_CASE("Audio widgets render declarative schemas and invalid schema fallback"
 }
 
 TEST_CASE("Audio widget schemas reject malformed dimension tokens without error fallback",
-          "[view][widget][schema][coverage][phase3]") {
+          "[view][widget][schema][coverage]") {
     Knob knob;
     knob.set_bounds({0, 0, 80, 80});
     knob.set_value(0.5f);


### PR DESCRIPTION
## Summary

Remove obsolete phase-oriented Catch2 coverage tags from test metadata in one consolidated source batch.

- removes `[phase3]`, `[phase3-large]`, `[phase3-github]`, and `[phase3-canvas]` tag suffixes from 30 test files
- preserves issue, protocol, regression, host-format, and contract tags such as `[issue-*]`, `[vst3]`, `[lv2]`, `[blacklist]`, `[scope]`, and `[rate]`
- keeps this as one batch PR instead of per-file comment-hygiene PRs

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-background-scanner pulp-test-canvas pulp-test-code-editor pulp-test-gpu-render-time pulp-test-gpu-timestamps pulp-test-host-regression pulp-test-hosted-editor pulp-test-image-convolution pulp-test-image-view-cache pulp-test-interpolator pulp-test-lock-to-source pulp-test-lv2-host-discovery pulp-test-midi-buffer-sysex pulp-test-midi-buffer-ump pulp-test-midi-file pulp-test-modulation-matrix pulp-test-motion-preferences pulp-test-osc pulp-test-osc-bundle pulp-test-osc-channel pulp-test-plugin-info-metadata pulp-test-resizable-shell pulp-test-screenshot-capture pulp-test-screenshot-compare pulp-test-simd pulp-test-uia-mapping pulp-test-vendor-url pulp-test-view-layout-widgets pulp-test-widget-bridge-css-animations pulp-test-widgets -j$(sysctl -n hw.ncpu)`
- ran all 30 affected binaries directly; all exited successfully (`pulp-test-canvas` retains its existing expected-failure assertion path)
- `rg -n '\[phase3(?:-[^\]]+)?\]' <edited files>` returned no matches
- `git diff --check origin/main..HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `/Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this as a documentation/comment hygiene patch..."` clean
- pre-push gates clean

## Review notes

RepoPrompt Oracle review and Claude bridge review were both attempted but quota-blocked with the weekly limit reset at 5am America/Los_Angeles. Local Codex autoreview completed cleanly and specifically confirmed the remaining tags are well formed and issue/protocol/contract tags are preserved.

Version-Bump: sdk=skip reason="test metadata cleanup only; no API or runtime behavior change"
Skill-Sync: skip reason="no mapped skill paths touched"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed obsolete phase-oriented coverage tags from Catch2 test metadata to reduce noise and simplify tag filters. No runtime, API, or test behavior changes.

- **Refactors**
  - Dropped `[phase3]`, `[phase3-large]`, `[phase3-github]`, and `[phase3-canvas]` suffixes in 30 test files.
  - Preserved issue/protocol/contract tags (e.g., `[issue-*]`, `[vst3]`, `[lv2]`, `[blacklist]`, `[scope]`, `[rate]`).

<sup>Written for commit 9e93738faf50bead1a028df33682f92928e01b50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

