### PR TITLE
docs(test): clean CLI coverage selector tags

### DIFF
--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -315,7 +315,7 @@ TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home",
 }
 
 TEST_CASE("Android SDK discovery skips invalid primary env roots",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto sdk = make_fake_sdk(temp.path);
     auto invalid_sdk = temp.path / "invalid-sdk";
@@ -332,7 +332,7 @@ TEST_CASE("Android SDK discovery skips invalid primary env roots",
 }
 
 TEST_CASE("Android SDK discovery returns empty for invalid env roots",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto invalid_home = temp.path / "not-an-sdk";
     fs::create_directories(invalid_home);
@@ -350,7 +350,7 @@ TEST_CASE("Android SDK discovery returns empty for invalid env roots",
 }
 
 TEST_CASE("Android SDK discovery ignores empty tool directories",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto sdk = temp.path / "sdk";
     fs::create_directories(sdk / "build-tools");
@@ -366,7 +366,7 @@ TEST_CASE("Android SDK discovery ignores empty tool directories",
 }
 
 TEST_CASE("Android SDK discovery treats malformed revisions as zero",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto sdk = temp.path / "sdk";
     fs::create_directories(sdk / "build-tools" / "preview");
@@ -384,7 +384,7 @@ TEST_CASE("Android SDK discovery treats malformed revisions as zero",
 }
 
 TEST_CASE("Android SDK discovery handles very large revision components",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto sdk = temp.path / "sdk";
     const std::string huge = "999999999999999999999999999999";
@@ -402,7 +402,7 @@ TEST_CASE("Android SDK discovery handles very large revision components",
 }
 
 TEST_CASE("Android Java version detection parses quoted java output",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto bin_dir = temp.path / "bin";
     fs::create_directories(bin_dir);
@@ -427,7 +427,7 @@ TEST_CASE("Android Java version detection parses quoted java output",
 }
 
 TEST_CASE("Android Java version detection returns empty for unquoted output",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto bin_dir = temp.path / "bin";
     fs::create_directories(bin_dir);
@@ -492,7 +492,7 @@ TEST_CASE("Android signing helpers use SDK tools and parse APK verification outp
 }
 
 TEST_CASE("Android signing helpers fail cleanly when SDK tools are unavailable",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     ScopedEnvVar android_home("ANDROID_HOME", (temp.path / "missing-sdk").string());
     ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
@@ -585,7 +585,7 @@ TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][and
 }
 
 TEST_CASE("Android Gradle packaging supports APK-only and AAB-only builds",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto project = temp.path / "android";
     fs::create_directories(project);
@@ -611,7 +611,7 @@ TEST_CASE("Android Gradle packaging supports APK-only and AAB-only builds",
 }
 
 TEST_CASE("Android Gradle packaging reports command failures",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto project = temp.path / "android";
     fs::create_directories(project);
@@ -676,7 +676,7 @@ TEST_CASE("Android bundletool conversion passes optional signing config", "[ship
 }
 
 TEST_CASE("Android bundletool conversion supports unsigned output",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     auto bundletool = tool_path(temp.path, "bundletool");
     auto bundletool_log = temp.path / "bundletool-unsigned.args";
@@ -697,7 +697,7 @@ TEST_CASE("Android bundletool conversion supports unsigned output",
 }
 
 TEST_CASE("Android bundletool conversion reports missing command",
-          "[ship][android][coverage][issue-644]") {
+          "[ship][android][issue-644]") {
     TempDir temp;
     ScopedEnvVar bundletool_env("BUNDLETOOL", (temp.path / "missing-bundletool").string());
 

--- a/test/test_cli_create_targets.cpp
+++ b/test/test_cli_create_targets.cpp
@@ -88,7 +88,7 @@ TEST_CASE("CLI create targets skip malformed targets when class_name is empty ac
 }
 
 TEST_CASE("CLI create targets match complete format tokens only",
-          "[cli][create][coverage]") {
+          "[cli][create]") {
     const auto auv3_only =
         create_default_build_targets("PulpPlugin", "instrument", "AUv3");
     CHECK(auv3_only == std::vector<std::string>{
@@ -129,7 +129,7 @@ TEST_CASE("CLI create selects build config at build/test time for multi-config g
 }
 
 TEST_CASE("CLI create standalone commands quote paths with spaces",
-          "[cli][create][shellout][coverage]") {
+          "[cli][create][shellout]") {
     const fs::path source_dir = fs::path("Generated Projects") / "My Plugin";
     const fs::path build_dir = source_dir / "build dir";
     const fs::path sdk_dir = fs::path("SDK Cache") / "Pulp SDK";

--- a/test/test_cli_design_binding.cpp
+++ b/test/test_cli_design_binding.cpp
@@ -59,7 +59,7 @@ TEST_CASE("CLI design binding honors explicit build dir and script", "[cli][desi
 }
 
 TEST_CASE("CLI design binding treats positional script as script-root selector",
-          "[cli][design][coverage]") {
+          "[cli][design]") {
     DesignBindingInput input;
     input.cwd_root = "/repo";
     input.script_path = "/worktree/ui/main.js";
@@ -77,7 +77,7 @@ TEST_CASE("CLI design binding treats positional script as script-root selector",
 }
 
 TEST_CASE("CLI design binding keeps checkout root when script is in same tree",
-          "[cli][design][coverage]") {
+          "[cli][design]") {
     DesignBindingInput input;
     input.cwd_root = "/repo";
     input.script_path = "/repo/ui/main.js";
@@ -92,7 +92,7 @@ TEST_CASE("CLI design binding keeps checkout root when script is in same tree",
 }
 
 TEST_CASE("CLI design binding can select root from explicit build cache",
-          "[cli][design][coverage]") {
+          "[cli][design]") {
     DesignBindingInput input;
     input.build_dir = "/repo/build";
     input.build_dir_cache_root = "/repo";
@@ -108,7 +108,7 @@ TEST_CASE("CLI design binding can select root from explicit build cache",
 }
 
 TEST_CASE("CLI design binding defaults build dir when binary root differs",
-          "[cli][design][coverage]") {
+          "[cli][design]") {
     DesignBindingInput input;
     input.cwd_root = "/repo";
     input.binary_root = "/sdk";

--- a/test/test_cli_docs_command.cpp
+++ b/test/test_cli_docs_command.cpp
@@ -182,7 +182,7 @@ commands:
 } // namespace
 
 TEST_CASE("docs command reports usage outside and inside projects",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
     TempDir tmp;
     {
         ScopedCurrentPath cwd{tmp.path};
@@ -199,7 +199,7 @@ TEST_CASE("docs command reports usage outside and inside projects",
 }
 
 TEST_CASE("docs command indexes opens and searches local docs",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
     TempDir tmp;
     auto root = make_project(tmp);
     ScopedCurrentPath cwd{root / "docs" / "guides"};
@@ -246,7 +246,7 @@ TEST_CASE("docs command indexes opens and searches local docs",
 }
 
 TEST_CASE("docs command shows support matrix entries sections and scalars",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
     TempDir tmp;
     auto root = make_project(tmp);
     ScopedCurrentPath cwd{root};
@@ -277,7 +277,7 @@ TEST_CASE("docs command shows support matrix entries sections and scalars",
 }
 
 TEST_CASE("docs command shows command cmake and style manifests",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
     TempDir tmp;
     auto root = make_project(tmp);
     ScopedCurrentPath cwd{root};
@@ -320,7 +320,7 @@ TEST_CASE("docs command shows command cmake and style manifests",
 }
 
 TEST_CASE("docs command reports missing manifest and script paths",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
     TempDir tmp;
     auto root = make_project(tmp);
     ScopedCurrentPath cwd{root};
@@ -371,7 +371,7 @@ TEST_CASE("docs command reports missing manifest and script paths",
 }
 
 TEST_CASE("docs command runs project docs check script",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -397,7 +397,7 @@ TEST_CASE("docs command runs project docs check script",
 }
 
 TEST_CASE("docs command runs project docs site build through mkdocs",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
 #if defined(_WIN32)
     SKIP("POSIX fake mkdocs assertions are only used on non-Windows");
 #else
@@ -446,7 +446,7 @@ TEST_CASE("docs command runs project docs site build through mkdocs",
 }
 
 TEST_CASE("docs command runs project API docs build script",
-          "[cli][docs][coverage]") {
+          "[cli][docs]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -131,7 +131,7 @@ TEST_CASE("discover: healthy entries report Healthy and exit 0",
 }
 
 TEST_CASE("discover: empty root or missing list_dir returns no entries",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     MockState state;
 
     auto env = make_mock_env("/fake/cache", {}, state);
@@ -144,7 +144,7 @@ TEST_CASE("discover: empty root or missing list_dir returns no entries",
 }
 
 TEST_CASE("discover: lstat miss reports unknown with manual remediation",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "mystery-v1";
     MockState state;
@@ -202,7 +202,7 @@ TEST_CASE("discover: dangling symlink reports Dangling, fixable, exit 1",
 }
 
 TEST_CASE("discover: root-owned dangling symlink reports RootOwned",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "threejs-077dd13c0e869d9f3dbe55875686f920367de457";
     MockState state;
@@ -260,7 +260,7 @@ TEST_CASE("discover: cached ref differs from declared REF reports StaleCommit",
 }
 
 TEST_CASE("discover: sanitized declared ref matches cache suffix",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "yoga-release_3.2.12";
     MockState state;
@@ -612,7 +612,7 @@ TEST_CASE("split_entry_name: longest-match prefers declared dep names",
 }
 
 TEST_CASE("split_entry_name: fallback uses last hyphen when dep is undeclared",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "custom-dep-v1.2.3";
     MockState state;
@@ -634,7 +634,7 @@ TEST_CASE("split_entry_name: fallback uses last hyphen when dep is undeclared",
 }
 
 TEST_CASE("split_entry_name: fallback without hyphen lowercases whole name",
-          "[fetchcontent_cache][coverage]") {
+          "[fetchcontent_cache]") {
     fs::path root = "/fake/cache";
     fs::path entry = root / "Catch2";
     MockState state;

--- a/test/test_cli_import_detect.cpp
+++ b/test/test_cli_import_detect.cpp
@@ -131,7 +131,7 @@ TEST_CASE("parse_compat_json rejects malformed input", "[cli][import-detect][iss
 }
 
 TEST_CASE("parse_compat_json preserves sources with empty detected formats",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     auto manifest = det::parse_compat_json(R"({
   "compat-schema-version": "1.0",
   "imports": {
@@ -158,7 +158,7 @@ TEST_CASE("parse_compat_json preserves sources with empty detected formats",
 }
 
 TEST_CASE("parse_compat_json keeps optional format metadata and skips bad shapes",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto manifest = det::parse_compat_json(R"({
   "compat-schema-version": "0.9",
   "imports": {
@@ -203,7 +203,7 @@ TEST_CASE("parse_compat_json keeps optional format metadata and skips bad shapes
 }
 
 TEST_CASE("parse_compat_json ignores malformed optional fields without dropping formats",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto manifest = det::parse_compat_json(R"({
   "compat-schema-version": 3,
   "imports": {
@@ -252,7 +252,7 @@ TEST_CASE("parse_compat_json ignores malformed optional fields without dropping 
 }
 
 TEST_CASE("find_compat_json walks parents and reports absence",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-compat-walk";
     fs::remove_all(dir);
     fs::create_directories(dir / "repo" / "nested" / "child");
@@ -273,7 +273,7 @@ TEST_CASE("find_compat_json walks parents and reports absence",
 }
 
 TEST_CASE("snapshot_input scrapes script attributes and frontmatter edge cases",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     ScratchDir scratch("snapshot-edges");
 
     write_text(scratch.path / "case.html", R"HTML(
@@ -387,7 +387,7 @@ TEST_CASE("clause matcher honors the fingerprint vocabulary", "[cli][import-dete
 }
 
 TEST_CASE("clause matcher handles filename regex flags and invalid patterns",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::InputSnapshot snap;
     snap.filename = "DESIGN.md";
     snap.directory_basenames = {"DESIGN.md"};
@@ -405,7 +405,7 @@ TEST_CASE("clause matcher handles filename regex flags and invalid patterns",
 }
 
 TEST_CASE("clause matcher rejects empty filename and script clauses",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::InputSnapshot snap;
     det::FingerprintClause c;
 
@@ -423,7 +423,7 @@ TEST_CASE("clause matcher rejects empty filename and script clauses",
 }
 
 TEST_CASE("clause matcher covers frontmatter fence and required key clauses",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::InputSnapshot snap;
     snap.has_frontmatter_fence = true;
     snap.frontmatter_keys = {"name", "colors", "typography"};
@@ -442,7 +442,7 @@ TEST_CASE("clause matcher covers frontmatter fence and required key clauses",
 }
 
 TEST_CASE("clause matcher covers frontmatter any-of keys",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::InputSnapshot snap;
     snap.has_frontmatter_fence = true;
     snap.frontmatter_keys = {"tokens", "spacing"};
@@ -457,7 +457,7 @@ TEST_CASE("clause matcher covers frontmatter any-of keys",
 }
 
 TEST_CASE("detect enforces all-of formats before considering a match",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "design-md";
@@ -497,7 +497,7 @@ TEST_CASE("detect enforces all-of formats before considering a match",
 }
 
 TEST_CASE("detect enforces minimum confidence thresholds",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "threshold";
@@ -541,7 +541,7 @@ TEST_CASE("detect enforces minimum confidence thresholds",
 }
 
 TEST_CASE("detect prefers higher confidence when match counts tie",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "tie";
@@ -576,7 +576,7 @@ TEST_CASE("detect prefers higher confidence when match counts tie",
 }
 
 TEST_CASE("snapshot_input extracts Markdown frontmatter only from markdown files",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-phase3-frontmatter";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -602,7 +602,7 @@ TEST_CASE("snapshot_input extracts Markdown frontmatter only from markdown files
 }
 
 TEST_CASE("snapshot_input accepts CRLF frontmatter and filters invalid top-level keys",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-frontmatter-crlf";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -638,7 +638,7 @@ TEST_CASE("snapshot_input accepts CRLF frontmatter and filters invalid top-level
 }
 
 TEST_CASE("snapshot_input rejects incomplete frontmatter fences",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-frontmatter-reject";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -665,7 +665,7 @@ TEST_CASE("snapshot_input rejects incomplete frontmatter fences",
 }
 
 TEST_CASE("snapshot_input prefers index html when code html is absent",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-index-html";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -691,7 +691,7 @@ TEST_CASE("snapshot_input prefers index html when code html is absent",
 }
 
 TEST_CASE("snapshot_input scrapes script attributes without case or prefix traps",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-script-attrs";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -738,7 +738,7 @@ TEST_CASE("snapshot_input scrapes script attributes without case or prefix traps
 }
 
 TEST_CASE("snapshot_input ignores script-like tags and prefixed attributes",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-script-boundaries";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -787,7 +787,7 @@ TEST_CASE("snapshot_input ignores script-like tags and prefixed attributes",
 }
 
 TEST_CASE("snapshot_input accepts script tag and attribute whitespace boundaries",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-script-whitespace-boundaries";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -830,7 +830,7 @@ TEST_CASE("snapshot_input accepts script tag and attribute whitespace boundaries
 }
 
 TEST_CASE("snapshot_input falls back to sorted html candidates with attribute forms",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-script-fallback";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -864,7 +864,7 @@ TEST_CASE("snapshot_input falls back to sorted html candidates with attribute fo
 }
 
 TEST_CASE("snapshot_input captures unquoted script attributes and sorted directory names",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-unquoted-script-attrs";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -896,7 +896,7 @@ TEST_CASE("snapshot_input captures unquoted script attributes and sorted directo
 }
 
 TEST_CASE("new-format reports cap unknown tailwind tokens and keep fallbacks stable",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "stitch";
@@ -945,7 +945,7 @@ TEST_CASE("new-format reports cap unknown tailwind tokens and keep fallbacks sta
 }
 
 TEST_CASE("render_new_format_json includes removals and empty additions",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     det::NewFormatReport report;
     report.candidate_source = "stitch";
     report.candidate_format_version = "2026.06";
@@ -965,7 +965,7 @@ TEST_CASE("render_new_format_json includes removals and empty additions",
 }
 
 TEST_CASE("render_new_format_json escapes generated string fields",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     det::NewFormatReport report;
     report.candidate_source = "stitch\"beta";
     report.candidate_format_version = "2026.06\\next";
@@ -985,7 +985,7 @@ TEST_CASE("render_new_format_json escapes generated string fields",
 }
 
 TEST_CASE("detect preserves manifest order when matches and confidence tie",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
 
     det::FingerprintClause script;
@@ -1028,7 +1028,7 @@ TEST_CASE("detect preserves manifest order when matches and confidence tie",
 }
 
 TEST_CASE("detect reports matched and unmatched clause kinds for partial matches",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "diagnostic";
@@ -1075,7 +1075,7 @@ TEST_CASE("detect reports matched and unmatched clause kinds for partial matches
 }
 
 TEST_CASE("snapshot_input prefers code html over sorted html fallbacks",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     auto dir = fs::temp_directory_path() / "pulp-import-detect-code-html-priority";
     fs::remove_all(dir);
     fs::create_directories(dir);
@@ -1107,7 +1107,7 @@ TEST_CASE("snapshot_input prefers code html over sorted html fallbacks",
 }
 
 TEST_CASE("new-format reports keep empty additions when no baseline tokens exist",
-          "[cli][import-detect][coverage]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "claude";
@@ -1216,7 +1216,7 @@ TEST_CASE("snapshot_input handles file and directory inputs", "[cli][import-dete
 }
 
 TEST_CASE("snapshot_input chooses deterministic directory HTML candidates",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     ScratchDir scratch("html-priority");
     write_text(scratch.path / "z-last.html",
                R"(<html><script src="/fallback.js"></script></html>)");
@@ -1239,7 +1239,7 @@ TEST_CASE("snapshot_input chooses deterministic directory HTML candidates",
 }
 
 TEST_CASE("snapshot_input falls back to the sorted first HTML candidate",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     ScratchDir scratch("html-fallback");
     write_text(scratch.path / "b-page.htm",
                R"(<html><script src="/b.js"></script></html>)");
@@ -1254,7 +1254,7 @@ TEST_CASE("snapshot_input falls back to the sorted first HTML candidate",
 }
 
 TEST_CASE("snapshot_input frontmatter probe records only top-level valid keys",
-          "[cli][import-detect][coverage][requested]") {
+          "[cli][import-detect]") {
     ScratchDir scratch("frontmatter-keys");
     const auto path = scratch.path / "DESIGN.md";
     write_text(path,
@@ -1444,7 +1444,7 @@ TEST_CASE("report-new-format diffs unknown tokens against the closest match",
 }
 
 TEST_CASE("report-new-format caps token suggestions at twenty entries",
-          "[cli][import-detect][coverage][large]") {
+          "[cli][import-detect]") {
     det::ImportsManifest manifest;
     det::SourceEntry source;
     source.source = "stitch";

--- a/test/test_cli_inspect_shellout.cpp
+++ b/test/test_cli_inspect_shellout.cpp
@@ -125,7 +125,7 @@ std::string compact_json_for_assertion(std::string text) {
 }  // namespace
 
 TEST_CASE("pulp inspect one-shot prints a server response",
-          "[cli][shellout][inspect][coverage][requested]") {
+          "[cli][shellout][inspect]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     InspectServerFixture fixture;
@@ -161,7 +161,7 @@ TEST_CASE("pulp inspect one-shot prints a server response",
 }
 
 TEST_CASE("pulp inspect one-shot can discover the advertised server port",
-          "[cli][shellout][inspect][coverage][requested]") {
+          "[cli][shellout][inspect]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     InspectServerFixture fixture;
@@ -191,7 +191,7 @@ TEST_CASE("pulp inspect one-shot can discover the advertised server port",
 }
 
 TEST_CASE("pulp inspect one-shot writes output files and propagates errors",
-          "[cli][shellout][inspect][coverage][requested]") {
+          "[cli][shellout][inspect]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     InspectServerFixture fixture;
@@ -237,7 +237,7 @@ TEST_CASE("pulp inspect one-shot writes output files and propagates errors",
 }
 
 TEST_CASE("pulp inspect validates missing values before connecting",
-          "[cli][shellout][inspect][coverage][requested]") {
+          "[cli][shellout][inspect]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");

--- a/test/test_cli_json_parser.cpp
+++ b/test/test_cli_json_parser.cpp
@@ -25,7 +25,7 @@ json::JsonValue parse_json(const std::string& text) {
 }  // namespace
 
 TEST_CASE("json parser: object lookup returns matching keys and null for missing keys",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"name":"pulp","enabled":true})");
     REQUIRE(value.type == json::JsonValue::Object);
     REQUIRE(value.get("name") != nullptr);
@@ -34,14 +34,14 @@ TEST_CASE("json parser: object lookup returns matching keys and null for missing
 }
 
 TEST_CASE("json parser: get on non-objects is null-safe",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"(["name","pulp"])");
     REQUIRE(value.type == json::JsonValue::Array);
     CHECK(value.get("name") == nullptr);
 }
 
 TEST_CASE("json parser: string escapes decode the supported JSON escape set",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"s":"quote:\" slash:\/ backslash:\\ line:\n tab:\t cr:\r"})");
     auto* s = value.get("s");
     REQUIRE(s != nullptr);
@@ -54,7 +54,7 @@ TEST_CASE("json parser: string escapes decode the supported JSON escape set",
 }
 
 TEST_CASE("json parser: unicode escapes advance and use placeholder text",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"symbol":"A\u2665B","after":"ok"})");
     auto* symbol = value.get("symbol");
     REQUIRE(symbol != nullptr);
@@ -64,7 +64,7 @@ TEST_CASE("json parser: unicode escapes advance and use placeholder text",
 }
 
 TEST_CASE("json parser: short unicode escapes still advance safely",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"symbol":"A\u12"})");
     auto* symbol = value.get("symbol");
     REQUIRE(symbol != nullptr);
@@ -72,7 +72,7 @@ TEST_CASE("json parser: short unicode escapes still advance safely",
 }
 
 TEST_CASE("json parser: unknown escapes preserve the escaped character",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"s":"prefix\q\/suffix"})");
     auto* s = value.get("s");
     REQUIRE(s != nullptr);
@@ -80,14 +80,14 @@ TEST_CASE("json parser: unknown escapes preserve the escaped character",
 }
 
 TEST_CASE("json parser: unterminated strings return accumulated text",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     json::JsonParser parser{"\"partial\\ntext", 0};
     CHECK(parser.parse_string() == "partial\ntext");
     CHECK(parser.pos == std::string{"\"partial\\ntext"}.size());
 }
 
 TEST_CASE("json parser: arrays preserve order across mixed values",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"(["first",2,false,null,{"k":"v"}])");
     REQUIRE(value.type == json::JsonValue::Array);
     REQUIRE(value.arr().size() == 5);
@@ -100,7 +100,7 @@ TEST_CASE("json parser: arrays preserve order across mixed values",
 }
 
 TEST_CASE("json parser: empty object and array keep empty accessors stable",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto object = parse_json("{}");
     auto array = parse_json("[]");
     REQUIRE(object.type == json::JsonValue::Object);
@@ -110,7 +110,7 @@ TEST_CASE("json parser: empty object and array keep empty accessors stable",
 }
 
 TEST_CASE("json parser: const accessors return stable empty containers",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     const auto scalar = parse_json("true");
     CHECK(scalar.arr().empty());
     CHECK(scalar.obj().empty());
@@ -121,7 +121,7 @@ TEST_CASE("json parser: const accessors return stable empty containers",
 }
 
 TEST_CASE("json parser: numeric forms feed integer and floating accessors",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"neg":-42,"frac":3.5,"exp":1.25e2})");
     REQUIRE(value.get("neg") != nullptr);
     REQUIRE(value.get("frac") != nullptr);
@@ -132,7 +132,7 @@ TEST_CASE("json parser: numeric forms feed integer and floating accessors",
 }
 
 TEST_CASE("json parser: signed exponents and leading plus are parsed as numbers",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"small":-1.5e-2,"plus":+7})");
     REQUIRE(value.get("small") != nullptr);
     REQUIRE(value.get("plus") != nullptr);
@@ -141,19 +141,19 @@ TEST_CASE("json parser: signed exponents and leading plus are parsed as numbers"
 }
 
 TEST_CASE("json parser: string array accessor filters non-string entries",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"(["alpha",1,"beta",true,{"ignored":"yes"},"gamma"])");
     CHECK(value.as_string_array() == std::vector<std::string>{"alpha", "beta", "gamma"});
 }
 
 TEST_CASE("json parser: string array accessor defaults for non-arrays",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"items":["ignored"]})");
     CHECK(value.as_string_array().empty());
 }
 
 TEST_CASE("json parser: scalar accessors return defaults for mismatched types",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"s":"42","n":7,"b":true,"f":false,"nil":null})");
     CHECK(value.get("n")->as_string().empty());
     CHECK(value.get("s")->as_int() == 0);
@@ -163,7 +163,7 @@ TEST_CASE("json parser: scalar accessors return defaults for mismatched types",
 }
 
 TEST_CASE("json parser: duplicate object keys return the first inserted value",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"dup":"first","dup":"second"})");
     REQUIRE(value.get("dup") != nullptr);
     CHECK(value.get("dup")->as_string() == "first");
@@ -171,7 +171,7 @@ TEST_CASE("json parser: duplicate object keys return the first inserted value",
 }
 
 TEST_CASE("json parser: nested object paths remain readable through get",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"outer":{"inner":{"leaf":"value"}}})");
     auto* outer = value.get("outer");
     REQUIRE(outer != nullptr);
@@ -183,7 +183,7 @@ TEST_CASE("json parser: nested object paths remain readable through get",
 }
 
 TEST_CASE("json parser: duplicate object keys keep first-match lookup semantics",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"name":"first","name":"second"})");
     REQUIRE(value.type == json::JsonValue::Object);
     REQUIRE(value.obj().size() == 2);
@@ -192,7 +192,7 @@ TEST_CASE("json parser: duplicate object keys keep first-match lookup semantics"
 }
 
 TEST_CASE("json parser: unknown escapes preserve escaped byte",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(R"({"path":"a\qb","slash":"c\/d"})");
     REQUIRE(value.get("path") != nullptr);
     REQUIRE(value.get("slash") != nullptr);
@@ -201,7 +201,7 @@ TEST_CASE("json parser: unknown escapes preserve escaped byte",
 }
 
 TEST_CASE("json parser: scalar empty accessors share immutable defaults",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     const auto value = parse_json(R"("not an array or object")");
     REQUIRE(value.type == json::JsonValue::String);
     CHECK(value.arr().empty());
@@ -210,7 +210,7 @@ TEST_CASE("json parser: scalar empty accessors share immutable defaults",
 }
 
 TEST_CASE("json parser: whitespace is accepted around tokens",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json(" \n\t { \r\n \"k\" \t : \n [ true , false ] \n } ");
     auto* k = value.get("k");
     REQUIRE(k != nullptr);
@@ -220,21 +220,21 @@ TEST_CASE("json parser: whitespace is accepted around tokens",
 }
 
 TEST_CASE("json parser: invalid number tokens become zero-valued numbers",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json("-");
     CHECK(value.type == json::JsonValue::Number);
     CHECK(value.as_int() == 0);
 }
 
 TEST_CASE("json parser: empty input becomes a zero-valued number",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto value = parse_json("");
     CHECK(value.type == json::JsonValue::Number);
     CHECK(value.as_int() == 0);
 }
 
 TEST_CASE("json parser: lenient object and array delimiter recovery is stable",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto object = parse_json(R"({"a":1 "b":2})");
     REQUIRE(object.type == json::JsonValue::Object);
     REQUIRE(object.get("a") != nullptr);
@@ -251,7 +251,7 @@ TEST_CASE("json parser: lenient object and array delimiter recovery is stable",
 }
 
 TEST_CASE("json parser: delimiter recovery accepts adjacent object keys",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto object = parse_json(R"({"a":1 "b":2 "c":3})");
     REQUIRE(object.type == json::JsonValue::Object);
     REQUIRE(object.obj().size() == 3);
@@ -261,7 +261,7 @@ TEST_CASE("json parser: delimiter recovery accepts adjacent object keys",
 }
 
 TEST_CASE("json parser: delimiter recovery accepts adjacent array values",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto array = parse_json(R"([1 "two" {"three":3} true false null -4 +5 .6])");
     REQUIRE(array.type == json::JsonValue::Array);
     REQUIRE(array.arr().size() == 9);
@@ -278,7 +278,7 @@ TEST_CASE("json parser: delimiter recovery accepts adjacent array values",
 }
 
 TEST_CASE("json parser: EOF terminates lenient object and array recovery",
-          "[cli][json-parser][coverage][large]") {
+          "[cli][json-parser]") {
     auto object = parse_json(R"({"a":1 "b":2)");
     REQUIRE(object.type == json::JsonValue::Object);
     REQUIRE(object.obj().size() == 2);

--- a/test/test_cli_migration_index.cpp
+++ b/test/test_cli_migration_index.cpp
@@ -189,7 +189,7 @@ TEST_CASE("render_notes_text - includes version, summary, body, breaking tag",
 }
 
 TEST_CASE("render_notes_text - body without trailing newline is terminated",
-          "[cli][migration][coverage]") {
+          "[cli][migration]") {
     mig::MigrationEntry entry{
         "1.2.3",
         false,
@@ -238,7 +238,7 @@ TEST_CASE("render_notes_json - empty entries emits valid JSON with empty array",
 }
 
 TEST_CASE("render_notes_json - escapes strings and control characters",
-          "[cli][migration][coverage]") {
+          "[cli][migration]") {
     std::string summary = "quote \" slash \\ tab\t";
     std::string body = std::string("line\ncarriage\rcontrol ") + char(0x01);
     mig::MigrationEntry entry{
@@ -256,7 +256,7 @@ TEST_CASE("render_notes_json - escapes strings and control characters",
 }
 
 TEST_CASE("render_notes_json escapes hop version strings",
-          "[cli][migration][coverage]") {
+          "[cli][migration]") {
     std::vector<const mig::MigrationEntry*> empty;
     auto out = mig::render_notes_json(empty,
                                       "1.0.0\"from",

--- a/test/test_cli_package_commands.cpp
+++ b/test/test_cli_package_commands.cpp
@@ -458,7 +458,7 @@ TEST_CASE("cmd_target list shows source-checkout defaults without pulp.toml",
 }
 
 TEST_CASE("cmd_target covers alternate valid architectures",
-          "[cli][package-commands][target][coverage]") {
+          "[cli][package-commands][target]") {
     TempDir tmp;
     write_project_scaffold(tmp.path);
     REQUIRE(write_project_targets(tmp.path, {PlatformTarget{"macOS", "arm64"}}));
@@ -1083,7 +1083,7 @@ TEST_CASE("cmd_add does not accept arbitrary external sources for dependency pac
 }
 
 TEST_CASE("cmd_add accepts commercial override for proprietary packages",
-          "[cli][package-commands][add-remove][coverage]") {
+          "[cli][package-commands][add-remove]") {
     TempDir tmp;
     write_project_scaffold(tmp.path);
     write_file(tmp.path / "tools" / "packages" / "registry.json", R"({
@@ -1135,7 +1135,7 @@ TEST_CASE("cmd_add accepts commercial override for proprietary packages",
 }
 
 TEST_CASE("cmd_add permits review-required licenses with local metadata updates",
-          "[cli][package-commands][add-remove][coverage]") {
+          "[cli][package-commands][add-remove]") {
     TempDir tmp;
     write_project_scaffold(tmp.path);
     write_registry_fixture(tmp.path);
@@ -1172,7 +1172,7 @@ TEST_CASE("cmd_remove handles help and registry-free removal",
 }
 
 TEST_CASE("cmd_remove regenerates cmake when other packages remain",
-          "[cli][package-commands][add-remove][coverage]") {
+          "[cli][package-commands][add-remove]") {
     TempDir tmp;
     write_project_scaffold(tmp.path);
     write_registry_fixture(tmp.path);

--- a/test/test_cli_package_registry.cpp
+++ b/test/test_cli_package_registry.cpp
@@ -393,7 +393,7 @@ targets = ["Linux-x64"]
 }
 
 TEST_CASE("project targets cover alternate valid architectures and platform rewrite",
-          "[cli][package-registry][targets][coverage]") {
+          "[cli][package-registry][targets]") {
     auto linux_x86_64 = PlatformTarget::parse("Linux-x86_64");
     REQUIRE(linux_x86_64);
     REQUIRE(linux_x86_64->to_string() == "Linux-x86_64");
@@ -449,7 +449,7 @@ name = "DemoPlugin"
 }
 
 TEST_CASE("project target parsing prefers targets over later platforms key",
-          "[cli][package-registry][targets][coverage]") {
+          "[cli][package-registry][targets]") {
     TempDir tmp;
     write_file(tmp.path / "pulp.toml", R"([project]
 targets = ["Linux-x64"]
@@ -461,7 +461,7 @@ platforms = ["macOS"]
 }
 
 TEST_CASE("lock files tolerate sparse package entries and escaped package ids",
-          "[cli][package-registry][lock][coverage]") {
+          "[cli][package-registry][lock]") {
     TempDir tmp;
     write_file(tmp.path / "sparse-lock.json", R"({
   "lockfile_version": 4,
@@ -563,7 +563,7 @@ TEST_CASE("licenses, semver, and quality scoring classify local registry metadat
 }
 
 TEST_CASE("semver and quality cover boundary tiers",
-          "[cli][package-registry][quality][coverage]") {
+          "[cli][package-registry][quality]") {
     auto rc1 = *SemVer::parse("1.2.3-rc1");
     auto rc2 = *SemVer::parse("1.2.3-rc2");
     auto next_minor = *SemVer::parse("1.3.0");
@@ -636,7 +636,7 @@ TEST_CASE("package registry queries rank search hits and detect unsupported targ
 }
 
 TEST_CASE("package registry search covers category description and no-platform fallbacks",
-          "[cli][package-registry][search][coverage]") {
+          "[cli][package-registry][search]") {
     TempDir tmp;
     auto loaded = load_registry(write_registry_fixture(tmp.path));
     REQUIRE(loaded.error.empty());
@@ -669,7 +669,7 @@ TEST_CASE("package registry search covers category description and no-platform f
 }
 
 TEST_CASE("remote registry retries corrupt fresh cache before stale fallback",
-          "[cli][package-registry][remote][cache][coverage]") {
+          "[cli][package-registry][remote][cache]") {
     TempDir tmp;
     write_file(tmp.path / "registry-cache.json", "[]");
 

--- a/test/test_cli_project_bump.cpp
+++ b/test/test_cli_project_bump.cpp
@@ -212,7 +212,7 @@ TEST_CASE("refuse_dynamic_pin rejects branch names and SHAs",
 }
 
 TEST_CASE("pin normalization accepts uppercase v but preserves lowercase style only",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     REQUIRE(pb::pin_has_v_prefix("V1.2.3"));
     REQUIRE(pb::normalize_pin("V1.2.3") == "1.2.3");
     REQUIRE(pb::parse_semver_strict("V2.3.4").ok);
@@ -282,7 +282,7 @@ TEST_CASE("rewrite_pin returns nullopt on Unknown site",
 }
 
 TEST_CASE("rewrite_pin rejects stale and invalid captured spans",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     std::string src = "project(App VERSION 0.23.0)\n";
     auto site = pb::find_pin_site(src);
     REQUIRE(site.kind == pb::PinKind::ProjectVersion);
@@ -322,7 +322,7 @@ TEST_CASE("is_downgrade compares semver strictly",
 }
 
 TEST_CASE("compare_semver returns zero when either input is invalid",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     auto ok = pb::parse_semver_strict("1.2.3");
     auto bad = pb::parse_semver_strict("1.2");
     REQUIRE(pb::compare_semver(ok, bad) == 0);
@@ -403,7 +403,7 @@ TEST_CASE("legacy undo batch synthesizes a CMake edit",
 }
 
 TEST_CASE("parse_undo_batch rejects non-object roots and missing separators",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     REQUIRE_FALSE(pb::parse_undo_batch("").has_value());
     REQUIRE_FALSE(pb::parse_undo_batch("[]").has_value());
     REQUIRE_FALSE(pb::parse_undo_batch(R"({"timestamp" "missing-colon"})").has_value());
@@ -457,7 +457,7 @@ TEST_CASE("list_undo_batches returns newest-first",
 }
 
 TEST_CASE("list_undo_batches ignores non-files and non-undo names",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     TempDir tmp;
     fs::create_directories(tmp.path / "bump-undo-directory.json");
     std::ofstream(tmp.path / "not-an-undo.json") << "{}";
@@ -483,7 +483,7 @@ TEST_CASE("undo_batch_path replaces colons for Windows safety",
 }
 
 TEST_CASE("undo_batch_path returns empty for empty home",
-          "[project-bump][coverage][issue-643]") {
+          "[project-bump][issue-643]") {
     REQUIRE(pb::undo_batch_path({}, "2026-04-21T14:30:00Z").empty());
 }
 

--- a/test/test_cli_projects_registry.cpp
+++ b/test/test_cli_projects_registry.cpp
@@ -227,7 +227,7 @@ TEST_CASE("add_project falls back to directory basename when no name hint",
 }
 
 TEST_CASE("add_project canonicalises relative paths from current directory",
-          "[projects-registry][coverage]") {
+          "[projects-registry]") {
     TempDir tmp;
     auto reg = tmp.path / "projects.json";
     auto repo = tmp.path / "repo";
@@ -271,7 +271,7 @@ TEST_CASE("remove_project drops matching entries and is idempotent",
 }
 
 TEST_CASE("remove_project matches canonical relative paths",
-          "[projects-registry][coverage]") {
+          "[projects-registry]") {
     TempDir tmp;
     auto reg = tmp.path / "projects.json";
     auto repo = tmp.path / "repo";

--- a/test/test_cli_run_options.cpp
+++ b/test/test_cli_run_options.cpp
@@ -118,7 +118,7 @@ TEST_CASE("pulp run --frames rejects non-positive and non-integer values",
 }
 
 TEST_CASE("pulp run --frames rejects overflow and plus-prefixed values",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     REQUIRE_FALSE(parse_run_options({"--frames", "999999999999999999999"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames=999999999999999999999"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames", "+5"}).error.empty());
@@ -181,7 +181,7 @@ TEST_CASE("pulp run forwards arguments after `--` verbatim",
 }
 
 TEST_CASE("pulp run forwards all tokens after separator including known flags",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({"target", "--", "--headless", "--frames", "9"});
     REQUIRE(r.target_name == "target");
     REQUIRE_FALSE(r.headless);
@@ -195,14 +195,14 @@ TEST_CASE("pulp run forwards all tokens after separator including known flags",
 }
 
 TEST_CASE("pulp run ignores repeated separator tokens before pass-through",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({"target", "--", "--", "--frames=4"});
     REQUIRE(r.target_name == "target");
     REQUIRE(r.user_pass_through == std::vector<std::string>{"--frames=4"});
 }
 
 TEST_CASE("pulp run treats additional positionals as pass-through",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({"primary-target", "secondary", "third"});
     REQUIRE(r.target_name == "primary-target");
     REQUIRE(r.user_pass_through == std::vector<std::string>{"secondary", "third"});
@@ -236,7 +236,7 @@ TEST_CASE("pulp run --frames default does not appear in launch args",
 }
 
 TEST_CASE("pulp run keeps last repeated scalar flag values",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({
         "--frames", "2",
         "--screenshot", "/tmp/first.png",
@@ -257,7 +257,7 @@ TEST_CASE("pulp run keeps last repeated scalar flag values",
 }
 
 TEST_CASE("pulp run preserves pass-through ordering after launcher flags",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({
         "demo",
         "--headless",
@@ -282,7 +282,7 @@ TEST_CASE("pulp run preserves pass-through ordering after launcher flags",
 }
 
 TEST_CASE("pulp run records launcher flags before a separator only",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({
         "--screenshot=/tmp/before.png",
         "--",
@@ -312,7 +312,7 @@ TEST_CASE("pulp run records launcher flags before a separator only",
 }
 
 TEST_CASE("pulp run help stops before later invalid flags",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto long_help = parse_run_options({"--help", "--frames", "bad"});
     REQUIRE(long_help.help);
     REQUIRE(long_help.error.empty());
@@ -325,7 +325,7 @@ TEST_CASE("pulp run help stops before later invalid flags",
 }
 
 TEST_CASE("pulp run reports screenshot path shape errors without consuming later tokens",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto flag_like = parse_run_options({"--screenshot", "-out.png"});
     REQUIRE(flag_like.error == "--screenshot requires a path argument");
     REQUIRE(flag_like.headless);
@@ -338,7 +338,7 @@ TEST_CASE("pulp run reports screenshot path shape errors without consuming later
 }
 
 TEST_CASE("pulp run reports frame count shape errors precisely",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto missing = parse_run_options({"--frames"});
     REQUIRE(missing.error == "--frames requires an integer argument");
     REQUIRE(missing.frames == 1);
@@ -357,7 +357,7 @@ TEST_CASE("pulp run reports frame count shape errors precisely",
 }
 
 TEST_CASE("pulp run accepts boundary frame count values",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto single = parse_run_options({"--frames", "1"});
     REQUIRE(single.error.empty());
     REQUIRE(single.frames == 1);
@@ -552,7 +552,7 @@ TEST_CASE("pulp run rejects invalid audio-capture-rolling options and capture-mo
 }
 
 TEST_CASE("pulp run treats negative-looking targets as pass-through flags",
-          "[cli][run][coverage]") {
+          "[cli][run]") {
     auto r = parse_run_options({"--standalone", "demo"});
     REQUIRE(r.target_name == "demo");
     REQUIRE(r.user_pass_through == std::vector<std::string>{"--standalone"});

--- a/test/test_cli_sdk_tarball_filename.cpp
+++ b/test/test_cli_sdk_tarball_filename.cpp
@@ -67,24 +67,24 @@ TEST_CASE("sdk_tarball_filename and legacy form disagree on every supported "
 }
 
 TEST_CASE("sdk_tarball_filename: prerelease versions remain literal in cache keys",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(sdk_tarball_filename("1.2.3-rc.1", "darwin-arm64") ==
             "pulp-sdk-v1.2.3-rc.1-darwin-arm64.tar.gz");
 }
 
 TEST_CASE("sdk_tarball_filename: platform strings are not normalized",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(sdk_tarball_filename("0.92.0", "Darwin-ARM64") ==
             "pulp-sdk-v0.92.0-Darwin-ARM64.tar.gz");
 }
 
 TEST_CASE("legacy_unversioned_sdk_tarball_filename: empty platform keeps legacy prefix",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(legacy_unversioned_sdk_tarball_filename("") == "pulp-sdk-.tar.gz");
 }
 
 TEST_CASE("sdk_tarball_filename: empty version keeps the version slot visible",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(sdk_tarball_filename("", "linux-x64") ==
             "pulp-sdk-v-linux-x64.tar.gz");
     REQUIRE(sdk_tarball_filename("", "darwin-arm64") ==
@@ -92,13 +92,13 @@ TEST_CASE("sdk_tarball_filename: empty version keeps the version slot visible",
 }
 
 TEST_CASE("sdk_tarball_filename: empty platform keeps the trailing platform slot",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(sdk_tarball_filename("0.92.0", "") ==
             "pulp-sdk-v0.92.0-.tar.gz");
 }
 
 TEST_CASE("sdk_tarball_filename: literal input is preserved for cache-key transparency",
-          "[cli][cache][coverage][large]") {
+          "[cli][cache]") {
     REQUIRE(sdk_tarball_filename(" 0.92.0 ", "linux x64") ==
             "pulp-sdk-v 0.92.0 -linux x64.tar.gz");
     REQUIRE(legacy_unversioned_sdk_tarball_filename("linux x64") ==

--- a/test/test_cli_shell_quote.cpp
+++ b/test/test_cli_shell_quote.cpp
@@ -28,7 +28,7 @@ TEST_CASE("yaml_value reads plain and list-item scalars", "[cli][yaml][docs][iss
     REQUIRE(yaml_value("      - summary: list item", "summary") == "list item");
 }
 
-TEST_CASE("yaml_value rejects mismatched keys and empty values", "[cli][yaml][coverage]") {
+TEST_CASE("yaml_value rejects mismatched keys and empty values", "[cli][yaml]") {
     REQUIRE(yaml_value("slug_name: wrong", "slug").empty());
     REQUIRE(yaml_value("slug", "slug").empty());
     REQUIRE(yaml_value("slug:", "slug").empty());
@@ -37,7 +37,7 @@ TEST_CASE("yaml_value rejects mismatched keys and empty values", "[cli][yaml][co
     REQUIRE(yaml_value("  - name: ship", "slug").empty());
 }
 
-TEST_CASE("cli string helpers preserve command-facing contracts", "[cli][common][coverage]") {
+TEST_CASE("cli string helpers preserve command-facing contracts", "[cli][common]") {
     REQUIRE(trim("  \tPulp\n") == "Pulp");
     REQUIRE(strip_quotes("\"quoted value\"") == "quoted value");
     REQUIRE(strip_quotes("'quoted value'") == "quoted value");
@@ -53,7 +53,7 @@ TEST_CASE("cli string helpers preserve command-facing contracts", "[cli][common]
 }
 
 TEST_CASE("parse_size_arg accepts decimal integers without disturbing failures",
-          "[cli][common][coverage]") {
+          "[cli][common]") {
     std::size_t value = 77;
     REQUIRE(parse_size_arg("0", "--top", value));
     REQUIRE(value == 0);
@@ -79,7 +79,7 @@ TEST_CASE("parse_size_arg accepts decimal integers without disturbing failures",
 }
 
 TEST_CASE("parse_double_arg accepts finite decimals and rejects non-finite text",
-          "[cli][common][coverage]") {
+          "[cli][common]") {
     double value = 9.0;
     REQUIRE(parse_double_arg("0", "--min-score", value));
     REQUIRE(value == 0.0);

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -263,7 +263,7 @@ TEST_CASE("pulp audio read-bundle json reports missing bundle errors",
 }
 
 TEST_CASE("pulp audio model commands report install, activation, and status state",
-          "[cli][shellout][audio][coverage]") {
+          "[cli][shellout][audio]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-audio-model-shellout-home");
@@ -330,7 +330,7 @@ TEST_CASE("pulp audio model commands report install, activation, and status stat
 }
 
 TEST_CASE("pulp audio read-bundle reports manifest metadata in text and json",
-          "[cli][shellout][audio][coverage]") {
+          "[cli][shellout][audio]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto root = unique_temp_dir("pulp-audio-bundle-shellout");
@@ -388,7 +388,7 @@ TEST_CASE("pulp audio read-bundle reports manifest metadata in text and json",
 }
 
 TEST_CASE("pulp audio excerpt-find surfaces service errors through text and json",
-          "[cli][shellout][audio][coverage]") {
+          "[cli][shellout][audio]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-audio-excerpt-shellout-home");
@@ -443,7 +443,7 @@ TEST_CASE("pulp audio excerpt-find surfaces service errors through text and json
 }
 
 TEST_CASE("pulp cache usage and parser errors are deterministic",
-          "[cli][shellout][cache][coverage]") {
+          "[cli][shellout][cache]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-cache-shellout-home");
@@ -609,7 +609,7 @@ TEST_CASE("pulp status reports effective PR workflow",
 }
 
 TEST_CASE("pulp status and clean reject unexpected arguments before side effects",
-          "[cli][shellout][misc][coverage]") {
+          "[cli][shellout][misc]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto status_extra = run_pulp({"status", "extra"});
@@ -626,7 +626,7 @@ TEST_CASE("pulp status and clean reject unexpected arguments before side effects
 }
 
 TEST_CASE("pulp clean removes the active project build directory",
-          "[cli][shellout][misc][coverage]") {
+          "[cli][shellout][misc]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto project = unique_temp_dir("pulp-clean-shellout");
@@ -871,7 +871,7 @@ TEST_CASE("pulp version check exits 0 on a clean tree and mentions SDK/plugin/ma
 }
 
 TEST_CASE("pulp version outside a project reports SDK but check fails clearly",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -897,7 +897,7 @@ TEST_CASE("pulp version outside a project reports SDK but check fails clearly",
 }
 
 TEST_CASE("pulp version check accepts a complete matching project fixture",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -934,7 +934,7 @@ TEST_CASE("pulp version check accepts a complete matching project fixture",
 }
 
 TEST_CASE("pulp version check reports every version drift surface",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -969,7 +969,7 @@ TEST_CASE("pulp version check reports every version drift surface",
 }
 
 TEST_CASE("pulp version check rejects unknown options before running checks",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -994,7 +994,7 @@ TEST_CASE("pulp version check rejects unknown options before running checks",
 }
 
 TEST_CASE("pulp version bump updates project version and changelog guidance",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -1030,7 +1030,7 @@ TEST_CASE("pulp version bump updates project version and changelog guidance",
 }
 
 TEST_CASE("pulp version bump --plugin only updates pulp_add_plugin version",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -1065,7 +1065,7 @@ TEST_CASE("pulp version bump --plugin only updates pulp_add_plugin version",
 }
 
 TEST_CASE("pulp version bump rejects missing and invalid components",
-          "[cli][shellout][version][coverage]") {
+          "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar updates("PULP_UPDATE_CHECK_DISABLED");
@@ -1202,7 +1202,7 @@ TEST_CASE("pulp help output lists the top-level subcommands",
 }
 
 TEST_CASE("pulp macos validates local operator arguments before gh calls",
-          "[cli][shellout][macos][coverage]") {
+          "[cli][shellout][macos]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
@@ -1259,7 +1259,7 @@ TEST_CASE("pulp macos validates local operator arguments before gh calls",
 }
 
 TEST_CASE("pulp overflow validates non-mutating operator arguments",
-          "[cli][shellout][overflow][coverage]") {
+          "[cli][shellout][overflow]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
@@ -1521,7 +1521,7 @@ TEST_CASE("pulp create rejects invalid type before scaffolding",
 }
 
 TEST_CASE("pulp create validates parser errors before scaffolding",
-          "[cli][shellout][create][coverage]") {
+          "[cli][shellout][create]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto base = fs::temp_directory_path() /
@@ -1761,7 +1761,7 @@ TEST_CASE("pulp build allows explicit unsupported SDK bypass",
 }
 
 TEST_CASE("pulp build validates js engine option before compatibility checks",
-          "[cli][shellout][build][coverage]") {
+          "[cli][shellout][build]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp = unique_temp_dir("pulp-shellout-build-js-engine");
@@ -2063,7 +2063,7 @@ TEST_CASE("pulp project bump rejects non-semver --to",
 }
 
 TEST_CASE("pulp project bump rejects missing --to values before project lookup",
-          "[cli][shellout][project][coverage]") {
+          "[cli][shellout][project]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());
@@ -2087,7 +2087,7 @@ TEST_CASE("pulp project bump rejects missing --to values before project lookup",
 }
 
 TEST_CASE("pulp project validates stray parser arguments before project lookup",
-          "[cli][shellout][project][coverage]") {
+          "[cli][shellout][project]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());

--- a/test/test_cli_shellout_lifecycle.cpp
+++ b/test/test_cli_shellout_lifecycle.cpp
@@ -116,7 +116,7 @@ TEST_CASE("pulp dev fails fast when standalone SDK is ahead of the installed CLI
 }
 
 TEST_CASE("pulp design validates owned option values before autobind",
-          "[cli][shellout][design][coverage]") {
+          "[cli][shellout][design]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     struct Case {
@@ -141,7 +141,7 @@ TEST_CASE("pulp design validates owned option values before autobind",
 }
 
 TEST_CASE("pulp dev validates value options before build or watch",
-          "[cli][shellout][dev][coverage]") {
+          "[cli][shellout][dev]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp = fs::temp_directory_path() /
@@ -269,7 +269,7 @@ TEST_CASE("pulp upgrade --notes --json emits stable-shape JSON keys",
 }
 
 TEST_CASE("pulp upgrade validates parser errors before network access",
-          "[cli][shellout][upgrade][coverage]") {
+          "[cli][shellout][upgrade]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     struct Case {
@@ -295,7 +295,7 @@ TEST_CASE("pulp upgrade validates parser errors before network access",
 }
 
 TEST_CASE("pulp sdk install validates parser errors before side effects",
-          "[cli][shellout][sdk][coverage]") {
+          "[cli][shellout][sdk]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-sdk-parser-home");
@@ -329,7 +329,7 @@ TEST_CASE("pulp sdk install validates parser errors before side effects",
 }
 
 TEST_CASE("pulp sdk status and clean report cache state deterministically",
-          "[cli][shellout][sdk][coverage]") {
+          "[cli][shellout][sdk]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto home = unique_temp_dir("pulp-sdk-status-home");
@@ -384,7 +384,7 @@ TEST_CASE("pulp sdk status and clean report cache state deterministically",
 }
 
 TEST_CASE("pulp status quotes source checkout paths before reading Git metadata",
-          "[cli][shellout][status][coverage]") {
+          "[cli][shellout][status]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto root = unique_temp_dir("pulp status path with spaces and quote ' fixture");
@@ -427,7 +427,7 @@ TEST_CASE("pulp status quotes source checkout paths before reading Git metadata"
 }
 
 TEST_CASE("pulp upgrade --check-only honors disabled update checks with an empty cache",
-          "[cli][shellout][upgrade][codecov]") {
+          "[cli][shellout][upgrade]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp = fs::temp_directory_path() /

--- a/test/test_cli_shellout_loop.cpp
+++ b/test/test_cli_shellout_loop.cpp
@@ -138,7 +138,7 @@ TEST_CASE("pulp loop --platform=<unknown> exits non-zero with diagnostic",
 }
 
 TEST_CASE("pulp loop validates value options before focus state changes",
-          "[cli][shellout][loop][coverage]") {
+          "[cli][shellout][loop]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto tmp_home = unique_temp_dir("pulp-loop-parser-errors");

--- a/test/test_cli_shellout_pr.cpp
+++ b/test/test_cli_shellout_pr.cpp
@@ -254,7 +254,7 @@ TEST_CASE("pulp pr native help stays available without shipyard",
 }
 
 TEST_CASE("pulp pr native validates option values before checkout lookup",
-          "[cli][shellout][pr][coverage]") {
+          "[cli][shellout][pr]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const auto bin = fs::absolute(pulp_binary());

--- a/test/test_cli_shellout_scan_projects.cpp
+++ b/test/test_cli_shellout_scan_projects.cpp
@@ -53,7 +53,7 @@ TEST_CASE("pulp projects list (no --json) emits human text",
 }
 
 TEST_CASE("pulp projects validates parser errors before registry mutation",
-          "[cli][shellout][projects][coverage]") {
+          "[cli][shellout][projects]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto pulp_home = unique_temp_dir("pulp-projects-parser-home");
@@ -201,7 +201,7 @@ TEST_CASE("pulp scan --help exits 0 with usage on stdout",
 }
 
 TEST_CASE("pulp scan validates parser errors before filesystem enumeration",
-          "[cli][shellout][scan][coverage]") {
+          "[cli][shellout][scan]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const struct {
@@ -226,7 +226,7 @@ TEST_CASE("pulp scan validates parser errors before filesystem enumeration",
 }
 
 TEST_CASE("pulp host validates parser errors before plugin loading",
-          "[cli][shellout][host][coverage]") {
+          "[cli][shellout][host]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     const struct {
@@ -267,7 +267,7 @@ TEST_CASE("pulp host help lists every supported format and descriptor id flag",
 }
 
 TEST_CASE("pulp host derives AU id from bundle Info.plist",
-          "[cli][shellout][host][au][coverage]") {
+          "[cli][shellout][host][au]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 #if !defined(__APPLE__)
     SUCCEED("AU host loading is macOS-only");

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -271,7 +271,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship help does not require a project or build directory",
-                 "[cli][shellout][ship][help][coverage]") {
+                 "[cli][shellout][ship][help]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
 
     auto outside = run_pulp_in(fs::temp_directory_path(), {"ship", "--help"});
@@ -324,7 +324,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship rejects unknown subcommands before side effects",
-                 "[cli][shellout][ship][help][coverage]") {
+                 "[cli][shellout][ship][help]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("unknown-subcommand", true);
 
@@ -424,7 +424,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship sign discovers desktop bundles via env and config identities",
-                 "[cli][shellout][ship][coverage]") {
+                 "[cli][shellout][ship]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("sign-bundles", true);
     make_fake_bundle(root, "VST3", "FakeShipPlugin.vst3");
@@ -459,7 +459,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship validates option parser errors before side effects",
-                 "[cli][shellout][ship][coverage]") {
+                 "[cli][shellout][ship]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("parser-errors", true);
 
@@ -519,7 +519,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship check reports desktop bundle signing status without credentials",
-                 "[cli][shellout][ship][coverage]") {
+                 "[cli][shellout][ship]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("check-desktop", true);
     make_fake_bundle(root, "VST3", "CheckMe.vst3");
@@ -577,7 +577,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship appcast uses safe defaults and preserves existing invalid feed fallback",
-                 "[cli][shellout][ship][appcast][coverage]") {
+                 "[cli][shellout][ship][appcast]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("appcast-defaults", true);
     auto feed = root / "artifacts" / "defaults.xml";
@@ -653,7 +653,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship appcast appends local artifact metadata",
-                 "[cli][shellout][ship][appcast][coverage]") {
+                 "[cli][shellout][ship][appcast]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("appcast-local", true);
     auto feed = root / "artifacts" / "updates.xml";
@@ -711,7 +711,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship appcast fails closed on invalid local signing keys",
-                 "[cli][shellout][ship][appcast][coverage]") {
+                 "[cli][shellout][ship][appcast]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("appcast-bad-sign", true);
     auto artifact = root / "artifacts" / "FakeShipPlugin-4.0.0.pkg";
@@ -740,7 +740,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship android check tolerates empty artifacts directory",
-                 "[cli][shellout][ship][android][coverage]") {
+                 "[cli][shellout][ship][android]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("android-empty-artifacts", true);
     fs::create_directories(root / "artifacts");
@@ -761,7 +761,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 #if defined(__APPLE__)
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship package with no plugin bundles reports zero artifacts",
-                 "[cli][shellout][ship][package][coverage]") {
+                 "[cli][shellout][ship][package]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("package-empty", true);
 
@@ -777,7 +777,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 #elif defined(__linux__)
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship package on Linux with no plugin bundles reports missing plugins",
-                 "[cli][shellout][ship][package][linux-package][coverage]") {
+                 "[cli][shellout][ship][package][linux-package]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("package-empty-linux", true);
 
@@ -850,7 +850,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship release aborts before later stages when signing fails",
-                 "[cli][shellout][ship][release][macos-7.4][coverage]") {
+                 "[cli][shellout][ship][release][macos-7.4]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("release-sign-fail", true);
 
@@ -990,7 +990,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 #ifdef __APPLE__
 TEST_CASE_METHOD(ShipShelloutFixture,
                  "pulp ship auv3-xcodeproj parser rejects missing values and extra positionals",
-                 "[cli][shellout][ship][auv3-xcodeproj][macos-3.10][coverage]") {
+                 "[cli][shellout][ship][auv3-xcodeproj][macos-3.10]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("auv3-xcodeproj-parser", true);
 

--- a/test/test_cli_tool_registry.cpp
+++ b/test/test_cli_tool_registry.cpp
@@ -467,7 +467,7 @@ TEST_CASE("tool registry rejects unsupported archive formats",
 }
 
 TEST_CASE("tool registry coverage preserves platform sources and home helpers",
-          "[cli][tool-registry][coverage]") {
+          "[cli][tool-registry]") {
     TempDir tmp;
     ScopedEnv home{"PULP_HOME", tmp.path / "custom-home"};
 
@@ -777,7 +777,7 @@ TEST_CASE("tool install helpers have deterministic local exits",
 }
 
 TEST_CASE("tool install all succeeds with cached binary and python tools",
-          "[cli][tool-registry][install][coverage]") {
+          "[cli][tool-registry][install]") {
     TempDir tmp;
     ScopedEnv home{"PULP_HOME", tmp.path / "home"};
     fs::create_directories(tmp.path / "repo" / "tools" / "packages");

--- a/test/test_cli_update_check.cpp
+++ b/test/test_cli_update_check.cpp
@@ -101,7 +101,7 @@ TEST_CASE("parse_cache_json tolerates missing/unknown fields",
 }
 
 TEST_CASE("parse_cache_json keeps defaults for non-positive schema and malformed ints",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     auto negative_schema = uc::parse_cache_json(R"({
         "schema": -7,
         "last_check_epoch_sec": -42,
@@ -122,7 +122,7 @@ TEST_CASE("parse_cache_json keeps defaults for non-positive schema and malformed
 }
 
 TEST_CASE("serialize_cache_json escapes cache string fields",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     uc::CacheEntry entry;
     entry.latest_version = "1.2.3\nnext";
     entry.release_notes_url = "https://example.invalid/tag/\"quoted\"";
@@ -156,7 +156,7 @@ TEST_CASE("write_cache_file + read_cache_file atomically round-trip",
 }
 
 TEST_CASE("write_cache_file creates parents and reports blocked parent paths",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     auto dir = make_tmpdir("write-cache-parents");
 
     uc::CacheEntry entry;
@@ -257,7 +257,7 @@ TEST_CASE("parse_semver tolerates release tag boundaries",
 }
 
 TEST_CASE("parse_semver accepts short release triples with zero-filled tail",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     auto major_only = uc::parse_semver("7");
     REQUIRE(major_only.ok);
     REQUIRE(major_only.major == 7);
@@ -285,7 +285,7 @@ TEST_CASE("is_newer compares correctly", "[cli][update-check][issue-547]") {
 }
 
 TEST_CASE("compare_semver orders each component and ignores invalid triples",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     REQUIRE(uc::compare_semver(uc::parse_semver("1.0.0"),
                                uc::parse_semver("2.0.0")) == -1);
     REQUIRE(uc::compare_semver(uc::parse_semver("2.1.0"),
@@ -320,7 +320,7 @@ TEST_CASE("write_toml_key_in_section creates missing section",
 }
 
 TEST_CASE("write_toml_key_in_section appends after existing content without trailing newline",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     std::string src =
         "[create]\n"
         "projects_dir = \"~/dev\"";
@@ -430,7 +430,7 @@ TEST_CASE("write_toml_key_in_section appends into empty section before the next 
 }
 
 TEST_CASE("read_toml_key_in_section handles bare values and section boundaries",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     std::string src =
         "[update]\n"
         "mode = manual\n"
@@ -445,7 +445,7 @@ TEST_CASE("read_toml_key_in_section handles bare values and section boundaries",
 }
 
 TEST_CASE("read_toml_key_in_section does not match substring keys",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     std::string src =
         "[update]\n"
         "mode_name = \"auto\"\n"
@@ -635,7 +635,7 @@ TEST_CASE("resolve_latest_with_persist refreshes when cached version is empty",
 }
 
 TEST_CASE("resolve_latest_with_persist supports empty cache path without writing",
-          "[cli][update-check][codecov]") {
+          "[cli][update-check]") {
     FakeFetcher fetcher;
     fetcher.canned.ok = true;
     fetcher.canned.latest_version = "0.81.0";

--- a/test/test_cli_update_mode.cpp
+++ b/test/test_cli_update_mode.cpp
@@ -166,7 +166,7 @@ TEST_CASE("write_snooze rejects non-positive hour values",
 }
 
 TEST_CASE("write_snooze creates missing parent directories",
-          "[cli][update-mode][coverage]") {
+          "[cli][update-mode]") {
     auto dir = make_tmpdir("snooze-parent");
     auto snooze = dir / "nested" / "state" / "update-snooze";
 
@@ -196,7 +196,7 @@ TEST_CASE("pending-upgrade JSON round-trips through serialize/parse",
 }
 
 TEST_CASE("pending-upgrade JSON escapes string fields",
-          "[cli][update-mode][coverage]") {
+          "[cli][update-mode]") {
     um::PendingUpgrade p;
     p.version = "0.31.0-rc\"1\nbuild\rmeta\t";
     p.staged_at_epoch_sec = 7;
@@ -226,7 +226,7 @@ TEST_CASE("parse_pending_upgrade rejects markers without a version",
 }
 
 TEST_CASE("parse_pending_upgrade tolerates optional fields and bad timestamps",
-          "[cli][update-mode][coverage]") {
+          "[cli][update-mode]") {
     auto missing_optional = um::parse_pending_upgrade(
         "{\"version\":\"0.31.0\",\"extra\":\"ignored\"}");
     REQUIRE(missing_optional.has_value());

--- a/test/test_cli_upgrade_install.cpp
+++ b/test/test_cli_upgrade_install.cpp
@@ -103,7 +103,7 @@ TEST_CASE("upgrade install copies sibling payloads before self replacement",
 }
 
 TEST_CASE("upgrade install skips directories, primary binary, and downloaded archive",
-          "[cli][upgrade][coverage][issue-643]") {
+          "[cli][upgrade][issue-643]") {
     auto extracted = make_tmpdir("skip");
     auto install = make_tmpdir("skip-install");
 
@@ -132,14 +132,14 @@ TEST_CASE("upgrade install skips directories, primary binary, and downloaded arc
 }
 
 TEST_CASE("upgrade install detects cpp delegate only by exact filename",
-          "[cli][upgrade][coverage][issue-643]") {
+          "[cli][upgrade][issue-643]") {
     REQUIRE(ui::installed_cpp_delegate({fs::path{"bin"} / ui::cpp_binary_name()}));
     REQUIRE_FALSE(ui::installed_cpp_delegate({fs::path{"bin"} / "pulp-cpp-helper"}));
     REQUIRE_FALSE(ui::installed_cpp_delegate({}));
 }
 
 TEST_CASE("upgrade install same_path falls back to lexical normalization",
-          "[cli][upgrade][coverage][issue-643]") {
+          "[cli][upgrade][issue-643]") {
     auto root = make_tmpdir("same-path");
     auto path = root / "a" / ".." / "artifact";
     auto normalized = root / "artifact";
@@ -151,7 +151,7 @@ TEST_CASE("upgrade install same_path falls back to lexical normalization",
 }
 
 TEST_CASE("upgrade install executable permission policy covers binary names and source bits",
-          "[cli][upgrade][coverage][issue-643]") {
+          "[cli][upgrade][issue-643]") {
     auto root = make_tmpdir("perms");
     auto primary = root / ui::primary_binary_name();
     auto cpp = root / ui::cpp_binary_name();

--- a/test/test_cli_upgrade_url.cpp
+++ b/test/test_cli_upgrade_url.cpp
@@ -59,32 +59,32 @@ TEST_CASE("pulp upgrade URL: version field flows into the release tag verbatim",
 }
 
 TEST_CASE("pulp upgrade URL: unknown non-Windows platforms keep tarball shape",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto r = pulp_upgrade_url_for("2.0.0", "freebsd", "x64");
     REQUIRE(r.asset == "pulp-freebsd-x64.tar.gz");
     REQUIRE(r.url.find("/v2.0.0/pulp-freebsd-x64.tar.gz") != std::string::npos);
 }
 
 TEST_CASE("pulp upgrade URL: platform comparison is intentionally exact",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto r = pulp_upgrade_url_for("2.0.0", "Windows", "x64");
     REQUIRE(r.asset == "pulp-Windows-x64.tar.gz");
 }
 
 TEST_CASE("pulp upgrade URL: asset name is reused verbatim as URL suffix",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto r = pulp_upgrade_url_for("2.1.0", "darwin", "arm64");
     REQUIRE(r.url.ends_with("/" + r.asset));
 }
 
 TEST_CASE("pulp upgrade URL: empty version still produces the v-prefixed tag slot",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto r = pulp_upgrade_url_for("", "linux", "x64");
     REQUIRE(r.url.find("/download/v/pulp-linux-x64.tar.gz") != std::string::npos);
 }
 
 TEST_CASE("pulp upgrade URL: empty platform and arch remain literal in asset",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto empty_platform = pulp_upgrade_url_for("2.2.0", "", "arm64");
     REQUIRE(empty_platform.asset == "pulp--arm64.tar.gz");
     REQUIRE(empty_platform.url.ends_with("/pulp--arm64.tar.gz"));
@@ -95,7 +95,7 @@ TEST_CASE("pulp upgrade URL: empty platform and arch remain literal in asset",
 }
 
 TEST_CASE("pulp upgrade URL: literal input is not normalized or URL escaped",
-          "[cli][upgrade][url][coverage][large]") {
+          "[cli][upgrade][url]") {
     auto r = pulp_upgrade_url_for(" 2.2.0 ", "darwin universal", "arm 64");
     REQUIRE(r.asset == "pulp-darwin universal-arm 64.tar.gz");
     REQUIRE(r.url.find("/download/v 2.2.0 /") != std::string::npos);

--- a/test/test_cli_validator_discovery.cpp
+++ b/test/test_cli_validator_discovery.cpp
@@ -338,7 +338,7 @@ TEST_CASE("first-existing priority path wins even when a healthy copy is further
 }
 
 TEST_CASE("discovery uses PATH-resolved validator when known paths are absent",
-          "[doctor][validators][coverage]") {
+          "[doctor][validators]") {
     StubEnv env;
     env.path_resolve["pluginval"] = "/opt/local/bin/pluginval";
     env.existing.insert("/opt/local/bin/pluginval");
@@ -354,7 +354,7 @@ TEST_CASE("discovery uses PATH-resolved validator when known paths are absent",
 }
 
 TEST_CASE("broken validator with unknown ownership requires manual sudo path",
-          "[doctor][validators][coverage]") {
+          "[doctor][validators]") {
     StubEnv env;
     env.existing.insert("/usr/local/bin/pluginval");
     // Deliberately omit owners entry: classify_ownership returns Unknown.
@@ -496,7 +496,7 @@ TEST_CASE("apply_fixes is a no-op on a fully healthy environment",
 }
 
 TEST_CASE("apply_fixes counts mixed healthy missing and root-owned reports",
-          "[doctor][validators][coverage]") {
+          "[doctor][validators]") {
     std::vector<vd::ValidatorReport> reports;
 
     vd::ValidatorReport healthy;
@@ -524,7 +524,7 @@ TEST_CASE("apply_fixes counts mixed healthy missing and root-owned reports",
 }
 
 TEST_CASE("render_report can emit ANSI color wrappers",
-          "[doctor][validators][coverage]") {
+          "[doctor][validators]") {
     vd::ValidatorReport healthy;
     healthy.name = "auval";
     healthy.status = vd::ValidatorStatus::Healthy;

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -120,7 +120,7 @@ TEST_CASE("read_plugin_version returns empty on missing file",
 }
 
 TEST_CASE("read_plugin_version returns empty when manifest has no version field",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     TempDir tmp;
     auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
     write_file(plugin_json, R"({
@@ -151,7 +151,7 @@ TEST_CASE("read_plugin_version accepts tag-style version strings",
 }
 
 TEST_CASE("read_plugin_version returns non-comparable for tagged dev manifests",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     TempDir tmp;
     auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
     write_file(plugin_json, R"({"version": "0.8.0-dev"})");
@@ -182,7 +182,7 @@ TEST_CASE("locate_plugin_json falls back to the repo .claude-plugin dir",
 }
 
 TEST_CASE("locate_plugin_json ignores a missing override and falls back",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     TempDir tmp;
     auto repo_plugin = tmp.path / ".claude-plugin" / "plugin.json";
     write_file(repo_plugin, R"({"version": "0.6.0"})");
@@ -192,7 +192,7 @@ TEST_CASE("locate_plugin_json ignores a missing override and falls back",
 }
 
 TEST_CASE("locate_plugin_json returns empty without repo or override matches",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     TempDir tmp;
     auto found = locate_plugin_json(tmp.path / "not-a-repo", {});
     REQUIRE(found.empty());
@@ -280,7 +280,7 @@ TEST_CASE("execution preflight ignores satisfied and non-comparable requirements
 }
 
 TEST_CASE("execution preflight records the highest required CLI version",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     auto sdk_required = analyze_execution_preflight(parse_semver("0.33.0"),
                                                    parse_semver("0.40.0"),
                                                    parse_semver("0.36.0"));
@@ -342,7 +342,7 @@ TEST_CASE("read_project_cli_min_version returns empty when absent",
 }
 
 TEST_CASE("read_project_cli_min_version ignores an empty project root",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     auto v = read_project_cli_min_version({});
     REQUIRE_FALSE(v.comparable);
     REQUIRE(v.raw.empty());
@@ -398,7 +398,7 @@ TEST_CASE("read_project_cli_min_version still reads through comments",
 }
 
 TEST_CASE("read_project_cli_min_version ignores unquoted and malformed values",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     TempDir tmp;
     write_file(tmp.path / "pulp.toml",
                "[pulp]\n"
@@ -498,7 +498,7 @@ TEST_CASE("analyze is silent when a per-project SDK matches the CLI",
 }
 
 TEST_CASE("analyze uses the path basename when project name is empty",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     VersionReport r;
     r.cli = parse_semver("0.20.0");
     ProjectEntry p;
@@ -554,7 +554,7 @@ TEST_CASE("read_plugin_min_cli_version is empty when the field is absent",
 }
 
 TEST_CASE("read_plugin_min_cli_version returns empty on missing file",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     auto v = read_plugin_min_cli_version("/nonexistent/path/plugin.json");
     REQUIRE_FALSE(v.comparable);
     REQUIRE(v.raw.empty());
@@ -680,7 +680,7 @@ TEST_CASE("render_report returns zero for an empty comparable report",
 }
 
 TEST_CASE("render_report prints scanned and missing project markers",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     VersionReport r;
     r.cli = parse_semver("0.31.0");
 
@@ -737,7 +737,7 @@ TEST_CASE("render_report_json emits JSON with projects[] and findings[]",
 }
 
 TEST_CASE("render_report_json escapes strings and control characters",
-          "[version-diag][coverage][issue-643]") {
+          "[version-diag][issue-643]") {
     VersionReport r;
     r.cli = parse_semver("0.20.0");
     r.plugin_json_path = "/tmp/plugin\"quoted\".json";


### PR DESCRIPTION
## Summary
- Removes stale Catch2 selector meta tags `[coverage]`, `[codecov]`, `[requested]`, and `[large]` from 29 CLI/package-tooling and Android package test files.
- Preserves product/platform/shellout selectors and issue selectors such as `[issue-643]` and `[issue-644]`.
- Tag-only cleanup: no test bodies, assertions, fixtures, generated artifacts, or test names changed.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target <29 affected test targets> -j$(sysctl -n hw.ncpu)`
- Affected direct test binaries, with `PULP_SOURCE_DIR=$PWD` where required for migration-index tests
- `ctest --test-dir build -R 'pulp ship' --output-on-failure`
- `ctest --test-dir build -R '^pulp build' --output-on-failure`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --head HEAD --mode=report --require-ceiling-reduction`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `git diff --check`
- RepoPrompt adversarial review: clean after verifying CI/CMake/script selector coupling
- Codex autoreview: clean, 0 accepted/actionable findings
- Claude bridge adversarial review: clean, no blocking findings

## Review notes
- Follow-up grep found no CI/CMake/script selector references for `[large]`, `[coverage]`, `[codecov]`, or `[requested]`; remaining occurrences are test-source tags in out-of-scope files.
- Direct push was used for the branch; pre-push gates still ran clean and this PR keeps the cleanup consolidated rather than opening micro-PRs.

Version-Bump: sdk=skip reason="test selector tag cleanup only; no API or runtime behavior change"
Skill-Sync: skip reason="skill-sync reports no mapped paths touched"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale Catch2 selector tags from CLI and Android tests to reduce noise and simplify filtering. Keeps product, platform, shellout, and issue tags; no test logic or behavior changes.

- **Refactors**
  - Removed `[coverage]`, `[codecov]`, `[requested]`, and `[large]` across 29 test files.
  - Preserved product/platform/shellout selectors and issue tags like `[issue-643]` and `[issue-644]`.

<sup>Written for commit e93d2665f56a8a3c9859f49345209e2f1e7e8b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

