### PR TITLE
docs(test): clean view coverage selector tags

### DIFF
--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -314,7 +314,7 @@ TEST_CASE("RecordingCanvas transforms", "[canvas]") {
 }
 
 TEST_CASE("RecordingCanvas restores save stack and transform snapshots",
-          "[canvas][coverage]") {
+          "[canvas]") {
     RecordingCanvas canvas;
 
     canvas.translate(5.0f, 7.0f);
@@ -346,7 +346,7 @@ TEST_CASE("RecordingCanvas restores save stack and transform snapshots",
 }
 
 TEST_CASE("RecordingCanvas captures Canvas2D state and media command payloads",
-          "[canvas][coverage]") {
+          "[canvas]") {
     RecordingCanvas canvas;
     const float dash[] = {2.0f, 4.0f, 6.0f};
     const uint8_t pixels[] = {
@@ -414,7 +414,7 @@ TEST_CASE("RecordingCanvas captures Canvas2D state and media command payloads",
 }
 
 TEST_CASE("RecordingCanvas captures remaining path primitive payloads",
-          "[canvas][coverage]") {
+          "[canvas]") {
     RecordingCanvas canvas;
 
     canvas.begin_path();
@@ -788,7 +788,7 @@ TEST_CASE("Canvas SDF fallback covers stroked shape variants",
 }
 
 TEST_CASE("RecordingCanvas captures sticky paint and image state payloads",
-          "[canvas][recording][coverage]") {
+          "[canvas][recording]") {
     RecordingCanvas rc;
     const uint8_t pixels[] = {
         1, 2, 3, 4,
@@ -828,7 +828,7 @@ TEST_CASE("RecordingCanvas captures sticky paint and image state payloads",
 }
 
 TEST_CASE("RecordingCanvas captures stroke gradient commands and stop payloads",
-          "[canvas][recording][coverage]") {
+          "[canvas][recording]") {
     RecordingCanvas rc;
     const Color colors[] = {
         Color::rgba8(10, 20, 30, 40),
@@ -869,7 +869,7 @@ TEST_CASE("RecordingCanvas captures stroke gradient commands and stop payloads",
 }
 
 TEST_CASE("Canvas base fallbacks delegate through recording backend",
-          "[canvas][fallback][coverage]") {
+          "[canvas][fallback]") {
     RecordingCanvas rc;
     const Color colors[] = {Color::rgba8(3, 4, 5, 6)};
     const float positions[] = {0.0f};

--- a/test/test_canvas_color.cpp
+++ b/test/test_canvas_color.cpp
@@ -26,7 +26,7 @@ void require_color_near(const Color& color,
 }  // namespace
 
 TEST_CASE("Color HSV covers primary and secondary hue sectors",
-          "[canvas][color][coverage]") {
+          "[canvas][color]") {
     struct Case {
         const char* name;
         float hue;
@@ -59,7 +59,7 @@ TEST_CASE("Color HSV covers primary and secondary hue sectors",
 }
 
 TEST_CASE("Color OKLCH covers sRGB transfer thresholds and wrapped hue",
-          "[canvas][color][coverage]") {
+          "[canvas][color]") {
     auto near_black = Color::rgba(0.003f, 0.003f, 0.003f).to_oklch();
     require_near(near_black.L, 0.06146f, 0.0002f);
     require_near(near_black.C, 0.0f, 0.0001f);
@@ -76,7 +76,7 @@ TEST_CASE("Color OKLCH covers sRGB transfer thresholds and wrapped hue",
 }
 
 TEST_CASE("Color binary encoding preserves unclamped float channels",
-          "[canvas][color][coverage]") {
+          "[canvas][color]") {
     auto original = Color::rgba(1.25f, -0.125f, 0.5f, 0.75f);
 
     uint8_t bytes[16]{};

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -1748,7 +1748,7 @@ TEST_CASE("CanvasWidget paint dispatches set_filter to the canvas",
 // proves draw_image_from_file_rect was called (the dst-only path leaves
 // `floats` empty — see test below).
 TEST_CASE("CanvasWidget::paint routes draw_image through _rect overload when has_source_rect",
-          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+          "[canvas_widget][issue-1739][canvas2d]") {
     CanvasWidget cw;
     cw.set_bounds({0, 0, 200, 100});
 
@@ -1797,7 +1797,7 @@ TEST_CASE("CanvasWidget::paint routes draw_image through _rect overload when has
 // or CG) distinguishes the two forms downstream. This pins the else
 // branch of canvas_widget.cpp's has_source_rect check.
 TEST_CASE("CanvasWidget::paint routes draw_image through dst-only path when has_source_rect is false",
-          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+          "[canvas_widget][issue-1739][canvas2d]") {
     CanvasWidget cw;
     cw.set_bounds({0, 0, 200, 100});
 
@@ -1836,7 +1836,7 @@ TEST_CASE("CanvasWidget::paint routes draw_image through dst-only path when has_
 // through to the labeled placeholder fallback. This pins the empty-src
 // early-exit edge of the new branch.
 TEST_CASE("CanvasWidget::paint draws placeholder when image path is empty even with source rect",
-          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+          "[canvas_widget][issue-1739][canvas2d]") {
     CanvasWidget cw;
     cw.set_bounds({0, 0, 200, 100});
 
@@ -1865,7 +1865,7 @@ TEST_CASE("CanvasWidget::paint draws placeholder when image path is empty even w
 }
 
 TEST_CASE("CanvasWidget paint dispatches extended text and stroke state commands",
-          "[canvas_widget][coverage]") {
+          "[canvas_widget]") {
     CanvasWidget cw;
     cw.set_bounds({0, 0, 160, 80});
 
@@ -1958,7 +1958,7 @@ TEST_CASE("CanvasWidget paint dispatches extended text and stroke state commands
 }
 
 TEST_CASE("CanvasWidget paint dispatches gradient pattern and native path commands",
-          "[canvas_widget][coverage]") {
+          "[canvas_widget]") {
     ScopedEnv guard("PULP_LOG_CANVAS_PAINT", "1");
 
     CanvasWidget cw;
@@ -2062,7 +2062,7 @@ TEST_CASE("CanvasWidget paint dispatches gradient pattern and native path comman
 }
 
 TEST_CASE("CanvasWidget data URI draw_image uses placeholder fallback",
-          "[canvas_widget][coverage]") {
+          "[canvas_widget]") {
     CanvasWidget cw;
     cw.set_bounds({0, 0, 80, 60});
 

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -95,7 +95,7 @@ TEST_CASE("CodeEditor insert text", "[gui][code-editor]") {
 }
 
 TEST_CASE("CodeEditor insert appends in read-only fallback mode",
-          "[gui][code-editor][coverage][issue-655]") {
+          "[gui][code-editor][issue-655]") {
     CodeEditor editor;
     editor.set_read_only(true);
     editor.set_text("alpha");
@@ -109,7 +109,7 @@ TEST_CASE("CodeEditor insert appends in read-only fallback mode",
 }
 
 TEST_CASE("CodeEditor marker API is a stable no-op in native fallback mode",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     CodeEditor editor;
     editor.set_text("alpha\nbeta");
     editor.set_markers({{1, "warn"}, {2, "error"}});
@@ -137,7 +137,7 @@ TEST_CASE("CodeEditor paint renders without crash", "[gui][code-editor]") {
 }
 
 TEST_CASE("CodeEditor paint covers line numbers highlight clipping and token colors",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     CodeEditor editor;
     CodeEditorConfig config;
     config.theme = "vs-light";
@@ -164,7 +164,7 @@ TEST_CASE("CodeEditor paint covers line numbers highlight clipping and token col
 }
 
 TEST_CASE("CodeEditor paint emits gutter line numbers when enabled",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     CodeEditor editor;
     CodeEditorConfig config;
     config.line_numbers = true;
@@ -184,7 +184,7 @@ TEST_CASE("CodeEditor paint emits gutter line numbers when enabled",
 }
 
 TEST_CASE("SystemTrayIcon lifecycle methods are safe without native handles",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     SystemTrayIcon tray;
     tray.set_icon("pulp-status");
     tray.set_tooltip("Pulp");
@@ -203,7 +203,7 @@ TEST_CASE("FileBasedDocument title from path", "[gui][code-editor]") {
 }
 
 TEST_CASE("FileBasedDocument handles save and load edge paths",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     TestDoc doc;
     int dirty_callback_count = 0;
     bool last_dirty = true;
@@ -238,7 +238,7 @@ TEST_CASE("FileBasedDocument handles save and load edge paths",
 }
 
 TEST_CASE("FileBasedDocument handles successful load and save_as paths",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     TestDoc doc;
     int dirty_callback_count = 0;
     bool last_dirty = true;
@@ -287,7 +287,7 @@ TEST_CASE("RecentlyOpenedFilesList MRU behavior", "[gui][code-editor]") {
 }
 
 TEST_CASE("RecentlyOpenedFilesList removes entries and ignores missing paths",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     RecentlyOpenedFilesList mru;
     mru.add("/path/a.txt");
     mru.add("/path/b.txt");
@@ -309,7 +309,7 @@ TEST_CASE("RecentlyOpenedFilesList removes entries and ignores missing paths",
 }
 
 TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",
-          "[gui][code-editor][coverage]") {
+          "[gui][code-editor]") {
     RecentlyOpenedFilesList mru;
     mru.add("/keep/existing.txt");
 
@@ -350,7 +350,7 @@ TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",
 }
 
 TEST_CASE("RecentlyOpenedFilesList remove and max-entry edge paths",
-          "[gui][code-editor][coverage][issue-655]") {
+          "[gui][code-editor][issue-655]") {
     RecentlyOpenedFilesList mru;
     mru.add("/a.txt");
     mru.add("/b.txt");

--- a/test/test_font_async_lifecycle.cpp
+++ b/test/test_font_async_lifecycle.cpp
@@ -83,7 +83,7 @@ TEST_CASE("register_font_url: file:// URL with invalid bytes → Failed",
 }
 
 TEST_CASE("register_font_url: file URL scheme matching is case-insensitive",
-          "[font][async][coverage]") {
+          "[font][async]") {
     std::string path = write_temp_dummy_font_bytes();
     auto fut = register_font_url("FiLe://" + path);
     REQUIRE(fut.wait_for(5s) == std::future_status::ready);
@@ -92,7 +92,7 @@ TEST_CASE("register_font_url: file URL scheme matching is case-insensitive",
 }
 
 TEST_CASE("register_font_url: file://localhost strips the host component",
-          "[font][async][coverage]") {
+          "[font][async]") {
     std::string path = write_temp_dummy_font_bytes();
     auto fut = register_font_url("file://localhost" + path);
     REQUIRE(fut.wait_for(5s) == std::future_status::ready);
@@ -101,7 +101,7 @@ TEST_CASE("register_font_url: file://localhost strips the host component",
 }
 
 TEST_CASE("register_font_url: bare file: scheme uses the following path",
-          "[font][async][coverage]") {
+          "[font][async]") {
     std::string path = write_temp_dummy_font_bytes();
     auto fut = register_font_url("file:" + path);
     REQUIRE(fut.wait_for(5s) == std::future_status::ready);
@@ -119,7 +119,7 @@ TEST_CASE("register_font_url: bare absolute path with invalid bytes → Failed",
 }
 
 TEST_CASE("register_font_url: unsupported schemes are treated as plain paths",
-          "[font][async][coverage]") {
+          "[font][async]") {
     auto fut = register_font_url("ftp://example.com/font.ttf");
     REQUIRE(fut.wait_for(5s) == std::future_status::ready);
     REQUIRE(fut.get() == FontState::Failed);

--- a/test/test_font_axis_animation.cpp
+++ b/test/test_font_axis_animation.cpp
@@ -162,7 +162,7 @@ TEST_CASE("FontResolver: LRU hit promotes entry past eviction line",
 }
 
 TEST_CASE("FontResolver: explicit generation splits otherwise identical cache keys",
-          "[font][axes][coverage]") {
+          "[font][axes]") {
     auto& r = FontResolver::instance();
     r.clear_cache();
     r.set_cache_capacity(8);
@@ -196,7 +196,7 @@ TEST_CASE("FontResolver: explicit generation splits otherwise identical cache ke
 }
 
 TEST_CASE("FontResolver: empty family stack uses a distinct default cache key",
-          "[font][axes][coverage]") {
+          "[font][axes]") {
     auto& r = FontResolver::instance();
     r.clear_cache();
     r.set_cache_capacity(8);

--- a/test/test_font_flight_recorder.cpp
+++ b/test/test_font_flight_recorder.cpp
@@ -57,7 +57,7 @@ TEST_CASE("FlightRecorder: capacity overflow drops oldest", "[font][diagnostics]
 }
 
 TEST_CASE("FlightRecorder: snapshot is non-destructive and ordered",
-          "[font][diagnostics][coverage]") {
+          "[font][diagnostics]") {
     auto& r = FontFlightRecorder::instance();
     r.clear();
     r.set_capacity(4);
@@ -106,7 +106,7 @@ TEST_CASE("FlightRecorder: shrinking capacity trims oldest records",
 }
 
 TEST_CASE("FlightRecorder: capacity=0 trims existing records immediately",
-          "[font][diagnostics][coverage]") {
+          "[font][diagnostics]") {
     auto& r = FontFlightRecorder::instance();
     r.clear();
     r.set_capacity(3);
@@ -135,7 +135,7 @@ TEST_CASE("FlightRecorder: capacity=0 disables recording", "[font][diagnostics]"
 }
 
 TEST_CASE("FlightRecorder: disabled recording still advances sequence",
-          "[font][diagnostics][coverage]") {
+          "[font][diagnostics]") {
     auto& r = FontFlightRecorder::instance();
     r.clear();
     r.set_capacity(1);
@@ -185,7 +185,7 @@ TEST_CASE("FlightRecorder: JSON drain is well-formed", "[font][diagnostics]") {
 }
 
 TEST_CASE("FlightRecorder: JSON drain preserves order and sequence fields",
-          "[font][diagnostics][coverage]") {
+          "[font][diagnostics]") {
     auto& r = FontFlightRecorder::instance();
     r.clear();
     r.set_capacity(4);

--- a/test/test_font_options.cpp
+++ b/test/test_font_options.cpp
@@ -46,7 +46,7 @@ FontOptions rich_options() {
 } // namespace
 
 TEST_CASE("FontOptions hash includes full resolver cache key",
-          "[canvas][font][options][coverage]") {
+          "[canvas][font][options]") {
     const FontOptions base = rich_options();
     REQUIRE(base == rich_options());
     REQUIRE(std::hash<FontOptions>{}(base) == std::hash<FontOptions>{}(rich_options()));
@@ -83,7 +83,7 @@ TEST_CASE("FontOptions hash includes full resolver cache key",
 }
 
 TEST_CASE("FontOptions hash includes scalar style and render policy fields",
-          "[canvas][font][options][coverage]") {
+          "[canvas][font][options]") {
     const FontOptions base = rich_options();
 
     auto changed = base;
@@ -153,7 +153,7 @@ TEST_CASE("FontOptions hash includes scalar style and render policy fields",
 }
 
 TEST_CASE("FontOptions hash canonicalizes signed zero on float members",
-          "[canvas][font][options][coverage][issue-2169]") {
+          "[canvas][font][options][issue-2169]") {
     // Regression for #2169: `FontOptions::operator==` is `= default`
     // (per-member float comparison). IEEE-754 reports `+0.0f == -0.0f` as
     // true, so two FontOptions whose only difference is a signed-zero float
@@ -191,7 +191,7 @@ TEST_CASE("FontOptions hash canonicalizes signed zero on float members",
 }
 
 TEST_CASE("Font tag helpers pack OpenType tags in byte order",
-          "[canvas][font][options][coverage]") {
+          "[canvas][font][options]") {
     REQUIRE(make_font_feature_tag('k', 'e', 'r', 'n') == 0x6B65726Eu);
     REQUIRE(make_font_feature_tag('t', 'n', 'u', 'm') == 0x746E756Du);
     REQUIRE(make_variation_axis_tag('w', 'g', 'h', 't') == 0x77676874u);
@@ -200,7 +200,7 @@ TEST_CASE("Font tag helpers pack OpenType tags in byte order",
 }
 
 TEST_CASE("FontScope factories and generations isolate plugin and view scopes",
-          "[canvas][font][scope][coverage]") {
+          "[canvas][font][scope]") {
     auto plugin_id = 728042u;
     auto view_id = 728043u;
 
@@ -235,7 +235,7 @@ TEST_CASE("FontScope factories and generations isolate plugin and view scopes",
 }
 
 TEST_CASE("Font resolver trace names cover every fallback origin",
-          "[canvas][font][resolver][coverage]") {
+          "[canvas][font][resolver]") {
     REQUIRE(std::string(to_string(FallbackOrigin::ScopeView)) == "scope-view");
     REQUIRE(std::string(to_string(FallbackOrigin::ScopePlugin)) == "scope-plugin");
     REQUIRE(std::string(to_string(FallbackOrigin::ScopeGlobal)) == "scope-global");
@@ -247,7 +247,7 @@ TEST_CASE("Font resolver trace names cover every fallback origin",
 }
 
 TEST_CASE("ResolvedFont default state is unresolved without a typeface",
-          "[canvas][font][resolver][coverage]") {
+          "[canvas][font][resolver]") {
     ResolvedFont font;
     REQUIRE_FALSE(font.has_typeface());
     REQUIRE_FALSE(font.resolved());
@@ -262,7 +262,7 @@ TEST_CASE("ResolvedFont default state is unresolved without a typeface",
 
 #ifndef PULP_HAS_SKIA
 TEST_CASE("FontResolver non-Skia path returns scoped NotFound results",
-          "[canvas][font][resolver][coverage]") {
+          "[canvas][font][resolver]") {
     auto& resolver = FontResolver::instance();
     resolver.clear_cache();
 
@@ -292,7 +292,7 @@ TEST_CASE("FontResolver non-Skia path returns scoped NotFound results",
 }
 
 TEST_CASE("Font registry non-Skia stubs reject registrations but validate bytes",
-          "[canvas][font][registry][coverage]") {
+          "[canvas][font][registry]") {
     const std::uint8_t bytes[] = {0x00, 0x01, 0x02, 0x03};
 
     REQUIRE_FALSE(register_font(bytes, sizeof(bytes), "StubFont"));
@@ -311,7 +311,7 @@ TEST_CASE("Font registry non-Skia stubs reject registrations but validate bytes"
 }
 
 TEST_CASE("Font cluster_step non-Skia skeleton skips UTF-8 continuation bytes",
-          "[canvas][font][registry][coverage]") {
+          "[canvas][font][registry]") {
     const std::string text = std::string("A") + "\xC3\xA9"
                            + "\xF0\x9F\x99\x82" + "Z";
 
@@ -330,7 +330,7 @@ TEST_CASE("Font cluster_step non-Skia skeleton skips UTF-8 continuation bytes",
 #endif
 
 TEST_CASE("TextRunPlanner skeleton maps UTF-8 scalars and line breaks",
-          "[canvas][font][planner][coverage]") {
+          "[canvas][font][planner]") {
     auto& planner = TextRunPlanner::instance();
     planner.clear_cache();
 
@@ -362,7 +362,7 @@ TEST_CASE("TextRunPlanner skeleton maps UTF-8 scalars and line breaks",
 }
 
 TEST_CASE("TextRunPlanner captures scope generation and RTL base direction",
-          "[canvas][font][planner][coverage]") {
+          "[canvas][font][planner]") {
     auto& planner = TextRunPlanner::instance();
     planner.clear_cache();
 
@@ -396,7 +396,7 @@ TEST_CASE("TextRunPlanner captures scope generation and RTL base direction",
 }
 
 TEST_CASE("TextRunPlanner handles empty text, cache hits, and ASCII breaks",
-          "[canvas][font][planner][coverage]") {
+          "[canvas][font][planner]") {
     auto& planner = TextRunPlanner::instance();
     planner.clear_cache();
 
@@ -436,7 +436,7 @@ TEST_CASE("TextRunPlanner handles empty text, cache hits, and ASCII breaks",
 }
 
 TEST_CASE("ShapedText value types report default metrics and emptiness",
-          "[canvas][font][shaped-text][coverage]") {
+          "[canvas][font][shaped-text]") {
     RunMetrics metrics;
     REQUIRE(metrics.line_height() == 0.0f);
     metrics.ascent = 9.0f;

--- a/test/test_font_variable_axes.cpp
+++ b/test/test_font_variable_axes.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Variable axes: tag construction is byte-stable", "[font][axes]") {
 }
 
 TEST_CASE("FontOptions hash includes render policy and fallback fields",
-          "[font][options][codecov]") {
+          "[font][options]") {
     FontOptions base;
     base.family_stack = {"Inter", "system"};
     base.size = 15.0f;
@@ -108,7 +108,7 @@ TEST_CASE("FontOptions hash includes render policy and fallback fields",
 }
 
 TEST_CASE("FontOptions hash includes synthesis flags and scope ids",
-          "[font][options][codecov]") {
+          "[font][options]") {
     FontOptions base;
     base.family_stack = {"Inter"};
 

--- a/test/test_font_woff2.cpp
+++ b/test/test_font_woff2.cpp
@@ -75,7 +75,7 @@ TEST_CASE("register_font_woff2: TTF/sfnt magic is rejected (not WOFF2)",
 }
 
 TEST_CASE("register_font_woff2: near-miss signatures are rejected",
-          "[font][woff2][coverage]") {
+          "[font][woff2]") {
     std::vector<std::uint8_t> lowercase = {'w', 'o', 'f', '2'};
     lowercase.resize(64, 0);
     REQUIRE_FALSE(register_font_woff2(lowercase.data(), lowercase.size(), ""));
@@ -91,7 +91,7 @@ TEST_CASE("register_font_woff2: near-miss signatures are rejected",
 }
 
 TEST_CASE("register_font_woff2: exact magic without header payload is rejected",
-          "[font][woff2][coverage]") {
+          "[font][woff2]") {
     std::array<std::uint8_t, 4> bytes = kWoff2Magic;
     REQUIRE_FALSE(register_font_woff2(bytes.data(), bytes.size(), ""));
     REQUIRE_FALSE(register_font_woff2(bytes.data(), bytes.size(), "Tiny WOFF2"));

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -302,7 +302,7 @@ TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
 }
 
 TEST_CASE("Toolbar missing ids and sizing fallbacks are stable",
-          "[gui][toolbar][coverage][issue-653]") {
+          "[gui][toolbar][issue-653]") {
     Toolbar toolbar;
     toolbar.add_toggle("solo", "Solo", [](bool) {});
 
@@ -325,7 +325,7 @@ TEST_CASE("Toolbar missing ids and sizing fallbacks are stable",
 }
 
 TEST_CASE("Toolbar mouse interaction skips separators and disabled items",
-          "[gui][toolbar][coverage]") {
+          "[gui][toolbar]") {
     Toolbar toolbar;
     int play_clicks = 0;
     int save_clicks = 0;
@@ -368,7 +368,7 @@ TEST_CASE("Toolbar mouse interaction skips separators and disabled items",
 }
 
 TEST_CASE("Toolbar forwards custom item clicks with local coordinates",
-          "[gui][toolbar][coverage]") {
+          "[gui][toolbar]") {
     Toolbar horizontal;
     horizontal.add_spacer();
     auto horizontal_custom = std::make_unique<ToolbarProbeView>();
@@ -394,7 +394,7 @@ TEST_CASE("Toolbar forwards custom item clicks with local coordinates",
 }
 
 TEST_CASE("Toolbar paint emits button, separator, custom, and orientation commands",
-          "[gui][toolbar][coverage]") {
+          "[gui][toolbar]") {
     Toolbar toolbar;
     toolbar.set_bounds({0, 0, 180, 40});
     toolbar.add_button("play", "Play", []() {});
@@ -435,7 +435,7 @@ TEST_CASE("Toolbar paint emits button, separator, custom, and orientation comman
 // ── Extended Buttons ────────────────────────────────────────────────────
 
 TEST_CASE("TextButton disabled state suppresses click and still paints",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     TextButton button("Render");
     button.set_bounds({0, 0, 96, 32});
 
@@ -458,7 +458,7 @@ TEST_CASE("TextButton disabled state suppresses click and still paints",
 }
 
 TEST_CASE("ArrowButton paints all directions and invokes click callback",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ArrowButton button;
     button.set_bounds({0, 0, 24, 24});
 
@@ -481,7 +481,7 @@ TEST_CASE("ArrowButton paints all directions and invokes click callback",
 }
 
 TEST_CASE("ShapeButton reports hover and pressed state to custom painter",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ShapeButton button;
     button.set_bounds({0, 0, 32, 20});
 
@@ -513,7 +513,7 @@ TEST_CASE("ShapeButton reports hover and pressed state to custom painter",
 }
 
 TEST_CASE("ImageButton selects normal hover and pressed image paths",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ImageButton button;
     button.set_bounds({0, 0, 40, 24});
     button.set_image("normal.png");
@@ -545,7 +545,7 @@ TEST_CASE("ImageButton selects normal hover and pressed image paths",
 }
 
 TEST_CASE("ImageButton falls back to normal image for missing state assets",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ImageButton button;
     button.set_bounds({0, 0, 40, 24});
     button.set_image("normal.png");
@@ -562,7 +562,7 @@ TEST_CASE("ImageButton falls back to normal image for missing state assets",
 }
 
 TEST_CASE("ResizableCorner reports drag deltas from mouse down origin",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ResizableCorner corner;
     corner.set_bounds({0, 0, 16, 16});
 
@@ -583,7 +583,7 @@ TEST_CASE("ResizableCorner reports drag deltas from mouse down origin",
 }
 
 TEST_CASE("Button constructors expose deterministic accessibility and intrinsic sizing",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     TextButton default_text;
     REQUIRE(default_text.label().empty());
     REQUIRE(default_text.focusable());
@@ -625,7 +625,7 @@ TEST_CASE("Button constructors expose deterministic accessibility and intrinsic 
 }
 
 TEST_CASE("Buttons tolerate absent callbacks and reset transient states",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     TextButton text("Mute");
     text.set_bounds({0, 0, 96, 32});
     REQUIRE_NOTHROW(text.on_mouse_down({4, 4}));
@@ -667,7 +667,7 @@ TEST_CASE("Buttons tolerate absent callbacks and reset transient states",
 }
 
 TEST_CASE("HyperlinkButton setter and hover states determine painted affordance",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     HyperlinkButton link("Docs", "https://example.invalid/docs");
     link.set_bounds({0, 0, 140, 28});
     REQUIRE(link.text() == "Docs");
@@ -698,7 +698,7 @@ TEST_CASE("HyperlinkButton setter and hover states determine painted affordance"
 }
 
 TEST_CASE("ResizableCorner drag without callback is safe and later reports new origin",
-          "[gui][buttons][coverage]") {
+          "[gui][buttons]") {
     ResizableCorner corner;
     corner.set_bounds({0, 0, 20, 20});
 
@@ -831,7 +831,7 @@ TEST_CASE("ConcertinaPanel paint and mouse hit testing cover content offsets",
 }
 
 TEST_CASE("ConcertinaPanel handles null content and default content heights",
-          "[gui][concertina][coverage]") {
+          "[gui][concertina]") {
     ConcertinaPanel panel;
     panel.set_bounds({0, 0, 160, 220});
     panel.set_header_height(18.0f);
@@ -867,7 +867,7 @@ TEST_CASE("ConcertinaPanel handles null content and default content heights",
 }
 
 TEST_CASE("ConcertinaPanel exclusive expansion collapses visible content",
-          "[gui][concertina][coverage]") {
+          "[gui][concertina]") {
     ConcertinaPanel panel;
     panel.set_exclusive(true);
 
@@ -926,7 +926,7 @@ TEST_CASE("TextButton disabled doesn't fire", "[gui][button]") {
 }
 
 TEST_CASE("TextButton paint covers enabled hover and disabled states",
-          "[gui][button][coverage]") {
+          "[gui][button]") {
     TextButton btn("Render");
     btn.set_bounds({0, 0, 120, 36});
 
@@ -1001,7 +1001,7 @@ TEST_CASE("TextButton paint with tiny width still truncates instead of leaking t
 }
 
 TEST_CASE("HyperlinkButton paint underlines only while hovered",
-          "[gui][button][coverage]") {
+          "[gui][button]") {
     HyperlinkButton link("Docs", "https://example.invalid/docs");
     link.set_bounds({0, 0, 160, 24});
     REQUIRE(link.text() == "Docs");
@@ -1043,7 +1043,7 @@ TEST_CASE("ArrowButton direction and click", "[gui][button]") {
     REQUIRE(clicked);
 }
 
-TEST_CASE("ArrowButton paint covers all directions", "[gui][button][coverage]") {
+TEST_CASE("ArrowButton paint covers all directions", "[gui][button]") {
     RecordingCanvas canvas;
     ArrowButton btn;
     btn.set_bounds({0, 0, 24, 24});
@@ -1059,7 +1059,7 @@ TEST_CASE("ArrowButton paint covers all directions", "[gui][button][coverage]") 
 }
 
 TEST_CASE("ShapeButton reports hover and pressed states to draw callback",
-          "[gui][button][coverage]") {
+          "[gui][button]") {
     ShapeButton btn;
     btn.set_bounds({0, 0, 32, 20});
 
@@ -1109,7 +1109,7 @@ TEST_CASE("ShapeButton reports hover and pressed states to draw callback",
 }
 
 TEST_CASE("ImageButton chooses normal hover and pressed image paths",
-          "[gui][button][coverage]") {
+          "[gui][button]") {
     ImageButton btn;
     btn.set_bounds({0, 0, 48, 24});
 
@@ -1160,7 +1160,7 @@ TEST_CASE("ImageButton chooses normal hover and pressed image paths",
 }
 
 TEST_CASE("ResizableCorner paints grip and reports drag deltas",
-          "[gui][button][coverage]") {
+          "[gui][button]") {
     ResizableCorner corner;
     corner.set_bounds({0, 0, 16, 16});
 
@@ -1227,7 +1227,7 @@ TEST_CASE("LassoComponent callback fires", "[gui][lasso]") {
 }
 
 TEST_CASE("SelectionRect contains and intersects use half-open bounds",
-          "[gui][lasso][coverage]") {
+          "[gui][lasso]") {
     SelectionRect rect{10.0f, 20.0f, 40.0f, 30.0f};
 
     REQUIRE(rect.contains(10.0f, 20.0f));
@@ -1243,7 +1243,7 @@ TEST_CASE("SelectionRect contains and intersects use half-open bounds",
 }
 
 TEST_CASE("LassoComponent inactive updates and end are no-ops",
-          "[gui][lasso][coverage]") {
+          "[gui][lasso]") {
     LassoComponent lasso;
     int changed = 0;
     int completed = 0;
@@ -1261,7 +1261,7 @@ TEST_CASE("LassoComponent inactive updates and end are no-ops",
 }
 
 TEST_CASE("LassoComponent completes selection and only paints while active",
-          "[gui][lasso][coverage]") {
+          "[gui][lasso]") {
     LassoComponent lasso;
     SelectionRect completed;
     int complete_calls = 0;

--- a/test/test_panel.cpp
+++ b/test/test_panel.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Panel: zero border width skips border", "[panel]") {
 }
 
 TEST_CASE("Panel: custom theme tokens drive fill and stroke colors",
-          "[panel][coverage]") {
+          "[panel]") {
     Theme theme;
     theme.colors["panel.fill"] = color_from_hex(0x112233);
     theme.colors["panel.stroke"] = color_from_hex(0x445566);
@@ -97,7 +97,7 @@ TEST_CASE("Panel: custom theme tokens drive fill and stroke colors",
 }
 
 TEST_CASE("Panel: missing theme tokens use documented fallback colors",
-          "[panel][coverage]") {
+          "[panel]") {
     Panel panel;
     panel.set_theme(Theme{});
     panel.set_bounds({0, 0, 80, 40});
@@ -120,7 +120,7 @@ TEST_CASE("Panel: missing theme tokens use documented fallback colors",
 }
 
 TEST_CASE("Panel: border geometry is inset and radius is clamped by border width",
-          "[panel][coverage]") {
+          "[panel]") {
     Panel panel;
     panel.set_bounds({0, 0, 100, 50});
     panel.set_corner_radius(3.0f);

--- a/test/test_screenshot_capture.cpp
+++ b/test/test_screenshot_capture.cpp
@@ -140,7 +140,7 @@ TEST_CASE("ScreenshotCapture default delay (30) honored when caller leaves field
 }
 
 TEST_CASE("ScreenshotCapture handles missing capture callback as empty bytes",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto path = tmp_screenshot_path("missing_capture");
     std::filesystem::remove(path);
@@ -160,7 +160,7 @@ TEST_CASE("ScreenshotCapture handles missing capture callback as empty bytes",
 }
 
 TEST_CASE("ScreenshotCapture reports empty screenshot path before writing",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto cap = h.make("", 1);
 
@@ -173,7 +173,7 @@ TEST_CASE("ScreenshotCapture reports empty screenshot path before writing",
 }
 
 TEST_CASE("ScreenshotCapture tolerates missing error callback for bad inputs",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto cap = h.make("", 1);
     cap.on_error = {};
@@ -186,7 +186,7 @@ TEST_CASE("ScreenshotCapture tolerates missing error callback for bad inputs",
 }
 
 TEST_CASE("ScreenshotCapture reports failed file writes and still closes",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto missing_dir = std::filesystem::temp_directory_path() /
                        "pulp_test_screenshot_missing_dir" /
@@ -204,7 +204,7 @@ TEST_CASE("ScreenshotCapture reports failed file writes and still closes",
 }
 
 TEST_CASE("ScreenshotCapture skips write error reporting when no handler is set",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto missing_dir = std::filesystem::temp_directory_path() /
                        "pulp_test_screenshot_missing_dir_no_error" /
@@ -221,7 +221,7 @@ TEST_CASE("ScreenshotCapture skips write error reporting when no handler is set"
 }
 
 TEST_CASE("ScreenshotCapture permits missing close callback after a successful write",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness h;
     auto path = tmp_screenshot_path("missing_close");
     std::filesystem::remove(path);
@@ -242,7 +242,7 @@ TEST_CASE("ScreenshotCapture permits missing close callback after a successful w
 }
 
 TEST_CASE("ScreenshotCapture captures immediately for non-positive delays",
-          "[issue-468][screenshot][coverage]") {
+          "[issue-468][screenshot]") {
     CaptureHarness zero_delay;
     auto zero_path = tmp_screenshot_path("zero_delay");
     std::filesystem::remove(zero_path);

--- a/test/test_screenshot_compare.cpp
+++ b/test/test_screenshot_compare.cpp
@@ -291,7 +291,7 @@ TEST_CASE("analyze_screenshot_content accepts non-empty UI captures",
 }
 
 TEST_CASE("compare_screenshots reports rendered decode failure",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto png = render_label_png("Reference", Theme::dark());
     REQUIRE_FALSE(png.empty());
 
@@ -302,7 +302,7 @@ TEST_CASE("compare_screenshots reports rendered decode failure",
 }
 
 TEST_CASE("compare_screenshots penalizes size mismatch",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto small = render_label_png("Same", Theme::dark(), 40, 20);
     auto large = render_label_png("Same", Theme::dark(), 80, 40);
     REQUIRE_FALSE(small.empty());
@@ -316,7 +316,7 @@ TEST_CASE("compare_screenshots penalizes size mismatch",
 }
 
 TEST_CASE("compare_screenshot_files covers file IO success and failures",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto ref_png = render_label_png("File A", Theme::dark());
     auto ren_png = render_label_png("File A", Theme::dark());
     REQUIRE_FALSE(ref_png.empty());
@@ -383,7 +383,7 @@ TEST_CASE("generate_diff_image rejects oversized combined canvas",
 }
 
 TEST_CASE("generate_diff_image handles invalid changed and size mismatch inputs",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto dark = render_label_png("Diff", Theme::dark(), 80, 40);
     auto light = render_label_png("Diff", Theme::light(), 80, 40);
     auto small = render_label_png("Diff", Theme::dark(), 40, 20);
@@ -439,7 +439,7 @@ TEST_CASE("crop_png clamps regions to image bounds", "[view][compare]") {
 }
 
 TEST_CASE("crop_png rejects invalid and non-intersecting regions",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto png = render_label_png("Crop guards", Theme::dark(), 80, 40);
     REQUIRE_FALSE(png.empty());
 
@@ -478,7 +478,7 @@ TEST_CASE("diff_bounds locates changed pixels", "[view][compare]") {
 }
 
 TEST_CASE("diff_bounds is invalid for identical or undecodable images",
-          "[view][compare][coverage]") {
+          "[view][compare]") {
     auto png = render_label_png("Same", Theme::dark(), 80, 40);
     REQUIRE_FALSE(png.empty());
 

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -62,7 +62,7 @@ const DrawCommand* find_text(const RecordingCanvas& canvas, const std::string& t
 
 } // namespace
 
-TEST_CASE("TableListBox paint returns early without model or columns", "[gui][table][coverage]") {
+TEST_CASE("TableListBox paint returns early without model or columns", "[gui][table]") {
     TableListBox table;
     table.set_bounds({0, 0, 200, 100});
 
@@ -77,7 +77,7 @@ TEST_CASE("TableListBox paint returns early without model or columns", "[gui][ta
 }
 
 TEST_CASE("TableListBox paints scaled aligned headers rows and sort indicator",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     RecordingTableModel model({
         {"Alpha", "Synth", "10"},
         {"Beta", "Effect", "2"},
@@ -126,7 +126,7 @@ TEST_CASE("TableListBox paints scaled aligned headers rows and sort indicator",
 }
 
 TEST_CASE("TableListBox ignores unsortable header clicks and selects visible rows",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     RecordingTableModel model({
         {"Row 0", "A"},
         {"Row 1", "B"},
@@ -160,7 +160,7 @@ TEST_CASE("TableListBox ignores unsortable header clicks and selects visible row
 }
 
 TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     SimpleTableModel model;
     model.add_row({"B"});
     model.add_row({"A", "two"});
@@ -175,7 +175,7 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
 }
 
 TEST_CASE("SimpleTableModel sorts descending and guards out-of-range cells",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     SimpleTableModel model;
     model.set_data({
         {"Alpha", "3"},
@@ -195,7 +195,7 @@ TEST_CASE("SimpleTableModel sorts descending and guards out-of-range cells",
 }
 
 TEST_CASE("SimpleTableModel set_data replaces rows and sorts sparse descending",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     SimpleTableModel model;
     model.add_row({"old", "row"});
     model.set_data({
@@ -218,7 +218,7 @@ TEST_CASE("SimpleTableModel set_data replaces rows and sorts sparse descending",
 }
 
 TEST_CASE("TableListBox clear columns and model-less clicks are stable",
-          "[gui][table][coverage][issue-653]") {
+          "[gui][table][issue-653]") {
     TableListBox table;
     table.set_bounds({0, 0, 160, 80});
     table.set_header_height(20.0f);
@@ -239,7 +239,7 @@ TEST_CASE("TableListBox clear columns and model-less clicks are stable",
 }
 
 TEST_CASE("TableListBox paints selected row and ignores negative body clicks",
-          "[gui][table][coverage][issue-653]") {
+          "[gui][table][issue-653]") {
     RecordingTableModel model({
         {"First", "A"},
         {"Second", "B"},
@@ -266,7 +266,7 @@ TEST_CASE("TableListBox paints selected row and ignores negative body clicks",
 }
 
 TEST_CASE("TableListBox ignores clicks outside right and bottom bounds",
-          "[gui][table][coverage][issue-653]") {
+          "[gui][table][issue-653]") {
     RecordingTableModel model({
         {"First", "A"},
         {"Second", "B"},
@@ -289,7 +289,7 @@ TEST_CASE("TableListBox ignores clicks outside right and bottom bounds",
 }
 
 TEST_CASE("TableListBox ignores header clicks past scaled columns",
-          "[gui][table][coverage]") {
+          "[gui][table]") {
     RecordingTableModel model({
         {"First", "A"},
         {"Second", "B"},

--- a/test/test_table_model.cpp
+++ b/test/test_table_model.cpp
@@ -71,7 +71,7 @@ TEST_CASE("sort_by falls back to text when numeric keys are mixed",
 }
 
 TEST_CASE("sort_by preserves insertion order for equal sort keys",
-          "[ui][table-model][coverage]") {
+          "[ui][table-model]") {
     TableModel m;
     m.add_column({"Name"});
     m.add_column({"Rank"});
@@ -87,7 +87,7 @@ TEST_CASE("sort_by preserves insertion order for equal sort keys",
 }
 
 TEST_CASE("sort_by None records state without reordering rows",
-          "[ui][table-model][coverage]") {
+          "[ui][table-model]") {
     auto m = make_preset_table();
 
     m.sort_by(0, TableSortOrder::None);
@@ -121,7 +121,7 @@ TEST_CASE("switching sort column resets to ascending",
 }
 
 TEST_CASE("sort_by none records state without reordering rows",
-          "[ui][table-model][coverage]") {
+          "[ui][table-model]") {
     auto m = make_preset_table();
 
     m.sort_by(0, TableSortOrder::None);
@@ -140,7 +140,7 @@ TEST_CASE("sort_by none records state without reordering rows",
 }
 
 TEST_CASE("sort_by keeps equal keys stable across sort directions",
-          "[ui][table-model][coverage]") {
+          "[ui][table-model]") {
     TableModel m;
     m.add_column({"Name"});
     m.add_column({"Score"});
@@ -240,7 +240,7 @@ TEST_CASE("add_column pads existing rows", "[ui][table-model][issue-493]") {
 }
 
 TEST_CASE("adding a column after short rows preserves padded cells",
-          "[ui][table-model][coverage]") {
+          "[ui][table-model]") {
     TableModel m;
     m.add_column({"Name"});
     m.add_column({"Author"});

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -216,7 +216,7 @@ TEST_CASE("TextEditor text input inserts characters", "[view][text_editor]") {
 }
 
 TEST_CASE("TextEditor text input replaces the active selection",
-          "[view][text_editor][coverage]") {
+          "[view][text_editor]") {
     TextEditor editor;
     editor.on_focus_changed(true);
     editor.set_text("alpha beta");
@@ -254,7 +254,7 @@ TEST_CASE("TextEditor numeric mode rejects non-digits", "[view][text_editor]") {
 }
 
 TEST_CASE("TextEditor numeric mode rejects mixed text atomically",
-          "[view][text_editor][coverage]") {
+          "[view][text_editor]") {
     TextEditor editor;
     editor.numeric_only = true;
     editor.on_focus_changed(true);
@@ -972,7 +972,7 @@ TEST_CASE("TextEditor marked text selected range can convert native UTF-16 offse
 }
 
 TEST_CASE("TextEditor empty marked text clears the previous composition",
-          "[view][text_editor][ime][coverage]") {
+          "[view][text_editor][ime]") {
     TextEditor editor;
     editor.on_focus_changed(true);
     editor.set_text("base");

--- a/test/test_text_editor_mouse.cpp
+++ b/test/test_text_editor_mouse.cpp
@@ -301,7 +301,7 @@ TEST_CASE("TextEditor mouse triple-click selects the current multiline row",
 }
 
 TEST_CASE("TextEditor ignores wheel input in single-line mode",
-          "[view][text_editor][coverage]") {
+          "[view][text_editor]") {
     TextEditor editor;
     editor.on_focus_changed(true);
     editor.set_text("abcdef");
@@ -318,7 +318,7 @@ TEST_CASE("TextEditor ignores wheel input in single-line mode",
 }
 
 TEST_CASE("TextEditor multi-line wheel clamps scroll offset before hit testing",
-          "[view][text_editor][coverage]") {
+          "[view][text_editor]") {
     TextEditor editor;
     editor.multi_line = true;
     editor.set_text("one\ntwo\nthree\nfour");

--- a/test/test_text_editor_paint.cpp
+++ b/test/test_text_editor_paint.cpp
@@ -34,7 +34,7 @@ void write_png_artifact(const std::vector<std::uint8_t>& png, std::string name) 
 } // namespace
 
 TEST_CASE("TextEditor caret_rect has a fallback before first paint",
-          "[view][text_editor][coverage]") {
+          "[view][text_editor]") {
     TextEditor editor;
     editor.set_bounds({0, 0, 120, 24});
     editor.set_text("abc");

--- a/test/test_text_overflow.cpp
+++ b/test/test_text_overflow.cpp
@@ -95,7 +95,7 @@ TEST_CASE("utf8 helpers count and advance over leading bytes correctly",
 }
 
 TEST_CASE("utf8 helpers skip stray continuation bytes without spending codepoint budget",
-          "[view][text-overflow][issue-1407][coverage]") {
+          "[view][text-overflow][issue-1407]") {
     const std::string leading = std::string("\x80", 1) + "abc";
     const std::string doubled = std::string("\x80\x81", 2) + "abc";
     const std::string middle = std::string("a") + std::string("\x80", 1) + "bc";
@@ -141,7 +141,7 @@ TEST_CASE("utf8 helpers skip stray continuation bytes without spending codepoint
 }
 
 TEST_CASE("truncate_to_width ignores stray continuation bytes when choosing prefix",
-          "[view][text-overflow][issue-1407][coverage]") {
+          "[view][text-overflow][issue-1407]") {
     RecordingCanvas canvas;
     const std::string leading = std::string("\x80", 1) + "abcdef";
     const std::string doubled = std::string("\x80\x81", 2) + "abcdef";
@@ -163,7 +163,7 @@ TEST_CASE("truncate_to_width ignores stray continuation bytes when choosing pref
 }
 
 TEST_CASE("utf8 helpers handle continuation three-byte and four-byte paths",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     const std::string stray_continuation("\x80" "abc", 4);
     REQUIRE(utf8_codepoint_count(stray_continuation) == 3);
     REQUIRE(utf8_advance(stray_continuation, 1) == 2);
@@ -181,7 +181,7 @@ TEST_CASE("utf8 helpers handle continuation three-byte and four-byte paths",
 }
 
 TEST_CASE("utf8 helpers clamp truncated multibyte sequences",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     const std::string truncated_two_byte("\xc3", 1);
     REQUIRE(utf8_codepoint_count(truncated_two_byte) == 1);
     REQUIRE(utf8_advance(truncated_two_byte, 1) == 1);
@@ -197,7 +197,7 @@ TEST_CASE("utf8 helpers clamp truncated multibyte sequences",
 }
 
 TEST_CASE("truncate_to_width respects exact text and ellipsis boundaries",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     RecordingCanvas canvas;
 
     REQUIRE(truncate_to_width(canvas, "abc", 21.0f) == "abc");
@@ -214,7 +214,7 @@ TEST_CASE("truncate_to_width respects exact text and ellipsis boundaries",
 }
 
 TEST_CASE("truncate_to_width handles empty text in collapsed boxes",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     RecordingCanvas canvas;
 
     REQUIRE(truncate_to_width(canvas, "", 0.0f) == kEllipsis);
@@ -224,7 +224,7 @@ TEST_CASE("truncate_to_width handles empty text in collapsed boxes",
 }
 
 TEST_CASE("truncate_to_width preserves full multibyte prefixes",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     RecordingCanvas canvas;
 
     const std::string input = "\xe2\x82\xac" "\xf0\x9f\x98\x80" "abcd";
@@ -241,7 +241,7 @@ TEST_CASE("truncate_to_width preserves full multibyte prefixes",
 }
 
 TEST_CASE("truncate_to_width keeps exact multibyte fits unmodified",
-          "[view][text-overflow][coverage]") {
+          "[view][text-overflow]") {
     RecordingCanvas canvas;
 
     const std::string text = "\xe2\x82\xac" "\xf0\x9f\x98\x80";

--- a/test/test_text_run_planner_parallel.cpp
+++ b/test/test_text_run_planner_parallel.cpp
@@ -102,7 +102,7 @@ TEST_CASE("shape_batch: parallel + serial paths produce equivalent output",
 }
 
 TEST_CASE("shape_batch: duplicate inputs preserve duplicate outputs",
-          "[font][parallel][coverage]") {
+          "[font][parallel]") {
     auto opts = make_opts("Inter", 12.0f);
     std::vector<std::pair<std::string, FontOptions>> inputs = {
         {"duplicate", opts},

--- a/test/test_text_shaper.cpp
+++ b/test/test_text_shaper.cpp
@@ -299,7 +299,7 @@ TEST_CASE("Parallelogram contains accepts interior and edge points",
 }
 
 TEST_CASE("GlyphArrangement aggregates manual lines and clears layout state",
-          "[canvas][text_layout][codecov]") {
+          "[canvas][text_layout]") {
     TextLine first;
     first.width = 20.0f;
     first.ascent = 6.0f;
@@ -339,7 +339,7 @@ TEST_CASE("GlyphArrangement aggregates manual lines and clears layout state",
 }
 
 TEST_CASE("layout_paragraph preserves hard breaks while wrapping later glyphs",
-          "[canvas][text_layout][codecov]") {
+          "[canvas][text_layout]") {
     FontSpec font;
     font.size = 10.0f;
 
@@ -367,7 +367,7 @@ TEST_CASE("layout_paragraph preserves hard breaks while wrapping later glyphs",
 }
 
 TEST_CASE("layout_paragraph treats non-positive width as unbounded and narrow width as per-glyph wrap",
-          "[canvas][text_layout][codecov]") {
+          "[canvas][text_layout]") {
     FontSpec font;
     font.size = 10.0f;
 
@@ -390,7 +390,7 @@ TEST_CASE("layout_paragraph treats non-positive width as unbounded and narrow wi
 }
 
 TEST_CASE("Parallelogram contains accepts reverse winding and rejects exterior points",
-          "[canvas][text_layout][codecov]") {
+          "[canvas][text_layout]") {
     Parallelogram clockwise{0.0f, 0.0f, 0.0f, 10.0f, 10.0f, 10.0f, 10.0f, 0.0f};
 
     REQUIRE(clockwise.contains(5.0f, 5.0f));
@@ -573,7 +573,7 @@ TEST_CASE("TextShaper BreakMode preserves remnant when the over-wide segment is 
 }
 
 TEST_CASE("TextRunPlanner emits UTF-8 scalar offsets and line breaks",
-          "[canvas][text_run_planner][codecov]") {
+          "[canvas][text_run_planner]") {
     FontOptions options;
     options.family_stack = {"system"};
     options.size = 14.0f;
@@ -601,7 +601,7 @@ TEST_CASE("TextRunPlanner emits UTF-8 scalar offsets and line breaks",
 }
 
 TEST_CASE("TextRunPlanner cache clear preserves shaped output contracts",
-          "[canvas][text_run_planner][codecov]") {
+          "[canvas][text_run_planner]") {
     FontOptions options;
     options.family_stack = {"system"};
     options.size = 18.0f;

--- a/test/test_texture_atlas.cpp
+++ b/test/test_texture_atlas.cpp
@@ -469,7 +469,7 @@ TEST_CASE("AtlasPacker occupancy is zero for a degenerate atlas",
 }
 
 TEST_CASE("AtlasPacker clamps degenerate capacity and used-area introspection",
-          "[render][atlas][coverage][introspection]") {
+          "[render][atlas][introspection]") {
     AtlasPacker zero_width(0, 64);
     AtlasPacker zero_height(64, 0);
     AtlasPacker negative_width(-16, 64);
@@ -612,7 +612,7 @@ TEST_CASE("AtlasInventory aggregates across multiple atlases",
 }
 
 TEST_CASE("AtlasInventory clamps malformed page counts and occupancy inputs",
-          "[render][atlas][coverage][inventory]") {
+          "[render][atlas][inventory]") {
     AtlasInventory inv;
     inv.add({AtlasKind::image, "negative pages", 10, 20, -5, 2u, -0.25f});
     inv.add({AtlasKind::glyph, "zero pages", 5, 7, 0, 3u, 1.25f});
@@ -633,7 +633,7 @@ TEST_CASE("AtlasInventory clamps malformed page counts and occupancy inputs",
 }
 
 TEST_CASE("AtlasInfo texel capacity clamps negative dimensions to zero",
-          "[render][atlas][coverage][inventory]") {
+          "[render][atlas][inventory]") {
     AtlasInfo negative_width;
     negative_width.width = -10;
     negative_width.height = 20;
@@ -660,7 +660,7 @@ TEST_CASE("AtlasInfo texel capacity clamps negative dimensions to zero",
 }
 
 TEST_CASE("AtlasInventory gradient snapshots clamp invalid ramp width",
-          "[render][atlas][coverage][inventory]") {
+          "[render][atlas][inventory]") {
     GradientAtlas ga;
     int row = -1;
     REQUIRE(ga.allocate(1, row));

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Theme apply_overrides", "[view][theme]") {
 }
 
 TEST_CASE("Theme apply_overrides with empty theme preserves existing tokens",
-          "[view][theme][coverage]") {
+          "[view][theme]") {
     auto base = Theme::dark();
     const auto bg = base.color("bg.primary");
     const auto spacing = base.dimension("spacing.md");
@@ -272,7 +272,7 @@ TEST_CASE("Theme from_json maps malformed color strings to default color",
 }
 
 TEST_CASE("Theme from_json maps invalid hex digits to default color",
-          "[view][theme][coverage]") {
+          "[view][theme]") {
     auto theme = Theme::from_json(R"({
         "colors": {
             "bad.digit": "#12xx56",
@@ -287,7 +287,7 @@ TEST_CASE("Theme from_json maps invalid hex digits to default color",
 }
 
 TEST_CASE("Theme from_json maps overflowing hex colors to default color",
-          "[view][theme][coverage]") {
+          "[view][theme]") {
     auto theme = Theme::from_json(R"({
         "colors": {
             "bad.overflow": "#ffffffffffffffffffffffffffffffff"
@@ -298,7 +298,7 @@ TEST_CASE("Theme from_json maps overflowing hex colors to default color",
 }
 
 TEST_CASE("Theme JSON parser covers optional sections and alpha colors",
-          "[view][theme][coverage][issue-651]") {
+          "[view][theme][issue-651]") {
     auto theme = Theme::from_json(R"({
         "colors": {
             "overlay.tint": "#10203040",
@@ -357,7 +357,7 @@ TEST_CASE("Theme load and save handle file edge cases",
 }
 
 TEST_CASE("Theme file IO rejects invalid JSON and unwritable targets",
-          "[view][theme][coverage][issue-651]") {
+          "[view][theme][issue-651]") {
     const auto path = std::filesystem::temp_directory_path() /
         "pulp-theme-invalid-json-test.json";
 

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -64,13 +64,13 @@ TEST_CASE("Min contrast thresholds are correct", "[view][contrast]") {
 }
 
 TEST_CASE("Unknown contrast levels fall back to AA normal",
-          "[view][contrast][coverage]") {
+          "[view][contrast]") {
     auto invalid = static_cast<ContrastLevel>(99);
     REQUIRE_THAT(min_contrast_for_level(invalid), WithinAbs(4.5, 0.01));
 }
 
 TEST_CASE("Contrast helpers clamp channel inputs",
-          "[view][contrast][coverage][issue-651]") {
+          "[view][contrast][issue-651]") {
     auto below_black = Color::rgba(-1.0f, -0.5f, -0.25f);
     auto above_white = Color::rgba(2.0f, 1.5f, 1.25f);
 
@@ -96,7 +96,7 @@ TEST_CASE("Auto contrast picks black on light background", "[view][contrast]") {
 }
 
 TEST_CASE("Auto contrast fallback chooses the higher ratio color",
-          "[view][contrast][coverage]") {
+          "[view][contrast]") {
     auto background = Color::rgba8(128, 128, 128);
     auto fg = auto_contrast_foreground(background, ContrastLevel::aaa_normal);
 
@@ -120,7 +120,7 @@ TEST_CASE("Adjust for contrast returns meeting color", "[view][contrast]") {
 }
 
 TEST_CASE("Auto contrast falls back to the higher-ratio endpoint",
-          "[view][contrast][coverage]") {
+          "[view][contrast]") {
     auto background = Color::rgba8(120, 120, 120);
     REQUIRE_FALSE(meets_contrast(Color::rgba8(255, 255, 255),
                                  background,
@@ -137,7 +137,7 @@ TEST_CASE("Auto contrast falls back to the higher-ratio endpoint",
 }
 
 TEST_CASE("Adjust for contrast preserves already compliant colors",
-          "[view][contrast][coverage]") {
+          "[view][contrast]") {
     auto foreground = Color::rgba8(255, 255, 255, 128);
     auto background = Color::rgba8(0, 0, 0);
 
@@ -155,7 +155,7 @@ TEST_CASE("Adjust for contrast preserves already compliant colors",
 }
 
 TEST_CASE("Adjust for contrast returns nullopt when threshold is impossible",
-          "[view][contrast][coverage]") {
+          "[view][contrast]") {
     auto background = Color::rgba8(128, 128, 128);
     auto foreground = Color::rgba8(128, 128, 128);
 
@@ -194,7 +194,7 @@ TEST_CASE("Shift hue wraps around", "[view][contrast][hsl]") {
 }
 
 TEST_CASE("Shift hue wraps negative and alpha is preserved",
-          "[view][contrast][hsl][coverage][issue-651]") {
+          "[view][contrast][hsl][issue-651]") {
     auto color = Color::rgba8(0, 255, 0, 96);
     auto shifted = shift_hue(color, -240.0f);
     auto hsl = rgb_to_hsl(shifted);
@@ -292,7 +292,7 @@ TEST_CASE("Auto-fix contrast produces valid theme", "[view][contrast][theme]") {
 }
 
 TEST_CASE("Theme contrast validation skips missing pairs and reports failures",
-          "[view][contrast][theme][coverage][issue-651]") {
+          "[view][contrast][theme][issue-651]") {
     Theme partial;
     partial.colors["bg.primary"] = Color::rgba8(255, 255, 255);
     partial.colors["text.primary"] = Color::rgba8(200, 200, 200);
@@ -311,7 +311,7 @@ TEST_CASE("Theme contrast validation skips missing pairs and reports failures",
 }
 
 TEST_CASE("Auto-fix leaves unresolved contrast issues unchanged",
-          "[view][contrast][theme][coverage]") {
+          "[view][contrast][theme]") {
     Theme bad;
     bad.colors["bg.primary"] = Color::rgba8(128, 128, 128);
     bad.colors["text.primary"] = Color::rgba8(128, 128, 128);

--- a/test/test_theme_presets.cpp
+++ b/test/test_theme_presets.cpp
@@ -39,7 +39,7 @@ TEST_CASE("find_preset returns nullptr for unknown", "[view][presets]") {
 }
 
 TEST_CASE("preset_ids preserves library order and exact size",
-          "[view][presets][coverage][issue-651]") {
+          "[view][presets][issue-651]") {
     const auto& presets = all_presets();
     auto ids = preset_ids();
 
@@ -121,7 +121,7 @@ TEST_CASE("Derived theme JSON round-trip", "[view][presets][derive]") {
 }
 
 TEST_CASE("theme_from_preset applies variant-specific overrides",
-          "[view][presets][derive][coverage][issue-651]") {
+          "[view][presets][derive][issue-651]") {
     ThemePreset preset;
     preset.id = "custom";
     preset.name = "Custom";
@@ -151,7 +151,7 @@ TEST_CASE("theme_from_preset applies variant-specific overrides",
 }
 
 TEST_CASE("derive_theme maps semantic colors to alpha and blend tokens",
-          "[view][presets][derive][coverage]") {
+          "[view][presets][derive]") {
     SemanticColors colors{
         color_from_hex(0x102030),
         color_from_hex(0xE0D0C0),

--- a/test/test_ui_components.cpp
+++ b/test/test_ui_components.cpp
@@ -84,7 +84,7 @@ TEST_CASE("ComboBox paint produces draw commands", "[view][combo]") {
 }
 
 TEST_CASE("ComboBox paint truncates long selected text",
-          "[view][combo][coverage]") {
+          "[view][combo]") {
     ComboBox combo;
     combo.set_items({"SuperLongOscillatorName"});
     combo.set_bounds({0, 0, 75, 28});
@@ -121,7 +121,7 @@ TEST_CASE("ComboBox key up/down changes selection", "[view][combo]") {
     REQUIRE(combo.selected() == 1);
 }
 
-TEST_CASE("ComboBox helper edges and keyboard popup controls", "[view][combo][coverage]") {
+TEST_CASE("ComboBox helper edges and keyboard popup controls", "[view][combo]") {
     ComboBox::close_active_popup();
 
     ComboBox empty;
@@ -180,7 +180,7 @@ TEST_CASE("ComboBox helper edges and keyboard popup controls", "[view][combo][co
 }
 
 TEST_CASE("ComboBox popup overlay paints separators hover and selection guards",
-          "[view][combo][coverage]") {
+          "[view][combo]") {
     ComboBox::close_active_popup();
     View::overlay_queue().clear();
 
@@ -223,7 +223,7 @@ TEST_CASE("ComboBox popup overlay paints separators hover and selection guards",
 }
 
 TEST_CASE("ComboBox mouse selection and hover guard paths",
-          "[view][combo][coverage]") {
+          "[view][combo]") {
     ComboBox::close_active_popup();
 
     ComboBox combo;
@@ -260,7 +260,7 @@ TEST_CASE("ComboBox mouse selection and hover guard paths",
 }
 
 TEST_CASE("ComboBox returns false for unrelated key presses",
-          "[view][combo][coverage]") {
+          "[view][combo]") {
     ComboBox combo;
     combo.set_items({"One", "Two"});
 
@@ -328,7 +328,7 @@ TEST_CASE("ComboBox opening another popup closes the previous one",
 }
 
 TEST_CASE("ComboBox destructor clears active popup slot",
-          "[view][combo][coverage]") {
+          "[view][combo]") {
     ComboBox::close_active_popup();
 
     {
@@ -593,7 +593,7 @@ TEST_CASE("ScrollView scroll_x clamped", "[view][scroll]") {
 }
 
 TEST_CASE("ScrollView scrollbar paint hit test and drag update offsets",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_direction(ScrollView::Direction::both);
     sv.set_bounds({0, 0, 100, 100});
@@ -632,7 +632,7 @@ TEST_CASE("ScrollView scrollbar paint hit test and drag update offsets",
 }
 
 TEST_CASE("ScrollView wheel respects horizontal direction and track clicks",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView horizontal;
     horizontal.set_direction(ScrollView::Direction::horizontal);
     horizontal.set_bounds({0, 0, 100, 100});
@@ -699,7 +699,7 @@ TEST_CASE("ScrollView vertical wheel leave and horizontal track click edges",
 }
 
 TEST_CASE("ScrollView auto scroll behavior updates immediately",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_direction(ScrollView::Direction::both);
     sv.set_bounds({0, 0, 100, 100});
@@ -714,7 +714,7 @@ TEST_CASE("ScrollView auto scroll behavior updates immediately",
 }
 
 TEST_CASE("ScrollView layout children restores viewport bounds",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_bounds({3, 4, 100, 50});
     sv.set_content_size({220, 180});
@@ -729,7 +729,7 @@ TEST_CASE("ScrollView layout children restores viewport bounds",
 }
 
 TEST_CASE("ScrollView paint_all applies opacity reset path",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_direction(ScrollView::Direction::both);
     sv.set_bounds({0, 0, 100, 50});
@@ -743,7 +743,7 @@ TEST_CASE("ScrollView paint_all applies opacity reset path",
 }
 
 TEST_CASE("ScrollView box-none suppresses scrollbar self hits",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_direction(ScrollView::Direction::both);
     sv.set_bounds({0, 0, 100, 100});
@@ -756,7 +756,7 @@ TEST_CASE("ScrollView box-none suppresses scrollbar self hits",
 }
 
 TEST_CASE("ScrollView both-direction wheel preserves both deltas",
-          "[view][scroll][coverage]") {
+          "[view][scroll]") {
     ScrollView sv;
     sv.set_direction(ScrollView::Direction::both);
     sv.set_bounds({0, 0, 100, 100});
@@ -890,7 +890,7 @@ TEST_CASE("ListBox paint with selection", "[view][listbox]") {
 }
 
 TEST_CASE("ListBox wheel scrolling double-click and enter activation",
-          "[view][listbox][coverage]") {
+          "[view][listbox]") {
     ListBox list;
     list.set_bounds({0, 0, 120, 48});
     list.set_items({"Alpha", "Beta", "Gamma", "Delta", "Epsilon"});

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -121,7 +121,7 @@ TEST_CASE("View child management", "[view]") {
     REQUIRE(removed->parent() == nullptr);
 }
 
-TEST_CASE("View child removal ignores unknown children", "[view][coverage]") {
+TEST_CASE("View child removal ignores unknown children", "[view]") {
     View root;
     auto child = std::make_unique<View>();
     auto* child_ptr = child.get();
@@ -200,7 +200,7 @@ TEST_CASE("View hit testing", "[view]") {
 }
 
 TEST_CASE("View hit testing honors disabled hit-testable and overflow states",
-          "[view][coverage]") {
+          "[view]") {
     View root;
     root.set_bounds({0, 0, 160, 160});
 
@@ -256,7 +256,7 @@ TEST_CASE("View theme resolution", "[view][theme]") {
 }
 
 TEST_CASE("View dimensions frame clock and repaint helpers resolve inherited state",
-          "[view][coverage]") {
+          "[view]") {
     class ResizedView : public View {
     public:
         void on_resized() override { ++resized_count; }
@@ -387,7 +387,7 @@ TEST_CASE("View simulate_drag calls drag sequence", "[view][events]") {
 }
 
 TEST_CASE("View pointer capture hover and inspector hooks cover edge paths",
-          "[view][coverage]") {
+          "[view]") {
     View v;
 
     v.set_pointer_capture(7);
@@ -705,7 +705,7 @@ TEST_CASE("Flex layout with padding", "[view][layout]") {
 }
 
 TEST_CASE("Grid layout with no columns leaves children unchanged",
-          "[view][layout][coverage]") {
+          "[view][layout]") {
     View root;
     root.set_bounds({0, 0, 120, 80});
     root.set_layout_mode(LayoutMode::grid);
@@ -1384,7 +1384,7 @@ TEST_CASE("absolute child with inset:0 fills parent ignoring explicit height",
 }
 
 TEST_CASE("LiveConstantRegistry registers reuses clamps and resets constants",
-          "[view][live-constant][coverage]") {
+          "[view][live-constant]") {
     auto& registry = LiveConstantRegistry::instance();
     registry.on_change = {};
 
@@ -1429,7 +1429,7 @@ TEST_CASE("LiveConstantRegistry registers reuses clamps and resets constants",
 }
 
 TEST_CASE("LiveConstantEditor toggles visibility and ignores header drags",
-          "[view][live-constant][coverage]") {
+          "[view][live-constant]") {
     auto& registry = LiveConstantRegistry::instance();
     registry.register_constant(
         "phase3.live.editor", "test_view.cpp", 303, 5.0f, 0.0f, 10.0f);

--- a/test/test_view_bridge.cpp
+++ b/test/test_view_bridge.cpp
@@ -274,7 +274,7 @@ TEST_CASE("ViewBridge defers on_view_opened until notify_attached", "[view_bridg
 }
 
 TEST_CASE("ViewBridge stores detached resize state and resets on reopen",
-          "[view_bridge][coverage]") {
+          "[view_bridge]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);

--- a/test/test_view_corner_radius.cpp
+++ b/test/test_view_corner_radius.cpp
@@ -163,7 +163,7 @@ TEST_CASE("pulp #1731 P1 — px radius still wins when pct is 0 (default)",
 // ─────────────────────────────────────────────────────────────────────────────
 
 TEST_CASE("pulp #1731 cov — effective_corner_radius uniform pct math",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     pulp::view::View v;
 
     SECTION("50% on 100x60 → 30 (50% × min(100,60))") {
@@ -216,7 +216,7 @@ TEST_CASE("pulp #1731 cov — effective_corner_radius uniform pct math",
 }
 
 TEST_CASE("pulp #1731 cov — effective_corner_radius_* per-corner pct math",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     pulp::view::View v;
     v.set_bounds({0, 0, 100, 60});
 
@@ -276,7 +276,7 @@ TEST_CASE("pulp #1731 cov — effective_corner_radius_* per-corner pct math",
 }
 
 TEST_CASE("pulp #1731 cov — uniform percent reflows when bounds change",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     // Same View, two different bounds — pct stays the same but resolved
     // px differs because min(w,h) differs.
     pulp::view::View v;
@@ -296,7 +296,7 @@ TEST_CASE("pulp #1731 cov — uniform percent reflows when bounds change",
 }
 
 TEST_CASE("pulp #1731 cov — per-corner pct paints as cubic_to with resolved px",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     // Per-corner percent forces View::paint_all into the per-corner path
     // builder (build_per_corner_rounded_rect_path), which emits cubic_to
     // commands whose end-points encode each effective radius.
@@ -338,7 +338,7 @@ TEST_CASE("pulp #1731 cov — per-corner pct paints as cubic_to with resolved px
 }
 
 TEST_CASE("pulp #1731 cov — box-shadow path reads the percent-resolved radius",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     // View::paint_all draws outset box-shadow before the background,
     // and the shadow's rounded-rect corner is computed from
     // effective_corner_radius(...). A 50% pct on a 200x200 view should
@@ -387,7 +387,7 @@ TEST_CASE("pulp #1731 cov — box-shadow path reads the percent-resolved radius"
 }
 
 TEST_CASE("pulp #1731 cov — Panel::paint reads pct via effective_corner_radius",
-          "[issue-1731][rn][borderRadius][coverage]") {
+          "[issue-1731][rn][borderRadius]") {
     // widgets.cpp:1774 — Panel reads effective_corner_radius for its
     // own fill_rounded_rect. Pin the pct path explicitly.
     pulp::view::Panel p;

--- a/test/test_view_layout_widgets.cpp
+++ b/test/test_view_layout_widgets.cpp
@@ -67,7 +67,7 @@ TEST_CASE("SplitView lays out horizontal and vertical panes around divider",
 }
 
 TEST_CASE("SplitView clamps split fraction and supports pane replacement",
-          "[view][split_view][coverage]") {
+          "[view][split_view]") {
     SplitView split;
     auto first = std::make_unique<View>();
     auto second = std::make_unique<View>();

--- a/test/test_view_size_aspect.cpp
+++ b/test/test_view_size_aspect.cpp
@@ -41,7 +41,7 @@ TEST_CASE("aspect ratio is independent of min/max bounds",
 }
 
 TEST_CASE("ViewSize zero max bounds remain unbounded when aspect is locked",
-          "[format][view-size][coverage]") {
+          "[format][view-size]") {
     ViewSize v;
     v.preferred_width = 1024;
     v.preferred_height = 768;

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2247,7 +2247,7 @@ TEST_CASE("Label paints with TextAlign::left when textAlign='auto' (LTR fallback
 //   - widgets.cpp Label::paint — paint-time parent-chain walk
 
 TEST_CASE("setTextAlign accepts match-parent on a Label",
-          "[view][bridge][css][issue-1434][coverage]") {
+          "[view][bridge][css][issue-1434]") {
     ScriptEngine engine;
     View root;
     StateStore store;
@@ -2262,7 +2262,7 @@ TEST_CASE("setTextAlign accepts match-parent on a Label",
 }
 
 TEST_CASE("Label with textAlign='match-parent' adopts parent's resolved value (center)",
-          "[view][widget][css][issue-1434][coverage]") {
+          "[view][widget][css][issue-1434]") {
     // Parent View carries an inheritable text-align (center = 1). Label
     // child set to match-parent should paint with TextAlign::center.
     View parent;
@@ -2288,7 +2288,7 @@ TEST_CASE("Label with textAlign='match-parent' adopts parent's resolved value (c
 }
 
 TEST_CASE("Label with textAlign='match-parent' falls back to left when no ancestor set a value",
-          "[view][widget][css][issue-1434][coverage]") {
+          "[view][widget][css][issue-1434]") {
     // CSS spec: `text-align` defaults to `start` (≡ left under LTR) when
     // no value is inherited. A match-parent Label with no parent (or a
     // parent chain that never called set_inheritable_text_align) must
@@ -2315,7 +2315,7 @@ TEST_CASE("Label with textAlign='match-parent' falls back to left when no ancest
 // value upstream. A chain like grandparent=center → parent=match-parent →
 // label=match-parent should resolve to center, not fall back to left.
 TEST_CASE("Label with match-parent walks past intermediate match-parent ancestor",
-          "[view][widget][css][issue-1434][issue-1879][coverage]") {
+          "[view][widget][css][issue-1434][issue-1879]") {
     // Build: grandparent(center) → parent(match-parent) → label(match-parent).
     View grandparent;
     grandparent.set_bounds({0, 0, 600, 200});
@@ -2353,7 +2353,7 @@ TEST_CASE("Label with match-parent walks past intermediate match-parent ancestor
 }
 
 TEST_CASE("Label with match-parent through chain of all match-parent ancestors falls back to left",
-          "[view][widget][css][issue-1434][issue-1879][coverage]") {
+          "[view][widget][css][issue-1434][issue-1879]") {
     // Pathological case: every ancestor in the chain has match-parent.
     // CSS spec says fall back to `start` (≡ left under LTR).
     View root;
@@ -2387,7 +2387,7 @@ TEST_CASE("Label with match-parent through chain of all match-parent ancestors f
 }
 
 TEST_CASE("setTextAlign on a container View accepts match-parent (encoded as 5)",
-          "[view][bridge][css][issue-1434][coverage]") {
+          "[view][bridge][css][issue-1434]") {
     // Non-Label Views store the alignment in the inheritable slot so
     // descendant Labels pick it up. The match-parent encoding (5) must
     // round-trip through inheritable_text_align().
@@ -2456,7 +2456,7 @@ TEST_CASE("setCursor maps the full CSS keyword set",
 // keywords (`wait` / `help` / `progress` / `cell`) stay collapsed to `default_`
 // because macOS has no native cursor for them. Pin both halves.
 TEST_CASE("setCursor wires 5 macOS-backed keywords to dedicated CursorStyle slots",
-          "[view][bridge][issue-1550][coverage]") {
+          "[view][bridge][issue-1550]") {
     ScriptEngine engine;
     View root;
     StateStore store;
@@ -2905,7 +2905,7 @@ TEST_CASE("setListStyleType unknown keyword falls back to disc (issue-1514)",
 // storage-only round-trips; paint-side glyph rendering is a separate gap. The
 // bridge stores each keyword on its own View::ListStyleType slot.
 TEST_CASE("setListStyleType maps counter-style keywords to enum slots (issue-1514)",
-          "[view][bridge][css][issue-1514][coverage]") {
+          "[view][bridge][css][issue-1514]") {
     ScriptEngine engine;
     View root;
     StateStore store;
@@ -2939,7 +2939,7 @@ TEST_CASE("setListStyleType maps counter-style keywords to enum slots (issue-151
 // silently dropped). Regression guard for the `lsTypes` table in
 // web-compat-style-decl.js.
 TEST_CASE("listStyle shorthand routes counter-style keywords (issue-1514)",
-          "[view][bridge][css][issue-1514][coverage]") {
+          "[view][bridge][css][issue-1514]") {
     ScriptEngine engine;
     View root;
     StateStore store;

--- a/test/test_widget_bridge_animation.cpp
+++ b/test/test_widget_bridge_animation.cpp
@@ -670,7 +670,7 @@ TEST_CASE("WidgetBridge loadAssetSync covers embedded file and missing records",
 }
 
 TEST_CASE("WidgetBridge loadAssetSync covers text mime variants and path normalization",
-          "[view][bridge][asset][coverage]")
+          "[view][bridge][asset]")
 {
     ScriptEngine engine;
     View root;
@@ -728,7 +728,7 @@ TEST_CASE("WidgetBridge loadAssetSync covers text mime variants and path normali
 }
 
 TEST_CASE("WidgetBridge registerDrop dispatches escaped payloads to JS",
-          "[view][bridge][dnd][coverage]")
+          "[view][bridge][dnd]")
 {
     ScriptEngine engine;
     View root;
@@ -774,7 +774,7 @@ TEST_CASE("WidgetBridge registerDrop dispatches escaped payloads to JS",
 }
 
 TEST_CASE("WidgetBridge registerContextMenu dispatches native menu position",
-          "[view][bridge][context-menu][coverage]")
+          "[view][bridge][context-menu]")
 {
     ScriptEngine engine;
     View root;
@@ -811,7 +811,7 @@ TEST_CASE("WidgetBridge registerContextMenu dispatches native menu position",
 }
 
 TEST_CASE("WidgetBridge loadFont reports existing and missing paths",
-          "[view][bridge][font][coverage]")
+          "[view][bridge][font]")
 {
     ScriptEngine engine;
     View root;

--- a/test/test_widget_bridge_canvas2d.cpp
+++ b/test/test_widget_bridge_canvas2d.cpp
@@ -202,7 +202,7 @@ TEST_CASE("WidgetBridge canvasGlobalCompositeOperation maps CSS strings to Blend
 }
 
 TEST_CASE("WidgetBridge direct Canvas2D gap APIs replay expected canvas commands",
-          "[view][bridge][canvas][coverage]") {
+          "[view][bridge][canvas]") {
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});
@@ -865,7 +865,7 @@ TEST_CASE("WidgetBridge canvasDrawImage 9-arg form plumbs source rect end-to-end
 // invokes canvasDrawImage directly via JS and asserts the CanvasDrawCmd state
 // right at the JS-→-bridge boundary (read back via CanvasWidget::commands()).
 TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the recorded cmd",
-          "[view][bridge][canvas][issue-1739][canvas2d][coverage]") {
+          "[view][bridge][canvas][issue-1739][canvas2d]") {
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});
@@ -922,7 +922,7 @@ TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the 
 // branch must NOT fire, so has_source_rect stays false. Pins the
 // else-branch of the bridge plumbing.
 TEST_CASE("WidgetBridge canvasDrawImage 6-arg call leaves has_source_rect=false",
-          "[view][bridge][canvas][issue-1739][canvas2d][coverage]") {
+          "[view][bridge][canvas][issue-1739][canvas2d]") {
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});
@@ -970,7 +970,7 @@ TEST_CASE("WidgetBridge canvasDrawImage 6-arg call leaves has_source_rect=false"
 // propagate that state into the fill_text cmd rather than reset to defaults.
 
 TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior fillStyle color",
-          "[view][bridge][canvas][issue-1901][canvas2d][coverage]") {
+          "[view][bridge][canvas][issue-1901][canvas2d]") {
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});
@@ -1013,7 +1013,7 @@ TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior fillStyle color",
 }
 
 TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior set_font state",
-          "[view][bridge][canvas][issue-1901][canvas2d][coverage]") {
+          "[view][bridge][canvas][issue-1901][canvas2d]") {
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});

--- a/test/test_widget_bridge_css_animations.cpp
+++ b/test/test_widget_bridge_css_animations.cpp
@@ -84,7 +84,7 @@ TEST_CASE("parse_transition_shorthand: steps(N, end|start)",
 }
 
 TEST_CASE("parse_transition_shorthand rejects partial easing numbers",
-          "[view][bridge][css][coverage]") {
+          "[view][bridge][css]") {
     auto bezier = parse_transition_shorthand(
         "opacity 200ms cubic-bezier(0.42junk, 0, 0.58, 1)");
     REQUIRE(bezier.size() == 1);

--- a/test/test_widget_bridge_wave5_css.cpp
+++ b/test/test_widget_bridge_wave5_css.cpp
@@ -1217,7 +1217,7 @@ static pulp::canvas::Color outline_stroke_color_from(
 }
 
 TEST_CASE("outline currentColor resolves to Label own text color in painted stroke",
-          "[issue-1728][rn][outlineColor][coverage]") {
+          "[issue-1728][rn][outlineColor]") {
     using namespace pulp::view;
     using namespace pulp::canvas;
     ScriptEngine engine;
@@ -1251,7 +1251,7 @@ TEST_CASE("outline currentColor resolves to Label own text color in painted stro
 }
 
 TEST_CASE("outline explicit color overrides currentColor resolution in painted stroke",
-          "[issue-1728][rn][outlineColor][coverage]") {
+          "[issue-1728][rn][outlineColor]") {
     using namespace pulp::view;
     using namespace pulp::canvas;
     ScriptEngine engine;
@@ -1284,7 +1284,7 @@ TEST_CASE("outline explicit color overrides currentColor resolution in painted s
 }
 
 TEST_CASE("outline currentColor with no color set falls back to theme text.primary",
-          "[issue-1728][rn][outlineColor][coverage]") {
+          "[issue-1728][rn][outlineColor]") {
     using namespace pulp::view;
     using namespace pulp::canvas;
     ScriptEngine engine;
@@ -1328,7 +1328,7 @@ TEST_CASE("outline currentColor with no color set falls back to theme text.prima
 }
 
 TEST_CASE("outline currentColor follows dynamic Label color update across repaints",
-          "[issue-1728][rn][outlineColor][coverage]") {
+          "[issue-1728][rn][outlineColor]") {
     using namespace pulp::view;
     using namespace pulp::canvas;
     ScriptEngine engine;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -846,7 +846,7 @@ TEST_CASE("Fader horizontal orientation", "[view][widget]") {
 }
 
 TEST_CASE("Knob and Fader render loaded sprite strips",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     auto knob_strip = make_sprite_strip(2, 9, 3, SpriteStrip::Orientation::vertical);
     Knob knob;
     knob.set_bounds({0, 0, 20, 30});
@@ -1075,7 +1075,7 @@ TEST_CASE("RangeSlider renders track + fill + handle",
 }
 
 TEST_CASE("RangeSlider vertical paint draws lower fill and inverted handle",
-          "[view][widget][issue-966][coverage]") {
+          "[view][widget][issue-966]") {
     RangeSlider rs;
     rs.set_bounds({0, 0, 24, 200});
     rs.set_orientation(RangeSlider::Orientation::vertical);
@@ -1222,7 +1222,7 @@ TEST_CASE("Audio widgets render declarative schemas and invalid schema fallback"
 }
 
 TEST_CASE("Audio widget schemas reject malformed dimension tokens without error fallback",
-          "[view][widget][schema][coverage]") {
+          "[view][widget][schema]") {
     Knob knob;
     knob.set_bounds({0, 0, 80, 80});
     knob.set_value(0.5f);
@@ -1716,7 +1716,7 @@ TEST_CASE("SpectrumView empty renders background", "[view][widget]") {
 }
 
 TEST_CASE("SpectrumView invalid dB range only draws background",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     SpectrumView spectrum;
     spectrum.set_bounds({0, 0, 300, 100});
     spectrum.set_style(SpectrumView::Style::bars);
@@ -1732,7 +1732,7 @@ TEST_CASE("SpectrumView invalid dB range only draws background",
 }
 
 TEST_CASE("SpectrogramView auto-configures and paints pushed spectrum",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     SpectrogramView spectrogram;
     spectrogram.set_bounds({0, 0, 128, 32});
 
@@ -1756,7 +1756,7 @@ TEST_CASE("SpectrogramView auto-configures and paints pushed spectrum",
 }
 
 TEST_CASE("SpectrogramView explicit configuration controls painted grid size",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     SpectrogramView spectrogram;
     spectrogram.set_bounds({0, 0, 40, 20});
     spectrogram.configure(4, 2, pulp::signal::ColorRamp::heat, -60.0f, -20.0f);
@@ -1776,7 +1776,7 @@ TEST_CASE("SpectrogramView explicit configuration controls painted grid size",
 }
 
 TEST_CASE("MultiMeter paints vertical and horizontal channel indicators",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     pulp::signal::MultiChannelMeterData data;
     data.num_channels = 3;
     data.channels[0].rms = 0.95f;
@@ -1833,7 +1833,7 @@ TEST_CASE("MultiMeter paints vertical and horizontal channel indicators",
 }
 
 TEST_CASE("MultiMeter with no channels paints nothing",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     MultiMeter meter;
     meter.set_bounds({0, 0, 80, 40});
 
@@ -1844,7 +1844,7 @@ TEST_CASE("MultiMeter with no channels paints nothing",
 }
 
 TEST_CASE("CorrelationMeter clamps updates and paints both polarities",
-          "[view][widget][coverage]") {
+          "[view][widget]") {
     CorrelationMeter meter;
     meter.set_bounds({0, 0, 100, 20});
 

--- a/test/test_widgets_label.cpp
+++ b/test/test_widgets_label.cpp
@@ -407,7 +407,7 @@ TEST_CASE("Label measured_height counts soft-wrapped lines under a bounded width
 }
 
 TEST_CASE("Label baseline_y follows text metrics and inherited font size",
-          "[view][widget][baseline][coverage]") {
+          "[view][widget][baseline]") {
     Label normal("CHAIN");
     normal.set_font_size(14.0f);
     const float normal_baseline = normal.baseline_y();


### PR DESCRIPTION
## Summary
- Remove stale Catch2 selector metadata from 39 view/canvas/font/gui test files.
- Drops only `[coverage]` and `[codecov]` tag tokens; `[requested]` and `[large]` were part of the audit scope but did not appear in this slice.
- Preserves product tags, issue tags, test names, test bodies, visible strings, and generated artifacts.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target <affected view/canvas/font/gui test targets>`
- Ran all affected test binaries directly; `pulp-test-canvas` has one expected-fail Catch case and the overall command exited 0.
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --head HEAD --mode=report --require-ceiling-reduction`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- Pre-push hook gates clean.

## Review
- RepoPrompt/rp-cli review: requested explicit CI/tooling selector-coupling verification; follow-up grep found no non-C++ selectors for `[coverage]`, `[codecov]`, `[requested]`, or `[large]`.
- Local autoreview: clean.
- Claude bridge review: clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale Catch2 `[coverage]`/`[codecov]` tags from 39 view/canvas/font/gui tests to reduce selector noise. No test logic or behavior changed; builds and test suites still pass.

- **Refactors**
  - Dropped only `[coverage]` and `[codecov]` tokens; kept product/issue tags, test names, and bodies.
  - Verified no CI/tooling depends on these tags (repo-wide grep and local scripts).
  - Built and ran affected test targets; results unchanged (one known expected-fail remains).

<sup>Written for commit 3026a7936ecde6580cbb026897c796725e339dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

