### PR TITLE
docs(test): clean format host selector tags

### DIFF
--- a/test/test_aax_model.cpp
+++ b/test/test_aax_model.cpp
@@ -430,7 +430,7 @@ TEST_CASE("AAX model exposes stem mapping helpers for supported and unknown layo
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_6_0)) == "unknown");
 }
 
-TEST_CASE("AAX model carries descriptor and parameter metadata into definitions", "[aax][model][coverage][issue-648]") {
+TEST_CASE("AAX model carries descriptor and parameter metadata into definitions", "[aax][model][issue-648]") {
     auto codes = valid_codes();
     auto descriptor = descriptor_with_buses(
         {{"Main In", 2, false}},

--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Appcast XML emits Sparkle signature when present", "[ship][appcast]")
 }
 
 TEST_CASE("Appcast XML escapes greater-than characters in feed and item fields",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     Appcast feed;
     feed.title = "Pulp > Beta";
     feed.link = "https://example.com/feed.xml";
@@ -275,7 +275,7 @@ TEST_CASE("Appcast from_xml ignores malformed enclosure length", "[ship][appcast
 }
 
 TEST_CASE("Appcast XML uses short version as build number when build is empty",
-          "[ship][appcast][coverage][issue-644]") {
+          "[ship][appcast][issue-644]") {
     Appcast feed;
     feed.title = "Fallback Feed";
     feed.link = "https://example.com/appcast.xml";
@@ -296,7 +296,7 @@ TEST_CASE("Appcast XML uses short version as build number when build is empty",
 }
 
 TEST_CASE("Appcast from_xml accepts rss with item-only metadata",
-          "[ship][appcast][coverage][issue-644]") {
+          "[ship][appcast][issue-644]") {
     auto parsed = Appcast::from_xml(R"(<rss version="2.0">
   <channel>
     <item>
@@ -319,7 +319,7 @@ TEST_CASE("Appcast from_xml accepts rss with item-only metadata",
 }
 
 TEST_CASE("Appcast from_xml only requires rss marker",
-          "[ship][appcast][coverage][issue-644]") {
+          "[ship][appcast][issue-644]") {
     auto parsed = Appcast::from_xml("<rss version=\"2.0\"></rss>");
 
     REQUIRE(parsed.has_value());
@@ -327,7 +327,7 @@ TEST_CASE("Appcast from_xml only requires rss marker",
 }
 
 TEST_CASE("Appcast XML emits stable empty-feed skeleton",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     Appcast feed;
     feed.title = "Empty Updates";
     feed.link = "https://example.com/empty.xml";
@@ -344,7 +344,7 @@ TEST_CASE("Appcast XML emits stable empty-feed skeleton",
 }
 
 TEST_CASE("Appcast XML emits each item branch independently",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     Appcast feed;
     feed.title = "Mixed Feed";
     feed.link = "https://example.com/appcast.xml";
@@ -384,7 +384,7 @@ TEST_CASE("Appcast XML emits each item branch independently",
 }
 
 TEST_CASE("Appcast from_xml handles empty and zero-valued enclosure attributes",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     auto parsed = Appcast::from_xml(R"(<rss version="2.0">
   <channel>
     <title>Zero Feed</title>
@@ -415,7 +415,7 @@ TEST_CASE("Appcast from_xml handles empty and zero-valued enclosure attributes",
 }
 
 TEST_CASE("Appcast from_xml keeps partial item metadata when optional tags are malformed",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     auto parsed = Appcast::from_xml(R"(<rss version="2.0">
   <channel>
     <title>Partial Items</title>
@@ -440,7 +440,7 @@ TEST_CASE("Appcast from_xml keeps partial item metadata when optional tags are m
 }
 
 TEST_CASE("Appcast from_xml ignores single-quoted enclosure attributes",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     auto parsed = Appcast::from_xml(R"(<rss version="2.0">
   <channel>
     <title>Quoted Feed</title>
@@ -461,7 +461,7 @@ TEST_CASE("Appcast from_xml ignores single-quoted enclosure attributes",
 }
 
 TEST_CASE("Appcast from_xml captures CDATA with nested markup and brackets",
-          "[ship][appcast][coverage]") {
+          "[ship][appcast]") {
     auto parsed = Appcast::from_xml(R"(<rss version="2.0">
   <channel>
     <title>Notes Feed</title>
@@ -499,7 +499,7 @@ TEST_CASE("Version comparison tolerates non-numeric segments", "[ship][version]"
 }
 
 TEST_CASE("Version comparison pads and orders long mixed versions",
-          "[ship][version][coverage][issue-644]") {
+          "[ship][version][issue-644]") {
     REQUIRE(compare_versions("", "0") == 0);
     REQUIRE(compare_versions("1.0.0", "1.0.0.0.0") == 0);
     REQUIRE(compare_versions("1.0.0.0.1", "1.0.0.0") == 1);

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -38,7 +38,7 @@ TEST_CASE("AraDocumentController subclass overrides work", "[ara]") {
     REQUIRE((c.supported_roles() & static_cast<int>(AraRole::EditorView)) != 0);
 }
 
-TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][coverage][issue-648]") {
+TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][issue-648]") {
     AraDocumentController controller;
     controller.begin_editing();
     controller.notify_audio_source_content_changed(123);
@@ -48,7 +48,7 @@ TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][coverag
     REQUIRE(controller.ara_factory_name().empty());
 }
 
-TEST_CASE("AraRole bit values remain stable for adapter metadata", "[ara][coverage][issue-648]") {
+TEST_CASE("AraRole bit values remain stable for adapter metadata", "[ara][issue-648]") {
     REQUIRE(static_cast<int>(AraRole::None) == 0);
     REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
     REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);

--- a/test/test_ara_types.cpp
+++ b/test/test_ara_types.cpp
@@ -20,7 +20,7 @@ TEST_CASE("AudioSourceContentChange is a bitset", "[ara][types]") {
 }
 
 TEST_CASE("AudioSourceContentChange supports combined invalidation masks",
-          "[ara][types][coverage]") {
+          "[ara][types]") {
     auto flags = AudioSourceContentChange::Notes
                | AudioSourceContentChange::Tempo
                | AudioSourceContentChange::Tuning

--- a/test/test_background_scanner.cpp
+++ b/test/test_background_scanner.cpp
@@ -65,7 +65,7 @@ TEST_CASE("BackgroundScanner: completes a quick scan", "[host][bg-scan]") {
 }
 
 TEST_CASE("BackgroundScanner: empty worker still completes",
-          "[host][bg-scan][coverage]") {
+          "[host][bg-scan]") {
     BackgroundScanner bs;
     bool completion_called = false;
     bool final_cancelled = true;
@@ -89,7 +89,7 @@ TEST_CASE("BackgroundScanner: empty worker still completes",
 }
 
 TEST_CASE("BackgroundScanner: worker may finish without completion callback",
-          "[host][bg-scan][coverage]") {
+          "[host][bg-scan]") {
     BackgroundScanner bs;
     std::atomic<bool> worker_ran{false};
     std::atomic<int> progress_calls{0};
@@ -115,7 +115,7 @@ TEST_CASE("BackgroundScanner: worker may finish without completion callback",
 }
 
 TEST_CASE("BackgroundScanner: idle cancel and join are no-ops",
-          "[host][bg-scan][coverage]") {
+          "[host][bg-scan]") {
     BackgroundScanner bs;
     REQUIRE_FALSE(bs.is_running());
     bs.cancel();
@@ -124,7 +124,7 @@ TEST_CASE("BackgroundScanner: idle cancel and join are no-ops",
 }
 
 TEST_CASE("BackgroundScanner: destructor requests cancel and joins active worker",
-          "[host][bg-scan][coverage]") {
+          "[host][bg-scan]") {
     std::atomic<bool> started{false};
     std::atomic<bool> worker_saw_cancel{false};
     std::atomic<bool> completed{false};
@@ -323,7 +323,7 @@ TEST_CASE("BackgroundScanner: progress callback fires from worker thread",
 }
 
 TEST_CASE("CancelToken reset clears a prior cancellation request",
-          "[host][bg-scan][coverage]") {
+          "[host][bg-scan]") {
     CancelToken token;
     REQUIRE_FALSE(token.requested());
     token.request();

--- a/test/test_clap_webview.cpp
+++ b/test/test_clap_webview.cpp
@@ -45,7 +45,7 @@ TEST_CASE("WebviewProvider message callback", "[format][webview]") {
 }
 
 TEST_CASE("WebviewProvider defaults and outbound callback are stable",
-          "[format][webview][coverage]") {
+          "[format][webview]") {
     class TestProvider : public WebviewProvider {
     public:
         WebviewContent get_webview_content() const override {

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -72,12 +72,12 @@ TEST_CASE("check_notarization on nonexistent path is false", "[ship][codesign]")
 }
 
 TEST_CASE("codesign rejects nonexistent path and identity",
-          "[ship][codesign][coverage][issue-644]") {
+          "[ship][codesign][issue-644]") {
     REQUIRE_FALSE(codesign("/nonexistent/binary", "Developer ID Application: Missing"));
 }
 
 TEST_CASE("codesign includes entitlements path on failure path",
-          "[ship][codesign][coverage][issue-644]") {
+          "[ship][codesign][issue-644]") {
     REQUIRE_FALSE(codesign("/nonexistent/binary",
                            "Developer ID Application: Missing",
                            "/nonexistent/entitlements.plist"));
@@ -97,12 +97,12 @@ TEST_CASE("codesign (Windows) rejects empty identity and empty path before signi
 #endif
 
 TEST_CASE("notarization staple on nonexistent path is false",
-          "[ship][codesign][coverage][issue-644]") {
+          "[ship][codesign][issue-644]") {
     REQUIRE_FALSE(notarize_staple("/nonexistent/binary"));
 }
 
 TEST_CASE("ASC notarization submit fails closed for missing inputs",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
     auto request = notarize_submit_asc("/nonexistent/archive.zip",
                                        "/nonexistent/AuthKey_TEST.p8",
                                        "TESTKEY123",
@@ -111,7 +111,7 @@ TEST_CASE("ASC notarization submit fails closed for missing inputs",
 }
 
 TEST_CASE("create_pkg on nonexistent component is false",
-          "[ship][codesign][coverage][issue-644]") {
+          "[ship][codesign][issue-644]") {
     auto output = (fs::temp_directory_path() / "pulp-missing-component.pkg").string();
     REQUIRE_FALSE(create_pkg("/nonexistent/component.vst3",
                              output,
@@ -161,7 +161,7 @@ TEST_CASE("create_dmg produces a file from valid source", "[ship][codesign]") {
 }
 
 TEST_CASE("codesign reports unsigned regular files without identity metadata",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
     ScopedTempDir temp("pulp-codesign-unsigned");
     const auto file = temp.path / "plain-tool";
     std::ofstream(file) << "not a Mach-O";
@@ -185,7 +185,7 @@ TEST_CASE("codesign reports unsigned regular files without identity metadata",
 }
 
 TEST_CASE("codesign failure paths leave requested outputs absent",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
     ScopedTempDir temp("pulp-codesign-failures");
     const auto pkg = temp.path / "missing.pkg";
     const auto signed_pkg = temp.path / "missing-signed.pkg";
@@ -211,7 +211,7 @@ TEST_CASE("codesign failure paths leave requested outputs absent",
 }
 
 TEST_CASE("combined pkg rejects empty and missing component inputs",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
     ScopedTempDir temp("pulp-combined-pkg-failures");
     const auto empty_output = temp.path / "empty.pkg";
     const auto missing_output = temp.path / "missing.pkg";
@@ -306,7 +306,7 @@ TEST_CASE("combined pkg is component-selectable with a choice per format",
 
 #ifdef __APPLE__
 TEST_CASE("codesign parsers tolerate noisy command output",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
     auto info = detail::parse_codesign_details(
         "Executable=/tmp/Pulp.app\n"
         "Authority=Developer ID Application: Pulp Labs (TEAM123456)\n"
@@ -343,7 +343,7 @@ TEST_CASE("codesign parsers tolerate noisy command output",
 #endif
 
 TEST_CASE("default audio entitlements keep hardened runtime permissions narrow",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
     const auto plist = default_audio_entitlements();
 #ifdef __APPLE__
     REQUIRE(plist.find(R"(<?xml version="1.0" encoding="UTF-8"?>)") != std::string::npos);
@@ -362,7 +362,7 @@ TEST_CASE("default audio entitlements keep hardened runtime permissions narrow",
 }
 
 TEST_CASE("codesign detail parser extracts identity and team fields",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto info = pulp::ship::detail::parse_codesign_details(R"(
 Executable=/Applications/Pulp.app/Contents/MacOS/Pulp
@@ -401,7 +401,7 @@ TeamIdentifier=FIRST12345
 }
 
 TEST_CASE("notarytool submit parser accepts UUID ids only",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto accepted = pulp::ship::detail::parse_notarytool_submit_id(R"(
 Submission ID received
@@ -432,7 +432,7 @@ Submission ID received
 }
 
 TEST_CASE("notarytool submit parser keeps UUID boundaries strict",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto tab_boundary = pulp::ship::detail::parse_notarytool_submit_id(
         "id: 12345678-abcd-4abc-9def-123456789abc\tstatus: Accepted");
@@ -456,7 +456,7 @@ TEST_CASE("notarytool submit parser keeps UUID boundaries strict",
 }
 
 TEST_CASE("notarytool status parser classifies terminal states",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto accepted = pulp::ship::detail::parse_notarytool_status("status: Accepted\nmessage: Ready");
     REQUIRE(accepted.complete);
@@ -481,7 +481,7 @@ TEST_CASE("notarytool status parser classifies terminal states",
 }
 
 TEST_CASE("notarytool status parser preserves raw diagnostic output",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     const std::string invalid_log = R"(status: Invalid
 issues:
@@ -503,7 +503,7 @@ issues:
 }
 
 TEST_CASE("security identity parser preserves quoted display names",
-          "[ship][codesign][coverage]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto identities = pulp::ship::detail::parse_signing_identities(R"IDENTITIES(
   1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Developer ID Application: Pulp Audio LLC (ABCDE12345)"
@@ -537,7 +537,7 @@ TEST_CASE("security identity parser preserves quoted display names",
 }
 
 TEST_CASE("security identity parser ignores unquoted validity summaries",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto identities = pulp::ship::detail::parse_signing_identities(R"IDENTITIES(
 Policy: Code Signing
@@ -558,7 +558,7 @@ Policy: Code Signing
 }
 
 TEST_CASE("mac codesign parsers ignore unrelated command noise",
-          "[ship][codesign][coverage][requested]") {
+          "[ship][codesign]") {
 #ifdef __APPLE__
     auto details = pulp::ship::detail::parse_codesign_details(R"DETAILS(
 warning: unable to build chain to self-signed root

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -66,7 +66,7 @@ TEST_CASE("DescriptorValidation: empty name/manufacturer/bundle_id/version are e
 }
 
 TEST_CASE("DescriptorValidation: empty version is an error",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     auto d = well_formed_effect();
     d.version.clear();
 
@@ -85,7 +85,7 @@ TEST_CASE("DescriptorValidation: non-reverse-DNS bundle_id produces a warning on
 }
 
 TEST_CASE("DescriptorValidation: reverse-DNS bundle_id requires at least three segments",
-          "[format][descriptor-validation][coverage]") {
+          "[format][descriptor-validation]") {
     auto d = well_formed_effect();
     d.bundle_id = "com.plugin";
 
@@ -95,7 +95,7 @@ TEST_CASE("DescriptorValidation: reverse-DNS bundle_id requires at least three s
 }
 
 TEST_CASE("DescriptorValidation: malformed reverse-DNS bundle_id segments warn only",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     for (const auto* bundle_id : {
              ".example.plugin",
              "com..plugin",
@@ -113,7 +113,7 @@ TEST_CASE("DescriptorValidation: malformed reverse-DNS bundle_id segments warn o
 }
 
 TEST_CASE("DescriptorValidation: whitespace-only bundle_id segments warn only",
-          "[format][descriptor-validation][coverage]") {
+          "[format][descriptor-validation]") {
     auto d = well_formed_effect();
     d.bundle_id = "com.\t.plugin";
 
@@ -140,7 +140,7 @@ TEST_CASE("DescriptorValidation: zero-channel main output is an error",
 }
 
 TEST_CASE("DescriptorValidation: negative bus channel counts are errors",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     SECTION("negative main output") {
         auto d = well_formed_effect();
         d.output_buses = {{"Invalid Out", -1, false}};
@@ -161,7 +161,7 @@ TEST_CASE("DescriptorValidation: negative bus channel counts are errors",
 }
 
 TEST_CASE("DescriptorValidation: negative main input is an error",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     auto d = well_formed_effect();
     d.input_buses = {{"Invalid In", -2, false}};
 
@@ -181,7 +181,7 @@ TEST_CASE("DescriptorValidation: instrument with non-optional stereo input warns
 }
 
 TEST_CASE("DescriptorValidation: instrument optional or zero-channel inputs do not warn",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     SECTION("optional stereo input") {
         auto d = well_formed_effect();
         d.category = PluginCategory::Instrument;
@@ -232,7 +232,7 @@ TEST_CASE("DescriptorValidation: supports_mpe without accepts_midi warns",
 }
 
 TEST_CASE("DescriptorValidation: MPE and UMP sidecars share one warning on audio effects",
-          "[format][descriptor-validation][coverage]") {
+          "[format][descriptor-validation]") {
     auto d = well_formed_effect();
     d.supports_mpe = true;
     d.supports_ump = true;
@@ -256,7 +256,7 @@ TEST_CASE("DescriptorValidation: node capabilities use sidecar MIDI warning cont
 }
 
 TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar warning contract",
-          "[format][descriptor-validation][coverage][issue-493]") {
+          "[format][descriptor-validation][issue-493]") {
     SECTION("UMP without MIDI input warns") {
         auto d = well_formed_effect();
         d.supports_ump = true;
@@ -279,7 +279,7 @@ TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar w
 }
 
 TEST_CASE("DescriptorValidation: MIDI capability warnings accumulate without invalidating descriptor",
-          "[format][descriptor-validation][coverage][issue-646]") {
+          "[format][descriptor-validation][issue-646]") {
     auto d = well_formed_effect();
     d.category = PluginCategory::MidiEffect;
     d.accepts_midi = false;
@@ -308,7 +308,7 @@ TEST_CASE("DescriptorValidation: MidiEffect without audio output is valid",
 }
 
 TEST_CASE("DescriptorValidation: MidiEffect ignores zero-channel audio output",
-          "[format][descriptor-validation][coverage]") {
+          "[format][descriptor-validation]") {
     auto d = well_formed_effect();
     d.category = PluginCategory::MidiEffect;
     d.accepts_midi = true;
@@ -372,7 +372,7 @@ TEST_CASE("DescriptorValidation: MIDI sidecar capabilities are warning-only with
 }
 
 TEST_CASE("descriptor_is_valid treats warnings as valid and any error as invalid",
-          "[format][descriptor-validation][coverage]") {
+          "[format][descriptor-validation]") {
     REQUIRE(descriptor_is_valid({}));
     REQUIRE(descriptor_is_valid({
         {DescriptorIssueSeverity::Warning, "bundle_id", "warning"},

--- a/test/test_design_debug_contracts.cpp
+++ b/test/test_design_debug_contracts.cpp
@@ -45,7 +45,7 @@ int run_design_debug(std::vector<std::string> args) {
 } // namespace
 
 TEST_CASE("design-debug JSON escaping preserves report syntax",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     REQUIRE(json_escape("plain") == "plain");
     REQUIRE(json_escape("quote\"slash\\") == "quote\\\"slash\\\\");
     REQUIRE(json_escape("line\nfeed") == "line\\nfeed");
@@ -56,7 +56,7 @@ TEST_CASE("design-debug JSON escaping preserves report syntax",
 }
 
 TEST_CASE("design-debug file helpers round-trip text and binary artifacts",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     auto temp = make_temp_dir("files");
     auto text_path = temp / "nested" / "artifact.txt";
     auto binary_path = temp / "artifact.bin";
@@ -83,7 +83,7 @@ TEST_CASE("design-debug file helpers round-trip text and binary artifacts",
 }
 
 TEST_CASE("design-debug slugifies artifact stems deterministically",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     REQUIRE(slugify("Make The Filter Pop!") == "make-the-filter-pop");
     REQUIRE(slugify("  spaced   prompt  ") == "spaced-prompt");
     REQUIRE(slugify("A/B\\C.D") == "a-b-c-d");
@@ -102,7 +102,7 @@ TEST_CASE("design-debug slugifies artifact stems deterministically",
 }
 
 TEST_CASE("design-debug repo discovery finds the design tool from nested directories",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     auto temp = make_temp_dir("repo-root");
     auto repo = temp / "repo";
     auto design_dir = repo / "examples" / "design-tool";
@@ -138,7 +138,7 @@ TEST_CASE("design-debug repo discovery finds the design tool from nested directo
 }
 
 TEST_CASE("design-debug loads ordered design-tool modules from the entry path",
-          "[tools][design-debug][coverage][requested]") {
+          "[tools][design-debug]") {
     auto temp = make_temp_dir("module-load");
     auto js_dir = temp / "examples" / "design-tool";
     REQUIRE(std::filesystem::create_directories(js_dir));
@@ -166,7 +166,7 @@ TEST_CASE("design-debug loads ordered design-tool modules from the entry path",
 }
 
 TEST_CASE("design-debug loads custom scripts without implicit design-tool modules",
-          "[tools][design-debug][coverage][requested]") {
+          "[tools][design-debug]") {
     auto temp = make_temp_dir("custom-script-load");
     auto js_dir = temp / "examples" / "design-tool";
     REQUIRE(std::filesystem::create_directories(js_dir));
@@ -192,7 +192,7 @@ TEST_CASE("design-debug loads custom scripts without implicit design-tool module
 }
 
 TEST_CASE("design-debug capture metadata matches backend behavior",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     REQUIRE(std::string(capture_mode_flag_name(CaptureMode::headless_skia,
                                                ScreenshotBackend::skia)) == "skia");
     REQUIRE(std::string(capture_mode_flag_name(CaptureMode::headless_coregraphics,
@@ -220,7 +220,7 @@ TEST_CASE("design-debug capture metadata matches backend behavior",
 }
 
 TEST_CASE("design-debug default option structs preserve artifact contracts",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     const Options opts;
     REQUIRE(opts.script_path.empty());
     REQUIRE(opts.design_tool_bin.empty());
@@ -256,7 +256,7 @@ TEST_CASE("design-debug default option structs preserve artifact contracts",
 }
 
 TEST_CASE("design-debug timestamp stamp uses sortable local format",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     const auto stamp = now_stamp();
     REQUIRE(stamp.size() == 15);
     REQUIRE(stamp[8] == '-');
@@ -267,7 +267,7 @@ TEST_CASE("design-debug timestamp stamp uses sortable local format",
 }
 
 TEST_CASE("design-debug target bounds parser accepts debug state shape",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     auto parsed = parse_target_bounds(R"JSON({
         "selection": "knob1",
         "targetBounds": { "x": 12.5, "y": -3, "width": 88.25, "height": 44 }
@@ -292,7 +292,7 @@ TEST_CASE("design-debug target bounds parser accepts debug state shape",
 }
 
 TEST_CASE("design-debug target bounds parser rejects incompatible JSON shapes",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     REQUIRE_FALSE(parse_target_bounds(R"JSON({"targetBounds":null})JSON").valid);
     REQUIRE_FALSE(parse_target_bounds(R"JSON({"targetBounds":[]})JSON").valid);
     REQUIRE_FALSE(parse_target_bounds(R"JSON({"targetBounds":{"x":"1","y":2,"width":3,"height":4}})JSON").valid);
@@ -311,7 +311,7 @@ TEST_CASE("design-debug target bounds parser rejects incompatible JSON shapes",
 }
 
 TEST_CASE("design-debug shell quoting keeps AI command templates inert",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     REQUIRE(shell_quote("plain") == "'plain'");
     REQUIRE(shell_quote("") == "''");
     REQUIRE(shell_quote("two words") == "'two words'");
@@ -320,7 +320,7 @@ TEST_CASE("design-debug shell quoting keeps AI command templates inert",
 }
 
 TEST_CASE("design-debug command capture preserves stdout and exit status",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     int exit_code = -1;
 #if defined(_WIN32)
     auto output = run_command_capture("cmd /C \"echo design-debug-output& exit /B 7\"",
@@ -335,7 +335,7 @@ TEST_CASE("design-debug command capture preserves stdout and exit status",
 }
 
 TEST_CASE("design-debug option validation fails before expensive render setup",
-          "[tools][design-debug][coverage]") {
+          "[tools][design-debug]") {
     auto temp = make_temp_dir("options");
     auto script = temp / "script.js";
     auto response = temp / "response.txt";
@@ -389,7 +389,7 @@ TEST_CASE("design-debug option validation fails before expensive render setup",
 }
 
 TEST_CASE("design-debug headless response-file run writes report artifacts",
-          "[tools][design-debug][coverage][requested]") {
+          "[tools][design-debug]") {
 #if !defined(__APPLE__)
     SKIP("design-debug artifact comparison needs the native screenshot backend");
 #endif
@@ -461,7 +461,7 @@ function getDesignDebugStateJson() {
 }
 
 TEST_CASE("design-debug response-file run accepts explicit CoreGraphics capture",
-          "[tools][design-debug][coverage][requested]") {
+          "[tools][design-debug]") {
 #if !defined(__APPLE__)
     SKIP("CoreGraphics capture is macOS-only");
 #endif

--- a/test/test_design_import_benchmark_contracts.cpp
+++ b/test/test_design_import_benchmark_contracts.cpp
@@ -75,7 +75,7 @@ public:
 }  // namespace
 
 TEST_CASE("design-import benchmark escapes JSON strings used in reports",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     REQUIRE(json_escape("plain") == "plain");
     REQUIRE(json_escape("quote\"slash\\") == "quote\\\"slash\\\\");
     REQUIRE(json_escape("line\nfeed") == "line\\nfeed");
@@ -86,7 +86,7 @@ TEST_CASE("design-import benchmark escapes JSON strings used in reports",
 }
 
 TEST_CASE("design-import benchmark parse_int accepts complete integers only",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     int value = 0;
     REQUIRE(parse_int("42", value));
     REQUIRE(value == 42);
@@ -108,7 +108,7 @@ TEST_CASE("design-import benchmark parse_int accepts complete integers only",
 }
 
 TEST_CASE("design-import benchmark argument parser supports split and equals forms",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     auto config = parse_args_vec({"bench", "--lane=baked-cpp", "--idle-ms=25",
                                   "--interactive-ms", "50", "--target-fps=120",
                                   "--output", "out.json"});
@@ -130,7 +130,7 @@ TEST_CASE("design-import benchmark argument parser supports split and equals for
 }
 
 TEST_CASE("design-import benchmark argument parser rejects invalid shapes",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     REQUIRE_FALSE(parse_args_vec({"bench", "--lane=nope"}).has_value());
     REQUIRE_FALSE(parse_args_vec({"bench", "--lane="}).has_value());
     REQUIRE_FALSE(parse_args_vec({"bench", "--lane"}).has_value());
@@ -145,7 +145,7 @@ TEST_CASE("design-import benchmark argument parser rejects invalid shapes",
 }
 
 TEST_CASE("design-import benchmark argument parser preserves explicit empty output",
-          "[design-import][benchmark][coverage][requested]") {
+          "[design-import][benchmark]") {
     auto config = parse_args_vec({"bench", "--output="});
     REQUIRE(config.has_value());
     CHECK(config->lane == "live");
@@ -156,7 +156,7 @@ TEST_CASE("design-import benchmark argument parser preserves explicit empty outp
 }
 
 TEST_CASE("design-import benchmark argument parser clamps timing knobs",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     auto config = parse_args_vec({"bench", "--idle-ms=-10",
                                   "--interactive-ms=-20", "--target-fps=0"});
     REQUIRE(config.has_value());
@@ -167,7 +167,7 @@ TEST_CASE("design-import benchmark argument parser clamps timing knobs",
 }
 
 TEST_CASE("design-import benchmark argument parser uses last explicit option",
-          "[design-import][benchmark][coverage][requested]") {
+          "[design-import][benchmark]") {
     auto config = parse_args_vec({"bench",
                                   "--lane", "live",
                                   "--lane=baked-cpp",
@@ -188,7 +188,7 @@ TEST_CASE("design-import benchmark argument parser uses last explicit option",
 }
 
 TEST_CASE("design-import benchmark argument parser rejects orphaned values",
-          "[design-import][benchmark][coverage][requested]") {
+          "[design-import][benchmark]") {
     REQUIRE_FALSE(parse_args_vec({"bench", "stray"}).has_value());
     REQUIRE_FALSE(parse_args_vec({"bench", "--lane", "live", "extra"}).has_value());
     REQUIRE_FALSE(parse_args_vec({"bench", "--idle-ms", "1", "--", "--target-fps", "60"}).has_value());
@@ -204,7 +204,7 @@ TEST_CASE("design-import benchmark argument parser rejects orphaned values",
 }
 
 TEST_CASE("design-import benchmark fixture and phase helpers fail closed",
-          "[design-import][benchmark][coverage][requested]") {
+          "[design-import][benchmark]") {
     REQUIRE(make_fixture("not-a-lane") == nullptr);
 
     CountingFixture fixture;
@@ -218,7 +218,7 @@ TEST_CASE("design-import benchmark fixture and phase helpers fail closed",
 }
 
 TEST_CASE("design-import benchmark JSON report contains escaped config and metrics",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     Config config;
     config.lane = "lane\"x";
     config.target_fps = 144;
@@ -252,7 +252,7 @@ TEST_CASE("design-import benchmark JSON report contains escaped config and metri
 }
 
 TEST_CASE("design-import benchmark JSON report includes complete phase fields",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     Config config;
     config.lane = "baked-native";
     config.target_fps = 90;
@@ -310,7 +310,7 @@ TEST_CASE("design-import benchmark JSON report includes complete phase fields",
 }
 
 TEST_CASE("design-import benchmark write_file handles stdout sentinel and nested paths",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     REQUIRE(write_file({}, "stdout sentinel"));
 
     auto path = temp_path("nested");
@@ -325,7 +325,7 @@ TEST_CASE("design-import benchmark write_file handles stdout sentinel and nested
 }
 
 TEST_CASE("design-import benchmark metric helpers handle edge inputs",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     REQUIRE(percentile({}, 50.0) == 0.0);
     REQUIRE(percentile({5.0}, 99.0) == 5.0);
     REQUIRE(percentile({30.0, 10.0, 20.0}, 50.0) == 20.0);
@@ -338,7 +338,7 @@ TEST_CASE("design-import benchmark metric helpers handle edge inputs",
 }
 
 TEST_CASE("design-import benchmark baked IR fixture carries expected controls",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     const auto ir = build_baked_ir();
 
     REQUIRE(ir.source == DesignSource::jsx);
@@ -375,7 +375,7 @@ TEST_CASE("design-import benchmark baked IR fixture carries expected controls",
 }
 
 TEST_CASE("design-import benchmark fixture factory and render path are deterministic",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     REQUIRE(make_fixture("missing") == nullptr);
 
     auto fixture = make_fixture("baked-cpp");
@@ -391,7 +391,7 @@ TEST_CASE("design-import benchmark fixture factory and render path are determini
 }
 
 TEST_CASE("design-import benchmark fixture factory creates the baked-native lane",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     auto baked_native = make_fixture("baked-native");
     REQUIRE(baked_native != nullptr);
     REQUIRE(baked_native->root().id() == "bench-root");
@@ -401,7 +401,7 @@ TEST_CASE("design-import benchmark fixture factory creates the baked-native lane
 }
 
 TEST_CASE("design-import benchmark run_phase records idle and interactive contracts",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     CountingFixture fixture;
 
     const auto zero = run_phase(fixture, 0, 60, true);
@@ -425,7 +425,7 @@ TEST_CASE("design-import benchmark run_phase records idle and interactive contra
 }
 
 TEST_CASE("design-import benchmark main writes reports and rejects invalid args",
-          "[design-import][benchmark][coverage]") {
+          "[design-import][benchmark]") {
     auto output = temp_path("main-report");
     std::filesystem::remove(output);
 

--- a/test/test_design_import_codegen.cpp
+++ b/test/test_design_import_codegen.cpp
@@ -1124,7 +1124,7 @@ TEST_CASE("parse_figma_json parses IR format", "[view][import]") {
 }
 
 TEST_CASE("parse_figma_json covers layout style and audio shape metadata edges",
-          "[view][import][coverage]") {
+          "[view][import]") {
     auto json = R"json({
         "type": "frame",
         "name": "Rack",
@@ -1891,7 +1891,7 @@ TEST_CASE("generate_pulp_js respects CodeGenOptions", "[view][import]") {
 }
 
 TEST_CASE("generate_pulp_js bridge_native_js mode covers layout and audio widget edge branches",
-          "[view][import][coverage]") {
+          "[view][import]") {
     DesignIR ir;
     ir.source = DesignSource::pencil;
     ir.root.type = "frame";
@@ -1998,7 +1998,7 @@ TEST_CASE("generate_pulp_js bridge_native_js mode covers layout and audio widget
 }
 
 TEST_CASE("generate_pulp_js web compat emits extended style and layout properties",
-          "[view][import][coverage]") {
+          "[view][import]") {
     DesignIR ir;
     ir.source = DesignSource::v0;
     ir.root.type = "frame";

--- a/test/test_design_import_sources.cpp
+++ b/test/test_design_import_sources.cpp
@@ -269,7 +269,7 @@ TEST_CASE("parse_pencil_json parses node tree", "[view][import]") {
 }
 
 TEST_CASE("parse_pencil_json covers sizing layout padding and widget metadata edges",
-          "[view][import][coverage]") {
+          "[view][import]") {
     auto json = R"json({
         "type": "frame",
         "name": "PencilRack",
@@ -362,7 +362,7 @@ TEST_CASE("parse_pencil_json covers sizing layout padding and widget metadata ed
 }
 
 TEST_CASE("generate_pulp_js bridge_native_js mode covers fill-height and leaf fallback branches",
-          "[view][import][coverage]") {
+          "[view][import]") {
     DesignIR ir;
     ir.source = DesignSource::pencil;
     ir.root.type = "frame";

--- a/test/test_design_import_w3c_tokens.cpp
+++ b/test/test_design_import_w3c_tokens.cpp
@@ -263,7 +263,7 @@ TEST_CASE("parse_w3c_tokens resolves alias then evaluates math", "[view][import]
 }
 
 TEST_CASE("token parsers cover border composites inference and alternate sources",
-          "[view][import][coverage]") {
+          "[view][import]") {
     auto w3c = R"({
         "border": {
             "$type": "border",

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -123,7 +123,7 @@ TEST_CASE("DiagnosticReporter captures parameter values", "[format][diagnostic]"
 }
 
 TEST_CASE("DiagnosticReporter renders unitless parameters without a unit suffix",
-          "[format][diagnostic][coverage]") {
+          "[format][diagnostic]") {
     DiagnosticReporter diag;
     auto desc = make_desc();
     StateStore store;
@@ -193,7 +193,7 @@ TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter
 }
 
 TEST_CASE("DiagnosticReporter JSON escapes string fields",
-          "[format][diagnostic][coverage]") {
+          "[format][diagnostic]") {
     DiagnosticReporter diag;
     PluginDescriptor desc;
     desc.name = R"(Quote "Synth")";
@@ -214,7 +214,7 @@ TEST_CASE("DiagnosticReporter JSON escapes string fields",
 }
 
 TEST_CASE("DiagnosticReporter replacing plugin info clears stale parameter snapshot",
-          "[format][diagnostic][coverage]") {
+          "[format][diagnostic]") {
     DiagnosticReporter diag;
 
     auto first_desc = make_desc();
@@ -263,7 +263,7 @@ TEST_CASE("HostType names and feature heuristics cover fixed-size and no-sidecha
 }
 
 TEST_CASE("HostType names cover every declared host enum",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE(host_type_name(HostType::LogicPro) == "Logic Pro");
     REQUIRE(host_type_name(HostType::GarageBand) == "GarageBand");
     REQUIRE(host_type_name(HostType::AbletonLive) == "Ableton Live");
@@ -282,7 +282,7 @@ TEST_CASE("HostType names cover every declared host enum",
 }
 
 TEST_CASE("HostType feature heuristics default permissive for modern hosts",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     for (auto host : {HostType::LogicPro,
                       HostType::AbletonLive,
                       HostType::Reaper,
@@ -302,7 +302,7 @@ TEST_CASE("HostType feature heuristics default permissive for modern hosts",
 }
 
 TEST_CASE("HostType process-name classifier covers DAW executable aliases",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE(host_type_from_process_name("/Applications/Logic Pro.app/Contents/MacOS/Logic Pro") == HostType::LogicPro);
     REQUIRE(host_type_from_process_name("GARAGEBAND") == HostType::GarageBand);
     REQUIRE(host_type_from_process_name("/Applications/Ableton Live 12 Suite.app/Live") == HostType::AbletonLive);
@@ -328,7 +328,7 @@ TEST_CASE("HostType process-name classifier covers DAW executable aliases",
 }
 
 TEST_CASE("HostType process-name classifier is substring ordered",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE(host_type_from_process_name("logic-live-helper") == HostType::LogicPro);
     REQUIRE(host_type_from_process_name("garageband-live-helper") == HostType::GarageBand);
     REQUIRE(host_type_from_process_name("ableton-reaper-bridge") == HostType::AbletonLive);
@@ -340,7 +340,7 @@ TEST_CASE("HostType process-name classifier is substring ordered",
 }
 
 TEST_CASE("HostType process-name classifier handles empty and path-like unknown names",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE(host_type_from_process_name("") == HostType::Unknown);
     REQUIRE(host_type_from_process_name("/usr/bin/pluginval") == HostType::Unknown);
     REQUIRE(host_type_from_process_name("/tmp/not-a-daw") == HostType::Unknown);
@@ -348,7 +348,7 @@ TEST_CASE("HostType process-name classifier handles empty and path-like unknown 
 }
 
 TEST_CASE("HostType process-name classifier feeds the feature policy",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE_FALSE(host_supports_resize(host_type_from_process_name("Pro Tools")));
     REQUIRE_FALSE(host_supports_resize(host_type_from_process_name("GarageBand")));
     REQUIRE_FALSE(host_supports_sidechain(host_type_from_process_name("Tenacity")));
@@ -356,6 +356,6 @@ TEST_CASE("HostType process-name classifier feeds the feature policy",
 }
 
 TEST_CASE("HostType process detection delegates through the classifier",
-          "[format][host-type][coverage]") {
+          "[format][host-type]") {
     REQUIRE_FALSE(host_type_name(detect_host_type()).empty());
 }

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -427,7 +427,7 @@ TEST_CASE("GraphSerializer rejects graph migrations that do not advance versions
 }
 
 TEST_CASE("GraphSerializer rejects invalid graph migration registrations",
-          "[host][serializer][migration][coverage]") {
+          "[host][serializer][migration]") {
     REQUIRE(GraphSerializer::current_format_version() == 2);
     REQUIRE_FALSE(GraphSerializer::register_migration(
         2, 2,
@@ -452,7 +452,7 @@ TEST_CASE("GraphSerializer rejects invalid graph migration registrations",
 }
 
 TEST_CASE("GraphSerializer rejects non-integer and out-of-range graph versions",
-          "[host][serializer][migration][coverage]") {
+          "[host][serializer][migration]") {
     SignalGraph string_version;
     auto string_result = GraphSerializer::from_json(string_version, R"({
   "format_version": "2",
@@ -475,7 +475,7 @@ TEST_CASE("GraphSerializer rejects non-integer and out-of-range graph versions",
 }
 
 TEST_CASE("GraphSerializer reports broken graph migration outputs",
-          "[host][serializer][migration][coverage]") {
+          "[host][serializer][migration]") {
     REQUIRE(GraphSerializer::register_migration(
         -20, GraphSerializer::current_format_version(),
         [](const std::string&, std::string&) {
@@ -1201,7 +1201,7 @@ TEST_CASE("GraphSerializer resolves custom nodes by exact registry version",
 }
 
 TEST_CASE("GraphSerializer preserves unresolved custom nodes when registered ABI mismatches",
-          "[host][serializer][node-abi][coverage]") {
+          "[host][serializer][node-abi]") {
     SignalGraph src;
     REQUIRE(src.register_custom_node_type(make_custom_node_type(
         "pulp.test.mismatched-node", 7, 2, 1, "Wide Node")));
@@ -1267,7 +1267,7 @@ TEST_CASE("GraphSerializer serializes plugin formats and state blobs",
 }
 
 TEST_CASE("GraphSerializer serializes short plugin state blobs with stable padding",
-          "[host][serializer][coverage]") {
+          "[host][serializer]") {
     SignalGraph src;
     auto one_byte = make_fake_plugin_info("OneByteState", "pulp.test.state.one",
                                           PluginFormat::CLAP, 1, 1);
@@ -1407,7 +1407,7 @@ TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field err
 }
 
 TEST_CASE("GraphSerializer reports plugin nodes missing plugin payload",
-          "[host][serializer][coverage]") {
+          "[host][serializer]") {
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, R"({
   "format_version": 1,
@@ -1474,7 +1474,7 @@ TEST_CASE("GraphSerializer reports plugin nodes missing plugin payload",
 }
 
 TEST_CASE("GraphSerializer defaults missing gain and coerces non-numeric layout to zero",
-          "[host][serializer][coverage]") {
+          "[host][serializer]") {
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, R"({
   "format_version": 2,

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -173,7 +173,7 @@ TEST_CASE("HeadlessHost creates processor", "[headless]") {
 }
 
 TEST_CASE("format registry stores and replaces the processor factory",
-          "[format][registry][coverage]") {
+          "[format][registry]") {
     const auto previous = pulp::format::registered_factory();
     {
         ScopedFactoryRegistration scoped(create_test_gain);
@@ -186,7 +186,7 @@ TEST_CASE("format registry stores and replaces the processor factory",
 }
 
 TEST_CASE("build_editor_ui falls back to AutoUi when no script path is configured",
-          "[format][editor_ui][codecov]") {
+          "[format][editor_ui]") {
     if (pulp::format::configured_ui_script_path().has_value()) {
         SKIP("AutoUi fallback requires a build without PULP_UI_SCRIPT_PATH");
     }
@@ -231,7 +231,7 @@ TEST_CASE("HeadlessHost processes audio at unity gain", "[headless]") {
 }
 
 TEST_CASE("HeadlessHost forwards prepare context and release",
-          "[headless][coverage][issue-647]") {
+          "[headless][issue-647]") {
     pulp::format::HeadlessHost host(create_test_gain);
     REQUIRE(last_processor != nullptr);
     auto* processor = last_processor;
@@ -342,7 +342,7 @@ TEST_CASE("HeadlessHost try_prepare reports channel and voice budget failures",
 }
 
 TEST_CASE("HeadlessHost fills default process context",
-          "[headless][coverage][issue-647]") {
+          "[headless][issue-647]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(44100.0, 512);
 
@@ -364,7 +364,7 @@ TEST_CASE("HeadlessHost fills default process context",
 }
 
 TEST_CASE("HeadlessHost defaults non-positive context fields",
-          "[headless][coverage]") {
+          "[headless]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(88200.0, 512);
 
@@ -639,7 +639,7 @@ TEST_CASE("HeadlessHost offline render matches direct process for stateless effe
 }
 
 TEST_CASE("HeadlessHost forwards explicit MIDI buffers",
-          "[headless][coverage][issue-647]") {
+          "[headless][issue-647]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
     REQUIRE(last_processor != nullptr);
@@ -661,7 +661,7 @@ TEST_CASE("HeadlessHost forwards explicit MIDI buffers",
 }
 
 TEST_CASE("HeadlessHost forwards explicit parameter-event queues",
-          "[headless][params][coverage]") {
+          "[headless][params]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
     REQUIRE(last_processor != nullptr);
@@ -696,7 +696,7 @@ TEST_CASE("HeadlessHost forwards explicit parameter-event queues",
 }
 
 TEST_CASE("HeadlessHost forwards MIDI, parameter events, and explicit context together",
-          "[headless][params][coverage]") {
+          "[headless][params]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);
     REQUIRE(last_processor != nullptr);
@@ -737,7 +737,7 @@ TEST_CASE("HeadlessHost forwards MIDI, parameter events, and explicit context to
 }
 
 TEST_CASE("HeadlessHost null processor process and release are no-ops",
-          "[headless][coverage][issue-647]") {
+          "[headless][issue-647]") {
     pulp::format::HeadlessHost host(create_null_processor);
     host.prepare(48000.0, 64);
 

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -137,7 +137,7 @@ TEST_CASE("cap_clap_plugin_count clamps an untrusted bundle count (issue-2703)",
 // and (b) the filename-fallback path produces a single PluginInfo so
 // users see SOMETHING in the catalog instead of a silent drop.
 TEST_CASE("scan_clap_bundle_descriptors survives malformed bundle (dlopen-fail path)",
-          "[host][scanner][issue-1862][coverage]") {
+          "[host][scanner][issue-1862]") {
     namespace fs = std::filesystem;
     auto tmp = fs::temp_directory_path() / "pulp_clap_dlopen_fail_test.clap";
     std::error_code ec;
@@ -339,7 +339,7 @@ TEST_CASE("PluginSlot load returns nullptr for stub", "[host][slot]") {
 }
 
 TEST_CASE("PluginSlot load fails cleanly for invalid dispatch inputs",
-          "[host][slot][coverage]") {
+          "[host][slot]") {
     PluginInfo clap;
     clap.name = "MissingClap";
     clap.path = "/definitely/missing/Missing.clap";
@@ -672,7 +672,7 @@ float process_first_sample(PluginSlot& slot, float input_sample) {
 } // namespace
 
 TEST_CASE("PluginScanner CLAP descriptor surfaces PulpGain bundle metadata",
-          "[host][scanner][clap][coverage][issue-493]") {
+          "[host][scanner][clap][issue-493]") {
     namespace fs = std::filesystem;
     const fs::path path = PULP_TEST_CLAP_PATH;
     if (!fs::exists(path)) {
@@ -756,7 +756,7 @@ TEST_CASE("PluginSlot loads and processes a real CLAP plugin", "[host][clap][int
 }
 
 TEST_CASE("ClapSlot process delivers automation and MIDI events to CLAP",
-          "[host][slot][clap][coverage][issue-493]") {
+          "[host][slot][clap][issue-493]") {
     auto slot = load_pulpgain_clap_slot();
     if (!slot) return;
 
@@ -803,7 +803,7 @@ TEST_CASE("ClapSlot process delivers automation and MIDI events to CLAP",
 }
 
 TEST_CASE("ClapSlot handles zero-channel processing and unknown params",
-          "[host][slot][clap][coverage][issue-493]") {
+          "[host][slot][clap][issue-493]") {
     auto slot = load_pulpgain_clap_slot();
     if (!slot) return;
 
@@ -828,7 +828,7 @@ TEST_CASE("ClapSlot handles zero-channel processing and unknown params",
 }
 
 TEST_CASE("ClapSlot exposes PulpGain parameter metadata and host defaults",
-          "[host][slot][clap][coverage][issue-493]") {
+          "[host][slot][clap][issue-493]") {
     auto slot = load_pulpgain_clap_slot();
     if (!slot) return;
 
@@ -868,7 +868,7 @@ TEST_CASE("ClapSlot exposes PulpGain parameter metadata and host defaults",
 }
 
 TEST_CASE("ClapSlot bypass and release paths copy input and zero extra outputs",
-          "[host][slot][clap][coverage][issue-493]") {
+          "[host][slot][clap][issue-493]") {
     auto slot = load_pulpgain_clap_slot();
     if (!slot) return;
 
@@ -910,7 +910,7 @@ TEST_CASE("ClapSlot bypass and release paths copy input and zero extra outputs",
 }
 
 TEST_CASE("ClapSlot restore_state supersedes cached host edits",
-          "[host][slot][clap][state][coverage][issue-493]") {
+          "[host][slot][clap][state][issue-493]") {
     auto slot = load_pulpgain_clap_slot();
     if (!slot) return;
 
@@ -1027,7 +1027,7 @@ TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race][iss
 }
 
 TEST_CASE("ParameterEventQueue sorts sample offsets and preserves duplicates",
-          "[host][params][codecov]") {
+          "[host][params]") {
     ParameterEventQueue queue;
     queue.push({3, 64, 0.75f});
     queue.push(ParameterEvent{1, 0, 0.25f});
@@ -1050,7 +1050,7 @@ TEST_CASE("ParameterEventQueue sorts sample offsets and preserves duplicates",
 }
 
 TEST_CASE("ParameterEventQueue iteration and clear expose queued values",
-          "[host][params][codecov]") {
+          "[host][params]") {
     ParameterEventQueue queue;
     queue.push({10, -4, -1.0f});
     queue.push({11, 128, 1.0f});

--- a/test/test_host_regression.cpp
+++ b/test/test_host_regression.cpp
@@ -333,7 +333,7 @@ TEST_CASE("PluginScanner VST3 bundle with well-formed moduleinfo.json yields FUI
 }
 
 TEST_CASE("PluginScanner VST3 moduleinfo raw CID bytes normalize to lowercase hex",
-          "[host][scanner][regression][codecov]") {
+          "[host][scanner][regression]") {
     ScratchDir scratch("vst3-raw-cid");
 
     const std::string body = R"({
@@ -370,7 +370,7 @@ TEST_CASE("PluginScanner VST3 moduleinfo raw CID bytes normalize to lowercase he
 }
 
 TEST_CASE("PluginScanner VST3 moduleinfo skips unusable class records",
-          "[host][scanner][regression][codecov]") {
+          "[host][scanner][regression]") {
     ScratchDir scratch("vst3-unusable-classes");
 
     const std::string body = R"({
@@ -638,7 +638,7 @@ TEST_CASE("ScanOptions progress callback fires at least once per format lane",
 }
 
 TEST_CASE("PluginScanner progress callback reports hermetic extra-path lanes",
-          "[host][scanner][coverage]") {
+          "[host][scanner]") {
     ScratchDir scratch("scan-progress-hermetic");
 
     const std::string ttl_body =
@@ -849,7 +849,7 @@ TEST_CASE("ParameterEventQueue has fixed capacity and drops overflow without all
 }
 
 TEST_CASE("ParameterEventQueue accepts rvalue pushes and exposes const iteration",
-          "[host][automation][coverage]") {
+          "[host][automation]") {
     pulp::host::ParameterEventQueue queue;
     queue.push(pulp::host::ParameterEvent{0x10, 5, 0.5f});
     queue.push(pulp::host::ParameterEvent{0x11, 5, 0.6f});

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -372,7 +372,7 @@ TEST_CASE("SignalGraph custom node registrations invalidate matching snapshots",
 }
 
 TEST_CASE("SignalGraph remove_node prunes edges and invalidates live graph",
-          "[host][graph][coverage]") {
+          "[host][graph]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "Input");
     auto gain = graph.add_gain_node("Gain");
@@ -1341,7 +1341,7 @@ TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing
 }
 
 TEST_CASE("SignalGraph rejects audio connections with invalid ports",
-          "[host][graph][routing][coverage]") {
+          "[host][graph][routing]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto gain = graph.add_gain_node("gain");
@@ -1476,7 +1476,7 @@ private:
 } // namespace
 
 TEST_CASE("SignalGraph prepare failure leaves process output silent",
-          "[host][graph][coverage]") {
+          "[host][graph]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto plugin = graph.add_plugin_node(std::make_unique<PrepareFailPlugin>(),
@@ -1503,7 +1503,7 @@ TEST_CASE("SignalGraph prepare failure leaves process output silent",
 }
 
 TEST_CASE("SignalGraph process silences oversized blocks",
-          "[host][graph][coverage]") {
+          "[host][graph]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1526,7 +1526,7 @@ TEST_CASE("SignalGraph process silences oversized blocks",
 }
 
 TEST_CASE("SignalGraph process ignores non-positive block sizes",
-          "[host][graph][coverage]") {
+          "[host][graph]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     auto output = graph.add_output_node(1, "out");
@@ -1550,7 +1550,7 @@ TEST_CASE("SignalGraph process ignores non-positive block sizes",
 }
 
 TEST_CASE("SignalGraph clears stale audio input channels",
-          "[host][graph][routing][coverage]") {
+          "[host][graph][routing]") {
     SignalGraph graph;
     auto input = graph.add_input_node(2, "in");
     auto gain = graph.add_gain_node("gain");
@@ -1587,7 +1587,7 @@ TEST_CASE("SignalGraph clears stale audio input channels",
 }
 
 TEST_CASE("SignalGraph placeholder plugin nodes preserve identity and clear extra outputs",
-          "[host][graph][routing][coverage]") {
+          "[host][graph][routing]") {
     SignalGraph graph;
     auto input = graph.add_input_node(1, "in");
     PluginInfo missing = make_plugin_info("Missing CLAP", 1, 2);
@@ -2226,7 +2226,7 @@ TEST_CASE("SignalGraph MIDI sidecar drops are caller-visible",
 }
 
 TEST_CASE("SignalGraph MIDI injection and extraction require a live node runtime",
-          "[host][graph][midi][coverage]") {
+          "[host][graph][midi]") {
     SignalGraph graph;
     auto midi_in = graph.add_midi_input_node("keys");
     auto midi_out = graph.add_midi_output_node("thru");
@@ -2794,7 +2794,7 @@ TEST_CASE("SignalGraph connect_automation rejects duplicate Replace edges",
 }
 
 TEST_CASE("SignalGraph connect_automation rejects invalid endpoints and params",
-          "[host][graph][automation][coverage]") {
+          "[host][graph][automation]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1);
     auto out_node = graph.add_output_node(1);
@@ -2815,7 +2815,7 @@ TEST_CASE("SignalGraph connect_automation rejects invalid endpoints and params",
 }
 
 TEST_CASE("SignalGraph automation rejects non-writable params and cycle edges",
-          "[host][graph][automation][coverage]") {
+          "[host][graph][automation]") {
     SignalGraph graph;
     auto source = graph.add_input_node(1, "source");
     auto passthrough = graph.add_gain_node("passthrough");
@@ -2846,7 +2846,7 @@ TEST_CASE("SignalGraph automation rejects non-writable params and cycle edges",
 }
 
 TEST_CASE("SignalGraph automation clamps add-mode and stored smoothing",
-          "[host][graph][automation][coverage]") {
+          "[host][graph][automation]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1, "in");
     auto slot = std::make_unique<MockAutomatable>();
@@ -2945,7 +2945,7 @@ TEST_CASE("SignalGraph connect_audio_rate_modulation gates on audio-rate params"
 }
 
 TEST_CASE("SignalGraph audio-rate modulation rejects non-writable params and cycle edges",
-          "[host][graph][automation][audio-rate][coverage]") {
+          "[host][graph][automation][audio-rate]") {
     SignalGraph graph;
     auto source = graph.add_input_node(1, "source");
     auto passthrough = graph.add_gain_node("passthrough");
@@ -3115,7 +3115,7 @@ TEST_CASE("SignalGraph audio-rate add modulation clamps independent of edge orde
 }
 
 TEST_CASE("SignalGraph audio-rate replace and add modulation clamp to parameter bounds",
-          "[host][graph][automation][audio-rate][coverage]") {
+          "[host][graph][automation][audio-rate]") {
     SignalGraph graph;
     auto in_node = graph.add_input_node(1, "in");
     auto slot = std::make_unique<MockAutomatable>(

--- a/test/test_hosted_editor.cpp
+++ b/test/test_hosted_editor.cpp
@@ -122,7 +122,7 @@ TEST_CASE("legacy slot is wrapped through the compat path",
 }
 
 TEST_CASE("legacy compat path handles null editor handles and null destroys",
-          "[host][hosted-editor][coverage]") {
+          "[host][hosted-editor]") {
     BrokenLegacySlot broken;
     auto ed = broken.create_hosted_editor(nullptr);
     REQUIRE(ed == nullptr);

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -194,7 +194,7 @@ TEST_CASE("ViewInspector type_name", "[view][inspector]") {
 }
 
 TEST_CASE("InspectorWindow public controls clamp and toggle deterministic state",
-          "[view][inspector][window][coverage][requested]") {
+          "[view][inspector][window]") {
     View root;
     root.set_id("root");
     root.set_bounds({0, 0, 640, 480});
@@ -219,7 +219,7 @@ TEST_CASE("InspectorWindow public controls clamp and toggle deterministic state"
 }
 
 TEST_CASE("CollapsableSection toggles only from header mouse-down events",
-          "[view][inspector][window][coverage][requested]") {
+          "[view][inspector][window]") {
     CollapsableSection section("Layout", true);
     section.set_bounds({0, 0, 200, 120});
 
@@ -374,7 +374,7 @@ TEST_CASE("Protocol: decode invalid JSON") {
 }
 
 TEST_CASE("Protocol: response encoding preserves parseable result JSON",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     auto object_response = encode_message(make_response(7, R"({"root":{"id":"gain"},"count":2})"));
     REQUIRE(object_response.find(R"("id")") != std::string::npos);
     REQUIRE(object_response.find(R"("result")") != std::string::npos);
@@ -391,7 +391,7 @@ TEST_CASE("Protocol: response encoding preserves parseable result JSON",
 }
 
 TEST_CASE("Protocol: invalid JSON payloads encode as strings",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     auto response = encode_message(make_response(10, "{not-json"));
     REQUIRE(response.find(R"("result")") != std::string::npos);
     REQUIRE(response.find("{not-json") != std::string::npos);
@@ -408,7 +408,7 @@ TEST_CASE("Protocol: invalid JSON payloads encode as strings",
 }
 
 TEST_CASE("Protocol: empty response and default params omit payload keys",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     auto empty_response = encode_message(make_response(12, ""));
     REQUIRE(empty_response.find(R"("id")") != std::string::npos);
     REQUIRE(empty_response.find(R"("result")") == std::string::npos);
@@ -426,7 +426,7 @@ TEST_CASE("Protocol: empty response and default params omit payload keys",
 }
 
 TEST_CASE("Protocol: error encoding and decoding round-trips message payloads",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     auto encoded = encode_message(make_error(15, "View not found: gain"));
     REQUIRE(encoded.find(R"("id")") != std::string::npos);
     REQUIRE(encoded.find(R"("error")") != std::string::npos);
@@ -445,7 +445,7 @@ TEST_CASE("Protocol: error encoding and decoding round-trips message payloads",
 }
 
 TEST_CASE("Protocol: decode preserves params, result arrays, and notifications",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     InspectorMessage request;
     REQUIRE(decode_message(R"({"id":17,"method":"DOM.search","params":{"query":"Knob"}})", request));
     REQUIRE(request.id == 17);
@@ -467,7 +467,7 @@ TEST_CASE("Protocol: decode preserves params, result arrays, and notifications",
 }
 
 TEST_CASE("Protocol: decode rejects invalid field types without partial output",
-          "[inspect][protocol][coverage]") {
+          "[inspect][protocol]") {
     InspectorMessage msg;
     msg.id = 99;
     msg.method = "stale";
@@ -1934,7 +1934,7 @@ TEST_CASE("CollapsableSection toggles content from header clicks", "[inspect][wi
 }
 
 TEST_CASE("CollapsableSection collapsed default paints and toggles predictably",
-          "[inspect][window][coverage][headers]") {
+          "[inspect][window][headers]") {
     CollapsableSection section("Theme Colors", false);
     section.set_bounds({0, 0, 220, 120});
     section.layout_children();
@@ -2052,7 +2052,7 @@ TEST_CASE("InspectorWindow builds tabs and updates element properties", "[inspec
 }
 
 TEST_CASE("InspectorWindow default refresh and selection mirror contracts",
-          "[inspect][window][coverage][headers]") {
+          "[inspect][window][headers]") {
     InspectorWindow window;
     REQUIRE(window.child_count() == 2);
     REQUIRE(window.active_tool() == 0);
@@ -2091,7 +2091,7 @@ TEST_CASE("InspectorWindow default refresh and selection mirror contracts",
 }
 
 TEST_CASE("Inspector overlay and window public header toggles are direct contracts",
-          "[inspect][overlay][window][coverage][requested]") {
+          "[inspect][overlay][window]") {
     View root;
     root.set_bounds({0, 0, 320, 200});
 
@@ -2130,7 +2130,7 @@ TEST_CASE("Inspector overlay and window public header toggles are direct contrac
 }
 
 TEST_CASE("InspectorOverlay auxiliary panel toggles are stable public contracts",
-          "[inspect][overlay][coverage][requested]") {
+          "[inspect][overlay]") {
     View root;
     root.set_bounds({0, 0, 320, 200});
 
@@ -2184,7 +2184,7 @@ TEST_CASE("InspectorOverlay auxiliary panel toggles are stable public contracts"
 }
 
 TEST_CASE("InspectorWindow rebuilds tree and theme sections only from live roots",
-          "[inspect][window][coverage][headers]") {
+          "[inspect][window][headers]") {
     View first_root;
     first_root.set_id("first-root");
     first_root.set_bounds({0, 0, 480, 320});

--- a/test/test_inspector_server.cpp
+++ b/test/test_inspector_server.cpp
@@ -207,7 +207,7 @@ TEST_CASE("InspectorServer starts on an explicit port and writes discovery file"
 }
 
 TEST_CASE("InspectorServer pre-start operations are inert",
-          "[inspect][server][coverage][requested]") {
+          "[inspect][server]") {
     InspectorServer server;
 
     REQUIRE(server.port() == 0);
@@ -252,7 +252,7 @@ TEST_CASE("InspectorServer honors PULP_INSPECTOR_PORT when starting with zero",
 }
 
 TEST_CASE("InspectorServer ignores malformed PULP_INSPECTOR_PORT values",
-          "[inspect][server][coverage][requested]") {
+          "[inspect][server]") {
     const auto tmp = std::filesystem::temp_directory_path() /
                      ("pulp-inspector-invalid-env-test-" +
                       std::to_string(socket_port_seed()));
@@ -360,7 +360,7 @@ TEST_CASE("InspectorServer dispatches requests through the configured handler",
 }
 
 TEST_CASE("InspectorServer uses the latest installed request handler",
-          "[inspect][server][coverage][requested]") {
+          "[inspect][server]") {
     InspectorServer server;
     auto port = start_inspector_server(server);
     REQUIRE(port.has_value());
@@ -526,7 +526,7 @@ TEST_CASE("InspectorServer returns protocol errors for invalid JSON frames",
 }
 
 TEST_CASE("InspectorServer drops valid requests when no handler is installed",
-          "[inspect][server][coverage][requested]") {
+          "[inspect][server]") {
     InspectorServer server;
     auto port = start_inspector_server(server);
     REQUIRE(port.has_value());

--- a/test/test_isolated_scanner.cpp
+++ b/test/test_isolated_scanner.cpp
@@ -100,7 +100,7 @@ TEST_CASE("IsolatedPluginScanner returns FormatError for an unknown extension",
 }
 
 TEST_CASE("pulp-scan-worker command line reports usage and unsupported bundles",
-          "[tools][scan-worker][coverage]") {
+          "[tools][scan-worker]") {
     auto usage = pulp::platform::exec(PULP_ISOLATED_SCANNER_REAL_WORKER, {}, 5000);
     REQUIRE(usage.exit_code == 2);
     REQUIRE_THAT(usage.stderr_output, ContainsSubstring("usage: pulp-scan-worker"));
@@ -127,7 +127,7 @@ TEST_CASE("pulp-scan-worker command line reports usage and unsupported bundles",
 // and `IsolatedPluginScanner::scan` (which consumes only the first JSON line)
 // would return or blacklist a sibling.
 TEST_CASE("pulp-scan-worker preserves requested-alias identity for symlinks",
-          "[tools][scan-worker][coverage][issue-3110]") {
+          "[tools][scan-worker][issue-3110]") {
     ScratchDir scratch("symlink-alias");
     auto real_bundle = scratch.path / "Real.vst3";
     fs::create_directories(real_bundle / "Contents" / "Resources");

--- a/test/test_linux_packaging.cpp
+++ b/test/test_linux_packaging.cpp
@@ -64,7 +64,7 @@ std::string quote(const fs::path& path) {
 } // namespace
 
 TEST_CASE("Linux packaging exposes no-op signing surface honestly",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     auto signing = pulp::ship::check_codesign("/tmp/missing");
     REQUIRE_FALSE(signing.is_signed);
     REQUIRE_FALSE(signing.is_valid);
@@ -107,7 +107,7 @@ TEST_CASE("Linux packaging exposes no-op signing surface honestly",
 }
 
 TEST_CASE("Linux packaging rejects macOS installer entry points",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     REQUIRE_FALSE(pulp::ship::create_pkg("component", "out.pkg", "com.pulp.test", "1.0.0", ""));
     REQUIRE_FALSE(pulp::ship::create_dmg("source", "out.dmg", "Volume"));
 
@@ -121,7 +121,7 @@ TEST_CASE("Linux packaging rejects macOS installer entry points",
 }
 
 TEST_CASE("Linux packaging creates tarballs with only present plugin formats",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     TempDir temp("tarball");
     auto build = temp.path / "build";
     write_file(build / "VST3" / "Echo.vst3" / "Contents" / "module.txt", "vst3");
@@ -142,7 +142,7 @@ TEST_CASE("Linux packaging creates tarballs with only present plugin formats",
 }
 
 TEST_CASE("Linux packaging tarball path fails closed without plugin formats",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     TempDir temp("empty-tarball");
     auto build = temp.path / "build";
     fs::create_directories(build);
@@ -154,7 +154,7 @@ TEST_CASE("Linux packaging tarball path fails closed without plugin formats",
 }
 
 TEST_CASE("Linux packaging tarballs support LV2-only bundles",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     TempDir temp("lv2-tarball");
     auto build = temp.path / "build";
     write_file(build / "LV2" / "Pad.lv2" / "manifest.ttl", "manifest");
@@ -184,7 +184,7 @@ TEST_CASE("Linux packaging tarballs support LV2-only bundles",
 }
 
 TEST_CASE("Linux packaging tarballs preserve nested plugin payloads only",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     TempDir temp("nested-plugin-payloads");
     auto build = temp.path / "build";
     write_file(build / "VST3" / "Nested.vst3" / "Contents" / "Resources" / "preset.json", "preset");
@@ -209,7 +209,7 @@ TEST_CASE("Linux packaging tarballs preserve nested plugin payloads only",
 }
 
 TEST_CASE("Linux packaging tarballs preserve format directory boundaries",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     TempDir temp("format-boundaries");
     auto build = temp.path / "build";
     write_file(build / "VST3" / "Format.vst3" / "Contents" / "module.txt", "vst3");
@@ -234,7 +234,7 @@ TEST_CASE("Linux packaging tarballs preserve format directory boundaries",
 }
 
 TEST_CASE("Linux packaging tarballs preserve empty declared format directories",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     TempDir temp("empty-format-directories");
     auto build = temp.path / "build";
     fs::create_directories(build / "VST3");
@@ -255,7 +255,7 @@ TEST_CASE("Linux packaging tarballs preserve empty declared format directories",
 }
 
 TEST_CASE("Linux packaging tarball command quotes paths with spaces",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     TempDir temp("space-tarball");
     auto build = temp.path / "build with spaces";
     write_file(build / "VST3" / "Space Echo.vst3" / "Contents" / "module.txt", "vst3");
@@ -286,7 +286,7 @@ TEST_CASE("Linux packaging tarball command quotes paths with spaces",
 }
 
 TEST_CASE("Linux packaging tarball failures do not leave partial archives",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     TempDir temp("tarball-failures");
 
     auto missing_build_output = temp.path / "missing-build.tar.gz";
@@ -306,7 +306,7 @@ TEST_CASE("Linux packaging tarball failures do not leave partial archives",
 }
 
 TEST_CASE("Linux packaging builds deb archives and removes staging",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -341,7 +341,7 @@ TEST_CASE("Linux packaging builds deb archives and removes staging",
 }
 
 TEST_CASE("Linux packaging deb archives can carry metadata without plugin dirs",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -373,7 +373,7 @@ TEST_CASE("Linux packaging deb archives can carry metadata without plugin dirs",
 }
 
 TEST_CASE("Linux packaging deb failures remove staging and preserve inputs",
-          "[ship][linux-package][coverage]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -391,7 +391,7 @@ TEST_CASE("Linux packaging deb failures remove staging and preserve inputs",
 }
 
 TEST_CASE("Linux packaging deb generation removes stale staging before writing",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -413,7 +413,7 @@ TEST_CASE("Linux packaging deb generation removes stale staging before writing",
 }
 
 TEST_CASE("Linux packaging deb preserves recursive plugin directories only",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -443,7 +443,7 @@ TEST_CASE("Linux packaging deb preserves recursive plugin directories only",
 }
 
 TEST_CASE("Linux packaging deb control keeps package metadata literal",
-          "[ship][linux-package][coverage][requested]") {
+          "[ship][linux-package]") {
     if (!command_available("dpkg-deb"))
         SKIP("dpkg-deb is required to inspect generated deb archives");
 
@@ -474,7 +474,7 @@ TEST_CASE("Linux packaging deb control keeps package metadata literal",
 }
 
 TEST_CASE("Linux packaging reports the host Debian architecture",
-          "[ship][linux-package][coverage][issue-3327]") {
+          "[ship][linux-package][issue-3327]") {
     // The .deb `Architecture:` field must reflect the build host, not the
     // historical hardcoded "amd64" — otherwise an arm64 build produces an
     // .deb that won't install on arm64.

--- a/test/test_lock_to_source.cpp
+++ b/test/test_lock_to_source.cpp
@@ -676,7 +676,7 @@ TEST_CASE("lock_tweak_into_source fails gracefully on unknown anchor", "[lock-to
 }
 
 TEST_CASE("lock_tweak_into_source rejects an empty anchor id",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string gen = make_generated_source();
 
     LockResult r = lock_tweak_into_source(gen, {"", "paint.backgroundColor", "#000000"});
@@ -714,7 +714,7 @@ TEST_CASE("lock_tweak_into_source escapes single quotes in the value", "[lock-to
 }
 
 TEST_CASE("lock_tweak_into_source escapes backslashes in inserted values",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string gen = make_generated_source();
     const std::string anchor = first_child_anchor();
 
@@ -743,7 +743,7 @@ TEST_CASE("lock_tweak_into_source escapes JS control characters in values",
 }
 
 TEST_CASE("lock_tweak_into_source preserves missing trailing newline",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string src =
         "// @pulp-anchor solo\n"
         "const solo = document.createElement('div');\n"
@@ -759,7 +759,7 @@ TEST_CASE("lock_tweak_into_source preserves missing trailing newline",
 }
 
 TEST_CASE("lock_tweak_into_source stops a block at the next anchor",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string src =
         "// @pulp-anchor first\n"
         "const first = document.createElement('div');\n"
@@ -782,7 +782,7 @@ TEST_CASE("lock_tweak_into_source stops a block at the next anchor",
 }
 
 TEST_CASE("lock_tweak_into_source falls back to el when declaration is missing",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string src =
         "// @pulp-anchor orphan\n"
         "setAnchor(orphan._id, 'orphan');\n";
@@ -795,7 +795,7 @@ TEST_CASE("lock_tweak_into_source falls back to el when declaration is missing",
 }
 
 TEST_CASE("lock_tweak_into_source appends when no tail call is present",
-          "[lock-to-source][coverage]") {
+          "[lock-to-source]") {
     const std::string src =
         "// @pulp-anchor solo\n"
         "const solo = document.createElement('div');\n"

--- a/test/test_lv2_host_discovery.cpp
+++ b/test/test_lv2_host_discovery.cpp
@@ -244,7 +244,7 @@ TEST_CASE("LV2 host discovery resolves shared objects from bundle roots",
 }
 
 TEST_CASE("LV2 host discovery tolerates sparse bundles and dylib modules",
-          "[host][lv2][coverage]") {
+          "[host][lv2]") {
     ScratchDir scratch("sparse");
     const auto missing = scratch.path / "Missing.lv2";
 
@@ -330,7 +330,7 @@ TEST_CASE("LV2 PluginSlot load fails cleanly for invalid bundles",
 #if defined(PULP_TEST_LV2_SLOT_PROBE_BUNDLE) && defined(PULP_TEST_LV2_SLOT_PROBE_BINARY)
 
 TEST_CASE("LV2 PluginSlot loads probe descriptor by URI and exposes TTL params",
-          "[host][lv2][slot][coverage][issue-493]") {
+          "[host][lv2][slot][issue-493]") {
     Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
     auto slot = try_load_lv2_slot_probe(probe);
     if (!slot) return;
@@ -362,7 +362,7 @@ TEST_CASE("LV2 PluginSlot loads probe descriptor by URI and exposes TTL params",
 }
 
 TEST_CASE("LV2 PluginSlot processes audio and applies control-port events",
-          "[host][lv2][slot][coverage][issue-493]") {
+          "[host][lv2][slot][issue-493]") {
     Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
     auto slot = try_load_lv2_slot_probe(probe);
     if (!slot) return;
@@ -419,7 +419,7 @@ TEST_CASE("LV2 PluginSlot processes audio and applies control-port events",
 }
 
 TEST_CASE("LV2 PluginSlot bypass and released processing avoid LV2 run",
-          "[host][lv2][slot][coverage][issue-493]") {
+          "[host][lv2][slot][issue-493]") {
     Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
     auto slot = try_load_lv2_slot_probe(probe);
     if (!slot) return;

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -347,7 +347,7 @@ TEST_CASE("MCP JSON helpers escape and parse primitive fields", "[mcp][json]") {
 }
 
 TEST_CASE("MCP JSON helpers preserve raw tokens and reject partial scalars",
-          "[mcp][json][coverage]") {
+          "[mcp][json]") {
     const std::string payload =
         "{"
         "\"message\":\"hello \\\"pulp\\\"\","
@@ -388,7 +388,7 @@ TEST_CASE("MCP JSON helpers preserve raw tokens and reject partial scalars",
 }
 
 TEST_CASE("MCP JSON helpers keep adjacent keys and string escapes isolated",
-          "[mcp][json][coverage][requested]") {
+          "[mcp][json]") {
     const std::string payload =
         R"({"tool":"pulp_build","tool_extra":"wrong","text":"a \"quoted\" value","n":17})";
 
@@ -403,7 +403,7 @@ TEST_CASE("MCP JSON helpers keep adjacent keys and string escapes isolated",
 }
 
 TEST_CASE("MCP JSON helpers keep numeric-looking keys distinct",
-          "[mcp][json][coverage][requested]") {
+          "[mcp][json]") {
     const std::string payload =
         R"({"id":5,"id2":99,"id_text":"5","method":"tools/call","methodExtra":"wrong"})";
 
@@ -416,7 +416,7 @@ TEST_CASE("MCP JSON helpers keep numeric-looking keys distinct",
 }
 
 TEST_CASE("MCP JSON-RPC envelopes escape structured payloads",
-          "[mcp][json][coverage]") {
+          "[mcp][json]") {
     const auto error = json_error("null", -32602, "bad \"arg\"\nline");
     require_contains(error, R"JSON("jsonrpc":"2.0")JSON");
     require_contains(error, R"JSON("id":null)JSON");
@@ -438,7 +438,7 @@ TEST_CASE("MCP JSON-RPC envelopes escape structured payloads",
 }
 
 TEST_CASE("MCP shell_quote keeps shell arguments atomic",
-          "[mcp][shell][coverage]") {
+          "[mcp][shell]") {
 #if defined(_WIN32)
     REQUIRE(shell_quote(R"(C:\Program Files\Pulp\pulp.exe)") ==
             R"("C:\Program Files\Pulp\pulp.exe")");
@@ -451,7 +451,7 @@ TEST_CASE("MCP shell_quote keeps shell arguments atomic",
 }
 
 TEST_CASE("MCP CLI resolver finds Windows multi-config delegates",
-          "[mcp][shell][coverage]") {
+          "[mcp][shell]") {
     TempDir project;
     const auto cli = project.path / "build" / "tools" / "cli" / "Release" / "pulp-cpp.exe";
     std::filesystem::create_directories(cli.parent_path());
@@ -461,7 +461,7 @@ TEST_CASE("MCP CLI resolver finds Windows multi-config delegates",
 }
 
 TEST_CASE("MCP shell exec returns stdout and failure diagnostics",
-          "[mcp][shell][coverage][requested]") {
+          "[mcp][shell]") {
 #if defined(_WIN32)
     auto ok = exec("cmd /c echo|set /p=pulp-mcp");
 #else
@@ -478,7 +478,7 @@ TEST_CASE("MCP shell exec returns stdout and failure diagnostics",
 }
 
 TEST_CASE("MCP find_project_root walks upward and reports absence",
-          "[mcp][shell][coverage][requested]") {
+          "[mcp][shell]") {
     TempDir temp;
     auto project = temp.path / "project";
     auto nested = project / "plugins" / "demo";
@@ -530,7 +530,7 @@ TEST_CASE("MCP protocol handles initialize ping notification and unknown methods
 }
 
 TEST_CASE("pulp-mcp flag-only invocations do not enter the JSON-RPC loop",
-          "[mcp][main][coverage]") {
+          "[mcp][main]") {
     std::ostringstream out;
     std::ostringstream err;
     ScopedStreamRedirect capture_out(std::cout, out.rdbuf());
@@ -600,7 +600,7 @@ TEST_CASE("MCP wire output never contains embedded newlines",
 }
 
 TEST_CASE("MCP JSON scalar extraction rejects partial typed values",
-          "[mcp][json][coverage][requested]") {
+          "[mcp][json]") {
     const std::string payload =
         R"JSON({"whole":12,"partial":"12x","truth":true,"lie":false,"nil":null,"float":3.25,"badFloat":"3.25x","quoted":"hello \"pulp\""})JSON";
 
@@ -790,7 +790,7 @@ TEST_CASE("MCP project-root dependent tools reject non-project directories", "[m
 }
 
 TEST_CASE("MCP audio probe JSON validates frames before shelling out",
-          "[mcp][tools][audio][coverage]") {
+          "[mcp][tools][audio]") {
     ScopedCurrentPath cwd(repo_root_path());
 
     auto zero_frames = handle_request(tool_call(
@@ -814,7 +814,7 @@ TEST_CASE("MCP audio probe JSON validates frames before shelling out",
 }
 
 TEST_CASE("MCP audio probe JSON reports missing project roots",
-          "[mcp][tools][audio][coverage]") {
+          "[mcp][tools][audio]") {
     TempDir temp;
     ScopedCurrentPath cwd(temp.path);
 
@@ -865,7 +865,7 @@ TEST_CASE("MCP audio scope validates parameters before shelling out",
 }
 
 TEST_CASE("MCP build and test handlers quote project paths and filters",
-          "[mcp][tools][shell][coverage]") {
+          "[mcp][tools][shell]") {
 #if defined(_WIN32)
     SKIP("PATH-injected POSIX fake tools are only used on non-Windows");
 #else
@@ -900,7 +900,7 @@ TEST_CASE("MCP build and test handlers quote project paths and filters",
 }
 
 TEST_CASE("MCP docs_search and create quote user arguments",
-          "[mcp][tools][shell][coverage]") {
+          "[mcp][tools][shell]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1105,7 +1105,7 @@ TEST_CASE("MCP docs_search and create quote user arguments",
 }
 
 TEST_CASE("MCP docs_check runs the project docs check script",
-          "[mcp][tools][docs][coverage]") {
+          "[mcp][tools][docs]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1257,7 +1257,7 @@ TEST_CASE("MCP status reports import-design defaults", "[mcp][tools]") {
 }
 
 TEST_CASE("MCP status quotes project roots before reading Git branch",
-          "[mcp][tools][shell][coverage][requested]") {
+          "[mcp][tools][shell]") {
 #if defined(_WIN32)
     SKIP("POSIX shell quoting assertion is only used on non-Windows");
 #else
@@ -1288,7 +1288,7 @@ TEST_CASE("MCP status quotes project roots before reading Git branch",
 // inherited GIT_DIR and mutated the WRONG repo — corrupting live worktrees
 // during pre-push / shipyard ctest runs.
 TEST_CASE("temp-repo git stays isolated despite an inherited GIT_DIR",
-          "[mcp][git-isolation][regression][coverage]") {
+          "[mcp][git-isolation][regression]") {
 #if defined(_WIN32)
     SKIP("POSIX git-environment isolation assertion is only used on non-Windows");
 #else
@@ -1330,7 +1330,7 @@ TEST_CASE("temp-repo git stays isolated despite an inherited GIT_DIR",
 }
 
 TEST_CASE("MCP status resolves import-design defaults from config and env",
-          "[mcp][tools][import-design][codecov]") {
+          "[mcp][tools][import-design]") {
     ScopedCurrentPath cwd(repo_root_path());
 
     SECTION("built-ins stay live and js when no config or env is present") {
@@ -1687,7 +1687,7 @@ TEST_CASE("MCP wrapper tools route to the correct handler arm (project-root gate
 }
 
 TEST_CASE("MCP inspect screenshot and evaluate wrappers preserve unavailable text",
-          "[mcp][tools][inspect][coverage]") {
+          "[mcp][tools][inspect]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1717,7 +1717,7 @@ TEST_CASE("MCP inspect screenshot and evaluate wrappers preserve unavailable tex
 }
 
 TEST_CASE("MCP validate only passes --all for the explicit all flag",
-          "[mcp][tools][validate][coverage]") {
+          "[mcp][tools][validate]") {
 #if defined(_WIN32)
     SKIP("fake extensionless pulp CLI is only executable through popen on POSIX");
 #else
@@ -1753,7 +1753,7 @@ TEST_CASE("MCP validate only passes --all for the explicit all flag",
 }
 
 TEST_CASE("MCP audio probe JSON wraps pulp run and returns structured content",
-          "[mcp][tools][audio][coverage]") {
+          "[mcp][tools][audio]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1875,7 +1875,7 @@ TEST_CASE("MCP audio scope wraps pulp audio scope and returns structured content
 }
 
 TEST_CASE("MCP audio probe JSON rejects malformed child output",
-          "[mcp][tools][audio][coverage]") {
+          "[mcp][tools][audio]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1913,7 +1913,7 @@ TEST_CASE("MCP audio probe JSON rejects malformed child output",
 }
 
 TEST_CASE("MCP audio probe JSON reports child runs that write no JSON",
-          "[mcp][tools][audio][coverage]") {
+          "[mcp][tools][audio]") {
 #if defined(_WIN32)
     SKIP("POSIX fake script assertions are only used on non-Windows");
 #else
@@ -1967,7 +1967,7 @@ TEST_CASE("MCP pulp_audio_model_list returns the structured tool-payload envelop
 }
 
 TEST_CASE("MCP audio tools return structured diagnostics without a project root",
-          "[mcp][tools][audio][coverage][requested]") {
+          "[mcp][tools][audio]") {
     TempDir home;
     ScopedEnvVar pulp_home("PULP_HOME", home.path.string());
     TempDir cwd_dir;
@@ -1999,7 +1999,7 @@ TEST_CASE("MCP audio tools return structured diagnostics without a project root"
 }
 
 TEST_CASE("MCP audio excerpt-find validates request fields through the handler",
-          "[mcp][tools][audio][coverage][requested]") {
+          "[mcp][tools][audio]") {
     TempDir home;
     ScopedEnvVar pulp_home("PULP_HOME", home.path.string());
     TempDir temp;
@@ -2050,7 +2050,7 @@ TEST_CASE("MCP audio excerpt-find validates request fields through the handler",
 }
 
 TEST_CASE("MCP audio read-bundle reports missing bundles as structured content",
-          "[mcp][tools][audio][coverage][requested]") {
+          "[mcp][tools][audio]") {
     TempDir home;
     ScopedEnvVar pulp_home("PULP_HOME", home.path.string());
     TempDir temp;
@@ -2211,7 +2211,7 @@ TEST_CASE("parse_cmake_project_version extracts VERSION from project()",
 }
 
 TEST_CASE("parse_cmake_project_version handles plugin VERSION fallback",
-          "[mcp][compat][coverage]") {
+          "[mcp][compat]") {
     REQUIRE(pulp_mcp::parse_cmake_project_version(
                 "cmake_minimum_required(VERSION 3.25)\n"
                 "pulp_add_plugin(MyPlugin VERSION \"1.2.3\")\n") == "1.2.3");
@@ -2238,7 +2238,7 @@ TEST_CASE("parse_cmake_project_version handles plugin VERSION fallback",
 }
 
 TEST_CASE("compare_semver tolerates metadata and leading zeroes",
-          "[mcp][compat][coverage]") {
+          "[mcp][compat]") {
     REQUIRE(compare_semver("1.2.3-alpha", "1.2.3") == 0);
     REQUIRE(compare_semver("1.2.4+build", "1.2.3") > 0);
     REQUIRE(compare_semver("01.002.0003", "1.2.3") == 0);
@@ -2471,7 +2471,7 @@ TEST_CASE("parse_pulp_toml_sdk_version extracts the top-level scalar",
 }
 
 TEST_CASE("parse_pulp_toml_sdk_version rejects ambiguous sdk pins",
-          "[mcp][compat][coverage]") {
+          "[mcp][compat]") {
     REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version(
                 "[pulp.extra]\nsdk_version = \"9.9.9\"\n").empty());
     REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version(

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -219,7 +219,7 @@ TEST_CASE("NSIS script maps standalone and unknown formats to INSTDIR", "[ship][
 }
 
 TEST_CASE("NSIS script handles empty plugin list with only post and uninstall sections",
-          "[ship][installer][coverage][issue-644]") {
+          "[ship][installer][issue-644]") {
     auto config = make_test_config();
     config.plugins.clear();
     auto script = generate_nsis_script(config);
@@ -232,7 +232,7 @@ TEST_CASE("NSIS script handles empty plugin list with only post and uninstall se
 }
 
 TEST_CASE("NSIS script honors configured output path and install root",
-          "[ship][installer][coverage][issue-644]") {
+          "[ship][installer][issue-644]") {
     auto config = make_test_config();
     config.output_path = "dist/TestPlugin Setup.exe";
     config.publisher = "Acme Audio";
@@ -244,7 +244,7 @@ TEST_CASE("NSIS script honors configured output path and install root",
 }
 
 TEST_CASE("NSIS script installs file plugins without recursive flag",
-          "[ship][installer][coverage][issue-644]") {
+          "[ship][installer][issue-644]") {
     ScopedTempDir temp;
     auto plugin = temp.path / "TestPlugin.clap";
     std::ofstream(plugin) << "plugin";
@@ -259,7 +259,7 @@ TEST_CASE("NSIS script installs file plugins without recursive flag",
 }
 
 TEST_CASE("NSIS script uses per-user plugin common directories",
-          "[ship][installer][coverage][issue-644]") {
+          "[ship][installer][issue-644]") {
     auto config = make_test_config();
     config.per_user_install = true;
     auto script = generate_nsis_script(config);
@@ -271,7 +271,7 @@ TEST_CASE("NSIS script uses per-user plugin common directories",
 }
 
 TEST_CASE("NSIS script keeps install_dir field non-authoritative for format destinations",
-          "[ship][installer][coverage][issue-644]") {
+          "[ship][installer][issue-644]") {
     auto config = make_test_config();
     config.plugins = {
         {"/tmp/custom/TestPlugin.vst3", "C:/Ignored/VST3", "vst3"},

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -163,7 +163,7 @@ TEST_CASE("nested PermissionsOverride clear exposes backend then restores outer 
 }
 
 TEST_CASE("PermissionsOverride clear on missing entries is a no-op",
-          "[platform][permissions][override][coverage][issue-649]") {
+          "[platform][permissions][override][issue-649]") {
     const auto backend_microphone = query(Permission::Microphone);
     const auto backend_camera = query(Permission::Camera);
 
@@ -178,7 +178,7 @@ TEST_CASE("PermissionsOverride clear on missing entries is a no-op",
 }
 
 TEST_CASE("empty nested PermissionsOverride preserves outer entries",
-          "[platform][permissions][override][coverage][issue-649]") {
+          "[platform][permissions][override][issue-649]") {
     const auto backend_microphone = query(Permission::Microphone);
     const auto outer_state = state_different_from(backend_microphone);
 

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Platform detection", "[platform]") {
 }
 
 TEST_CASE("Platform detection flags are mutually consistent",
-          "[platform][coverage]") {
+          "[platform]") {
     const int os_flags =
         static_cast<int>(is_macos) +
         static_cast<int>(is_ios) +
@@ -65,7 +65,7 @@ TEST_CASE("Platform detection flags are mutually consistent",
 }
 
 TEST_CASE("Architecture detection flags are mutually consistent",
-          "[platform][coverage]") {
+          "[platform]") {
     REQUIRE(is_arm == (current_arch == Arch::ARM64 || current_arch == Arch::ARM32));
     REQUIRE(is_x86 == (current_arch == Arch::x86_64 || current_arch == Arch::x86));
     REQUIRE(is_64bit == (current_arch == Arch::x86_64 || current_arch == Arch::ARM64));
@@ -132,7 +132,7 @@ TEST_CASE("PopupMenu records items and separators",
 }
 
 TEST_CASE("ProgressParser accepts payloads, empty payloads, and type-only lines",
-          "[platform][progress][coverage][issue-649]") {
+          "[platform][progress][issue-649]") {
     std::vector<ProgressEvent> events;
     ProgressParser parser([&](const ProgressEvent& e) {
         events.push_back(e);
@@ -155,7 +155,7 @@ TEST_CASE("ProgressParser accepts payloads, empty payloads, and type-only lines"
 }
 
 TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbacks",
-          "[platform][progress][coverage][issue-649]") {
+          "[platform][progress][issue-649]") {
     int calls = 0;
     ProgressParser parser([&](const ProgressEvent&) { ++calls; });
 
@@ -172,7 +172,7 @@ TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbac
 }
 
 TEST_CASE("ProgressParser preserves payload colons and empty event types",
-          "[platform][progress][coverage]") {
+          "[platform][progress]") {
     std::vector<ProgressEvent> events;
     ProgressParser parser([&](const ProgressEvent& e) {
         events.push_back(e);

--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -196,7 +196,7 @@ TEST_CASE("PluginFormat enum covers the 5 shipping formats",
 }
 
 TEST_CASE("PluginScanner default paths match platform format support",
-          "[host][plugin-info][format][coverage]") {
+          "[host][plugin-info][format]") {
 #if defined(__APPLE__)
     auto vst3 = PluginScanner::default_paths(PluginFormat::VST3);
     auto au = PluginScanner::default_paths(PluginFormat::AudioUnit);
@@ -254,7 +254,7 @@ TEST_CASE("PluginScanner identifies bundle suffixes for each host format",
 }
 
 TEST_CASE("PluginScanner honors disabled format flags without progress callbacks",
-          "[host][scanner][coverage]") {
+          "[host][scanner]") {
     PluginScanner scanner;
     ScanOptions opts;
     opts.scan_vst3 = false;
@@ -275,7 +275,7 @@ TEST_CASE("PluginScanner honors disabled format flags without progress callbacks
 }
 
 TEST_CASE("PluginScanner only_extra_paths reports each enabled format path",
-          "[host][scanner][coverage]") {
+          "[host][scanner]") {
     ScannerScratchDir scratch("empty-extra-paths");
 
     PluginScanner scanner;
@@ -304,7 +304,7 @@ TEST_CASE("PluginScanner only_extra_paths reports each enabled format path",
 }
 
 TEST_CASE("PluginScanner scans only supplied hermetic VST3 and LV2 directories",
-          "[host][scanner][coverage]") {
+          "[host][scanner]") {
     ScannerScratchDir scratch("synthetic-bundles");
     fs::create_directories(scratch.path / "BetaSynth.vst3" / "Contents" / "Resources");
     fs::create_directories(scratch.path / "AlphaVerb.lv2");
@@ -336,7 +336,7 @@ TEST_CASE("PluginScanner scans only supplied hermetic VST3 and LV2 directories",
 }
 
 TEST_CASE("PluginScanner skips missing and non-directory extra paths",
-          "[host][scanner][coverage]") {
+          "[host][scanner]") {
     ScannerScratchDir scratch("bad-extra-paths");
     const auto plain_file = scratch.path / "plain-file.vst3";
     write_text(plain_file, "not a directory");
@@ -366,7 +366,7 @@ TEST_CASE("PluginScanner skips missing and non-directory extra paths",
 }
 
 TEST_CASE("VST3 moduleinfo FUID reader normalizes valid CIDs and rejects malformed metadata",
-          "[host][scanner][vst3][coverage]") {
+          "[host][scanner][vst3]") {
     ScannerScratchDir scratch("vst3-moduleinfo");
     const auto bundle = scratch.path / "ModuleCase.vst3";
 
@@ -403,7 +403,7 @@ TEST_CASE("VST3 moduleinfo FUID reader normalizes valid CIDs and rejects malform
 }
 
 TEST_CASE("PluginScanner uses VST3 moduleinfo IDs while preserving blacklist short-circuiting",
-          "[host][scanner][vst3][blacklist][coverage]") {
+          "[host][scanner][vst3][blacklist]") {
     ScannerScratchDir scratch("vst3-scan-blacklist");
     const auto blocked = scratch.path / "BlockedSynth.vst3";
     const auto allowed = scratch.path / "AllowedFx.vst3";
@@ -438,7 +438,7 @@ TEST_CASE("PluginScanner uses VST3 moduleinfo IDs while preserving blacklist sho
 }
 
 TEST_CASE("PluginScanner LV2 URI extraction handles manifest variants and safe fallbacks",
-          "[host][scanner][lv2][coverage]") {
+          "[host][scanner][lv2]") {
     ScannerScratchDir scratch("lv2-manifest-variants");
     const auto canonical = scratch.path / "Canonical.lv2";
     const auto compound = scratch.path / "Compound.lv2";

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -228,7 +228,7 @@ TEST_CASE("plugin_state_io round-trips parameter and plugin-owned state",
 }
 
 TEST_CASE("plugin_state_io envelope encodes payload sizes and CRC",
-          "[format][plugin-state][coverage]") {
+          "[format][plugin-state]") {
     TestRig source;
     source.store.set_value(1, -2.5f);
     source.processor.plugin_state = "layout=full";
@@ -263,7 +263,7 @@ TEST_CASE("plugin_state_io envelope encodes payload sizes and CRC",
 }
 
 TEST_CASE("plugin_state_io preserves binary plugin-owned payload bytes",
-          "[format][plugin-state][coverage]") {
+          "[format][plugin-state]") {
     TestRig source;
     source.store.set_value(1, -3.0f);
     source.processor.plugin_state.assign(
@@ -309,7 +309,7 @@ TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plug
 }
 
 TEST_CASE("plugin_state_io envelope with empty plugin payload resets plugin state",
-          "[format][plugin-state][coverage][issue-647]") {
+          "[format][plugin-state][issue-647]") {
     TestRig source;
     source.store.set_value(1, -15.0f);
     auto store_blob = source.store.serialize();
@@ -487,7 +487,7 @@ TEST_CASE("plugin_state_io migrates old envelopes before parsing payloads",
 }
 
 TEST_CASE("plugin_state_io rejects invalid envelope migration registrations",
-          "[format][plugin-state][coverage]") {
+          "[format][plugin-state]") {
     using pulp::format::plugin_state_io::current_envelope_version;
     using pulp::format::plugin_state_io::register_envelope_migration;
 
@@ -671,7 +671,7 @@ TEST_CASE("plugin_state_io rejects malformed blobs without touching live state",
 }
 
 TEST_CASE("plugin_state_io rejects envelope CRC mismatch without plugin callback",
-          "[format][plugin-state][coverage][issue-647]") {
+          "[format][plugin-state][issue-647]") {
     TestRig source;
     source.store.set_value(1, -21.0f);
     source.processor.plugin_state = "snapshot-c";

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -610,7 +610,7 @@ TEST_CASE("PluginDescriptor effective_capabilities ORs legacy and node fields",
 }
 
 TEST_CASE("PluginDescriptor preserves optional vendor contact metadata",
-          "[format][processor-defaults][metadata][coverage]") {
+          "[format][processor-defaults][metadata]") {
     PluginDescriptor d;
     d.vendor_url = "https://example.test/pulp";
     d.vendor_email = "support@example.test";
@@ -921,7 +921,7 @@ TEST_CASE("Processor default view_size reflects an overridden editor_size",
 }
 
 TEST_CASE("Processor custom view_size can provide resize bounds and aspect ratio",
-          "[format][processor-defaults][editor][coverage]") {
+          "[format][processor-defaults][editor]") {
     CustomViewSizeProcessor p;
     const auto hints = p.view_size();
 
@@ -971,7 +971,7 @@ TEST_CASE("view_size_from_design derives sensible bounds + aspect from preferred
 }
 
 TEST_CASE("Processor has_editor override can disable default editor contract",
-          "[format][processor-defaults][editor][coverage]") {
+          "[format][processor-defaults][editor]") {
     EditorlessProcessor p;
 
     REQUIRE_FALSE(p.has_editor());
@@ -993,7 +993,7 @@ TEST_CASE("Processor default latency and plugin-owned state hooks are inert",
 }
 
 TEST_CASE("Processor default lifecycle hooks are callable no-ops",
-          "[format][processor-defaults][lifecycle][coverage]") {
+          "[format][processor-defaults][lifecycle]") {
     PlainProcessor p;
     pulp::view::View view;
 
@@ -1011,7 +1011,7 @@ TEST_CASE("Processor default lifecycle hooks are callable no-ops",
 }
 
 TEST_CASE("Processor prepare receives the exact host context",
-          "[format][processor-defaults][context][coverage]") {
+          "[format][processor-defaults][context]") {
     PlainProcessor p;
     PrepareContext context;
     context.sample_rate = 96000.0;
@@ -1029,7 +1029,7 @@ TEST_CASE("Processor prepare receives the exact host context",
 }
 
 TEST_CASE("Processor process receives the exact transport context",
-          "[format][processor-defaults][context][coverage]") {
+          "[format][processor-defaults][context]") {
     PlainProcessor p;
     float out_samples[4] = {};
     float* out_channels[1] = {out_samples};
@@ -1133,7 +1133,7 @@ TEST_CASE("Processor sidechain, MPE, and UMP sidecar pointers can be set and cle
 }
 
 TEST_CASE("Processor sidecar pointers replace independently between blocks",
-          "[format][processor-defaults][sidecars][coverage]") {
+          "[format][processor-defaults][sidecars]") {
     PlainProcessor p;
 
     const float first_samples[2] = {0.1f, 0.2f};
@@ -1276,7 +1276,7 @@ TEST_CASE("for_each_subblock invokes one full block for null or empty queues",
 }
 
 TEST_CASE("for_each_subblock skips zero-sample buffers",
-          "[format][params][subblock][coverage]") {
+          "[format][params][subblock]") {
     pulp::state::StateStore store;
     store.add_parameter({
         .id = 3,
@@ -1307,7 +1307,7 @@ TEST_CASE("for_each_subblock skips zero-sample buffers",
 }
 
 TEST_CASE("for_each_subblock ignores boundary events and slices input with output",
-          "[format][params][subblock][coverage]") {
+          "[format][params][subblock]") {
     pulp::state::StateStore store;
     store.add_parameter({
         .id = 9,
@@ -1462,7 +1462,7 @@ TEST_CASE("ControlRateParamSmoother is bit-exact off and ramps when opted in",
 }
 
 TEST_CASE("ControlRateParamSmoother handles invalid rates reset and skip",
-          "[format][params][smoothing][coverage]") {
+          "[format][params][smoothing]") {
     pulp::state::ParamInfo info;
     info.smoothing_ramp_seconds = 0.004f;
 

--- a/test/test_pulp_bridge.cpp
+++ b/test/test_pulp_bridge.cpp
@@ -220,7 +220,7 @@ TEST_CASE("PulpBridge state serialize and deserialize use the fallback store",
 }
 
 TEST_CASE("PulpBridge parameter calls fail closed for unknown ids",
-          "[apple][bridge][params][coverage]") {
+          "[apple][bridge][params]") {
     reset_bridge_store();
     constexpr PulpParamID kMissingParamId = 90909;
 
@@ -260,7 +260,7 @@ TEST_CASE("PulpBridge parameter calls fail closed for unknown ids",
 }
 
 TEST_CASE("PulpBridge parameters clamp raw and normalized values",
-          "[apple][bridge][params][coverage]") {
+          "[apple][bridge][params]") {
     reset_bridge_store();
 
     pulp_param_set(kBridgeParamId, -999.0f);
@@ -284,7 +284,7 @@ TEST_CASE("PulpBridge parameters clamp raw and normalized values",
 }
 
 TEST_CASE("PulpBridge deserialize rejects malformed state without clobbering values",
-          "[apple][bridge][state][coverage]") {
+          "[apple][bridge][state]") {
     reset_bridge_store();
     pulp_param_set(kBridgeParamId, 7.25f);
     pulp_param_set(kSecondBridgeParamId, 33.0f);
@@ -316,7 +316,7 @@ TEST_CASE("PulpBridge deserialize rejects malformed state without clobbering val
 }
 
 TEST_CASE("PulpBridge state serialization snapshots current parameter values",
-          "[apple][bridge][state][coverage]") {
+          "[apple][bridge][state]") {
     reset_bridge_store();
 
     pulp_param_set(kBridgeParamId, -6.0f);
@@ -382,7 +382,7 @@ TEST_CASE("PulpBridge plugin info exposes the registered descriptor",
 }
 
 TEST_CASE("PulpBridge plugin info string storage survives later descriptor calls",
-          "[apple][bridge][plugin-info][coverage]") {
+          "[apple][bridge][plugin-info]") {
     ScopedFactoryRegistration registration(create_test_processor);
 
     PulpPluginInfo first{};
@@ -409,7 +409,7 @@ TEST_CASE("PulpBridge plugin info string storage survives later descriptor calls
 }
 
 TEST_CASE("PulpBridge plugin info updates static string storage per descriptor",
-          "[apple][bridge][plugin-info][coverage]") {
+          "[apple][bridge][plugin-info]") {
     PulpPluginInfo info{};
 
     {
@@ -437,7 +437,7 @@ TEST_CASE("PulpBridge plugin info updates static string storage per descriptor",
 }
 
 TEST_CASE("PulpBridge state serialization owns returned buffers independently",
-          "[apple][bridge][state][coverage][requested]") {
+          "[apple][bridge][state]") {
     reset_bridge_store();
 
     pulp_param_set(kBridgeParamId, -30.0f);

--- a/test/test_scan_blacklist.cpp
+++ b/test/test_scan_blacklist.cpp
@@ -123,7 +123,7 @@ TEST_CASE("from_text skips malformed lines", "[host][blacklist]") {
 }
 
 TEST_CASE("from_text clears existing entries when every line is malformed",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text("/old.vst3|1|2|stale\n"));
     REQUIRE(bl.size() == 1);
@@ -138,7 +138,7 @@ TEST_CASE("from_text clears existing entries when every line is malformed",
 }
 
 TEST_CASE("from_text preserves empty blacklist reasons",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text("/plugin.vst3|10|20|\n"));
 
@@ -216,7 +216,7 @@ TEST_CASE("from_text tolerates signed stamp values from old blacklist files",
 }
 
 TEST_CASE("from_text rejects partially parsed numeric stamp fields",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text(
         "/mtime-junk.vst3|10junk|20|bad mtime\n"
@@ -234,7 +234,7 @@ TEST_CASE("from_text rejects partially parsed numeric stamp fields",
 }
 
 TEST_CASE("blacklisting a missing plugin records a durable manual block",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     TempFile f;
     ScanBlacklist bl;
 
@@ -253,7 +253,7 @@ TEST_CASE("blacklisting a missing plugin records a durable manual block",
 }
 
 TEST_CASE("from_text duplicate blacklist records keep the last valid entry",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text(
         "/plugin.vst3|1|2|first reason\n"
@@ -269,7 +269,7 @@ TEST_CASE("from_text duplicate blacklist records keep the last valid entry",
 }
 
 TEST_CASE("from_text keeps unknown percent escapes literal",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text("/plugin%2Fname.vst3|7|8|bad%2Greason%7Cok\n"));
 
@@ -283,7 +283,7 @@ TEST_CASE("from_text keeps unknown percent escapes literal",
 }
 
 TEST_CASE("from_text keeps trailing incomplete percent escapes literal",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     ScanBlacklist bl;
     REQUIRE(bl.from_text("/plugin.vst3|1|2|reason%"));
 
@@ -296,7 +296,7 @@ TEST_CASE("from_text keeps trailing incomplete percent escapes literal",
 }
 
 TEST_CASE("save_to creates nested blacklist parent directories",
-          "[host][blacklist][codecov]") {
+          "[host][blacklist]") {
     TempFile f;
     const auto root = f.path.parent_path() / (f.path.filename().string() + "-dir");
     const auto out_path = root / "nested" / "blacklist.txt";

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -201,7 +201,7 @@ TEST_CASE("from_json rejects wrong schema version", "[scan_cache]") {
 }
 
 TEST_CASE("ScanCache from_json rejects non-object roots without replacing cache",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     cache.put("/tmp/existing.vst3", sample_info());
 
@@ -215,7 +215,7 @@ TEST_CASE("ScanCache from_json rejects non-object roots without replacing cache"
 }
 
 TEST_CASE("ScanCache from_json rejects missing schema without replacing cache",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     cache.put("/tmp/existing.vst3", sample_info());
 
@@ -268,7 +268,7 @@ TEST_CASE("ScanCache from_json skips malformed entries while loading valid entri
 }
 
 TEST_CASE("ScanCache from_json skips entries missing required fields",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache c;
     REQUIRE(c.from_json(R"({
         "schema_version": 1,
@@ -305,7 +305,7 @@ TEST_CASE("ScanCache from_json keeps existing cache when blob is malformed",
 }
 
 TEST_CASE("ScanCache from_json keeps existing cache when entry fields have wrong types",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     cache.put("/tmp/existing.vst3", sample_info());
 
@@ -397,7 +397,7 @@ TEST_CASE("ScanCache load_from empty or malformed file keeps existing cache",
 }
 
 TEST_CASE("ScanCache put on a missing path records metadata but never hits",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     TempFile f;
     HostScanCache cache;
     auto info = sample_info();
@@ -418,7 +418,7 @@ TEST_CASE("ScanCache put on a missing path records metadata but never hits",
 }
 
 TEST_CASE("ScanCache erase and clear leave cache reusable",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     cache.put("/tmp/one.vst3", sample_info());
 
@@ -444,7 +444,7 @@ TEST_CASE("ScanCache erase and clear leave cache reusable",
 }
 
 TEST_CASE("ScanCache from_json rejects non-array entries without replacing cache",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     cache.put("/tmp/existing.vst3", sample_info());
 
@@ -457,7 +457,7 @@ TEST_CASE("ScanCache from_json rejects non-array entries without replacing cache
 }
 
 TEST_CASE("ScanCache duplicate JSON entries keep the last valid record",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,
@@ -509,7 +509,7 @@ TEST_CASE("ScanCache duplicate JSON entries keep the last valid record",
 }
 
 TEST_CASE("ScanCache JSON round-trip preserves every plugin format",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache written;
 
     const std::vector<std::pair<PluginFormat, std::string>> formats = {
@@ -544,7 +544,7 @@ TEST_CASE("ScanCache JSON round-trip preserves every plugin format",
 }
 
 TEST_CASE("ScanCache round-trips Audio Unit format identifiers",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache a;
 
     auto au = sample_info();
@@ -569,7 +569,7 @@ TEST_CASE("ScanCache round-trips Audio Unit format identifiers",
 }
 
 TEST_CASE("ScanCache from_json leaves features empty when features is not an array",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,
@@ -592,7 +592,7 @@ TEST_CASE("ScanCache from_json leaves features empty when features is not an arr
 }
 
 TEST_CASE("ScanCache save_to creates nested parent directories",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     TempFile f;
     const auto root = f.path.parent_path() / (f.path.filename().string() + "-dir");
     const auto cache_path = root / "nested" / "scan-cache.json";
@@ -612,7 +612,7 @@ TEST_CASE("ScanCache save_to creates nested parent directories",
 }
 
 TEST_CASE("ScanCache from_json loads entries without optional metadata",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,
@@ -644,7 +644,7 @@ TEST_CASE("ScanCache from_json loads entries without optional metadata",
 }
 
 TEST_CASE("ScanCache from_json keeps valid siblings around malformed records",
-          "[scan_cache][codecov]") {
+          "[scan_cache]") {
     HostScanCache cache;
     REQUIRE(cache.from_json(R"({
         "schema_version": 1,

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -50,7 +50,7 @@ int run_screenshot_cli(std::initializer_list<const char*> args) {
 }  // namespace
 
 TEST_CASE("pulp-screenshot base64 encoder handles RFC 4648 padding cases",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     REQUIRE(base64_encode({}).empty());
     REQUIRE(base64_encode({'f'}) == "Zg==");
     REQUIRE(base64_encode({'f', 'o'}) == "Zm8=");
@@ -72,7 +72,7 @@ TEST_CASE("pulp-screenshot base64 encoder handles RFC 4648 padding cases",
 }
 
 TEST_CASE("pulp-screenshot base64 encoder preserves binary PNG-like bytes",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     std::vector<uint8_t> png_header = {0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a};
     auto encoded = base64_encode(png_header);
     REQUIRE(encoded == "iVBORw0KGgo=");
@@ -91,7 +91,7 @@ TEST_CASE("pulp-screenshot base64 encoder preserves binary PNG-like bytes",
 }
 
 TEST_CASE("pulp-screenshot base64 encoder emits stable 4-character blocks",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     for (std::size_t size = 1; size <= 12; ++size) {
         std::vector<uint8_t> bytes(size);
         for (std::size_t i = 0; i < size; ++i)
@@ -112,7 +112,7 @@ TEST_CASE("pulp-screenshot base64 encoder emits stable 4-character blocks",
 }
 
 TEST_CASE("pulp-screenshot read_file preserves script bytes and fails closed",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto path = temp_file_path("script.js");
     std::filesystem::remove(path);
     write_bytes(path, "createLabel('title', 'Hello');\n");
@@ -135,7 +135,7 @@ TEST_CASE("pulp-screenshot read_file preserves script bytes and fails closed",
 }
 
 TEST_CASE("pulp-screenshot runtime trace script records live native bounds",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     const std::string script = runtime_trace_script();
     REQUIRE(script.find("native_bounds_count") != std::string::npos);
     REQUIRE(script.find("native_bounds") != std::string::npos);
@@ -148,7 +148,7 @@ TEST_CASE("pulp-screenshot runtime trace script records live native bounds",
 }
 
 TEST_CASE("pulp-screenshot option parser preserves documented defaults",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto options = parse_args({});
 
     REQUIRE(options.script_path.empty());
@@ -169,7 +169,7 @@ TEST_CASE("pulp-screenshot option parser preserves documented defaults",
 }
 
 TEST_CASE("pulp-screenshot option parser accepts explicit render settings",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto options = parse_args({
         "--script", "ui.js",
         "--output", "render.png",
@@ -197,7 +197,7 @@ TEST_CASE("pulp-screenshot option parser accepts explicit render settings",
 }
 
 TEST_CASE("pulp-screenshot option parser handles aliases and last value wins",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto options = parse_args({
         "--demo",
         "--script", "first.js",
@@ -227,7 +227,7 @@ TEST_CASE("pulp-screenshot option parser handles aliases and last value wins",
 }
 
 TEST_CASE("pulp-screenshot help option short-circuits parsing entirely",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     // After #2956's pre-scan fix, `--help` anywhere in argv short-circuits
     // BEFORE the option loop runs — including BEFORE flags that come
     // earlier in argv. This is the documented help-path contract: any
@@ -258,7 +258,7 @@ TEST_CASE("pulp-screenshot help option short-circuits parsing entirely",
 // of clean help output. This pins help-path robustness in the order
 // the user is most likely to hit it: a typo first, `--help` later.
 TEST_CASE("pulp-screenshot --help short-circuits malformed args before it (#2956)",
-          "[tools][screenshot][coverage][issue-2956]") {
+          "[tools][screenshot][issue-2956]") {
     // Malformed --width / --height BEFORE --help must not blow up.
     ScreenshotCliOptions options;
     REQUIRE_NOTHROW(options = parse_args({
@@ -287,7 +287,7 @@ TEST_CASE("pulp-screenshot --help short-circuits malformed args before it (#2956
 }
 
 TEST_CASE("pulp-screenshot backend normalization rejects unavailable explicit Skia",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto explicit_skia = parse_args({"--demo", "--backend", "skia"});
     REQUIRE(explicit_skia.backend_name == "skia");
     REQUIRE_FALSE(explicit_skia.backend_was_defaulted);
@@ -310,7 +310,7 @@ TEST_CASE("pulp-screenshot backend normalization rejects unavailable explicit Sk
 }
 
 TEST_CASE("pulp-screenshot option parser handles malformed non-help invocations",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     REQUIRE_THROWS(parse_args({"--width", "wide"}));
     REQUIRE_THROWS(parse_args({"--height", "tall"}));
     REQUIRE_THROWS(parse_args({"--scale", "large"}));
@@ -336,7 +336,7 @@ TEST_CASE("pulp-screenshot option parser handles malformed non-help invocations"
 }
 
 TEST_CASE("pulp-screenshot option parser ignores incomplete trailing switches",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto options = parse_args({
         "--script",
         "--output",
@@ -354,7 +354,7 @@ TEST_CASE("pulp-screenshot option parser ignores incomplete trailing switches",
 }
 
 TEST_CASE("pulp-screenshot option parser keeps numeric boundary contracts explicit",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto zero_size = parse_args({
         "--demo",
         "--width", "0",
@@ -378,13 +378,13 @@ TEST_CASE("pulp-screenshot option parser keeps numeric boundary contracts explic
 }
 
 TEST_CASE("pulp-screenshot main rejects unknown backend before rendering",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     auto exit_code = run_screenshot_cli({"--demo", "--backend", "metal"});
     REQUIRE(exit_code == 1);
 }
 
 TEST_CASE("pulp-screenshot main handles early non-render exits",
-          "[tools][screenshot][coverage]") {
+          "[tools][screenshot]") {
     REQUIRE(run_screenshot_cli({"--help"}) == 0);
     REQUIRE(run_screenshot_cli({"--width", "bad", "--help"}) == 0);
     REQUIRE(run_screenshot_cli({}) == 1);
@@ -396,7 +396,7 @@ TEST_CASE("pulp-screenshot main handles early non-render exits",
 }
 
 TEST_CASE("pulp-screenshot main renders demo files and base64 output",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto output = temp_file_path("demo-output.png");
     std::filesystem::remove(output);
     const auto output_arg = output.string();
@@ -426,7 +426,7 @@ TEST_CASE("pulp-screenshot main renders demo files and base64 output",
 }
 
 TEST_CASE("pulp-screenshot main captures the demo through the smart auto backend",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto output = temp_file_path("auto-output.png");
     std::filesystem::remove(output);
     const auto output_arg = output.string();
@@ -454,7 +454,7 @@ TEST_CASE("pulp-screenshot main captures the demo through the smart auto backend
 }
 
 TEST_CASE("pulp-screenshot --compare scores similarity and writes a diff image",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto img = temp_file_path("compare-input.png");
     auto diff = temp_file_path("compare-diff.png");
     std::filesystem::remove(img);
@@ -493,7 +493,7 @@ TEST_CASE("pulp-screenshot --compare scores similarity and writes a diff image",
 }
 
 TEST_CASE("pulp-screenshot main renders script files through the CLI path",
-          "[tools][screenshot][coverage][requested]") {
+          "[tools][screenshot]") {
     auto script = temp_file_path("script-render.js");
     auto output = temp_file_path("script-output.png");
     std::filesystem::remove(script);

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -279,7 +279,7 @@ TEST_CASE("Standalone settings callbacks skip rebind when apply fails",
 }
 
 TEST_CASE("StandaloneApp apply_config updates idle configuration without starting audio",
-          "[standalone][coverage]") {
+          "[standalone]") {
     counted_null_processor_factory_calls = 0;
     StandaloneApp app(counted_null_processor_factory);
 
@@ -305,7 +305,7 @@ TEST_CASE("StandaloneApp apply_config updates idle configuration without startin
 }
 
 TEST_CASE("StandaloneApp rejects headless editor runs without screenshot before startup",
-          "[standalone][coverage]") {
+          "[standalone]") {
     counted_null_processor_factory_calls = 0;
     StandaloneApp app(counted_null_processor_factory);
 
@@ -401,7 +401,7 @@ TEST_CASE("SettingsPanel applies audio and MIDI selections",
 }
 
 TEST_CASE("SettingsPanel set_current_config prefers explicit output over default",
-          "[standalone][settings][coverage]") {
+          "[standalone][settings]") {
     StubAudioSystem audio;
     audio.devices = {
         {.id = "builtin-out",
@@ -759,7 +759,7 @@ TEST_CASE("SettingsPanel refreshes hotplug lists and test tone callbacks",
 }
 
 TEST_CASE("SettingsPanel uses fallback rate and buffer choices without output devices",
-          "[standalone][settings][coverage]") {
+          "[standalone][settings]") {
     StubAudioSystem audio;
     audio.devices = {
         {.id = "mic-only",

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -229,7 +229,7 @@ TEST_CASE("ValidationHarness creates and reports descriptor", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness exposes the underlying headless host",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     const auto& const_harness = harness;
 
@@ -238,7 +238,7 @@ TEST_CASE("ValidationHarness exposes the underlying headless host",
 }
 
 TEST_CASE("ValidationHarness option and entry defaults match report schema",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationRunOptions options;
     REQUIRE(options.output_dir.empty());
     REQUIRE(options.sample_rate == 48000.0);
@@ -275,7 +275,7 @@ TEST_CASE("ValidationHarness set/get param", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness configure creates artifact directory",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     auto out_dir = make_temp_dir("pulp-harness-output-dir");
     REQUIRE_FALSE(std::filesystem::exists(out_dir));
@@ -304,7 +304,7 @@ TEST_CASE("ValidationHarness processes silence blocks", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness process_blocks zero blocks returns one silent buffer",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 8, .output_channels = 2});
 
@@ -333,7 +333,7 @@ TEST_CASE("ValidationHarness processes audio buffer with gain", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness process_buffer auto-prepares with caller channel layout",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 3, .input_channels = 1, .output_channels = 1});
 
@@ -382,7 +382,7 @@ TEST_CASE("ValidationHarness MIDI note-off and CC helpers reach process_buffer",
 }
 
 TEST_CASE("ValidationHarness process_blocks consumes queued MIDI once",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 4});
     harness.prepare();
@@ -462,7 +462,7 @@ TEST_CASE("ValidationHarness generates valid report JSON", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness report omits payload for unknown entry types",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -480,7 +480,7 @@ TEST_CASE("ValidationHarness report omits payload for unknown entry types",
 }
 
 TEST_CASE("ValidationHarness report includes sanitizer payloads",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -669,7 +669,7 @@ TEST_CASE("ValidationHarness rejects mismatched plugin runtime manifest id",
 }
 
 TEST_CASE("ValidationHarness report escapes JSON metadata and entry strings",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({
         .git_ref = "branch/quote\"slash\\",
@@ -692,7 +692,7 @@ TEST_CASE("ValidationHarness report escapes JSON metadata and entry strings",
 }
 
 TEST_CASE("ValidationHarness report escapes generic control characters",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -747,7 +747,7 @@ TEST_CASE("ValidationHarness write_report creates file", "[harness]") {
 }
 
 TEST_CASE("ValidationHarness write_report creates nested directories",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -762,7 +762,7 @@ TEST_CASE("ValidationHarness write_report creates nested directories",
 }
 
 TEST_CASE("ValidationHarness write_report reports failure for directory paths",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -809,7 +809,7 @@ TEST_CASE("ValidationHarness run_validator errors on missing plugin", "[harness]
 }
 
 TEST_CASE("ValidationHarness run_validator errors on unknown installed tool",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -876,7 +876,7 @@ TEST_CASE("ValidationHarness disables plugin editors for external validators",
 }
 
 TEST_CASE("ValidationHarness run_validator captures installed pluginval success",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -917,7 +917,7 @@ TEST_CASE("ValidationHarness run_validator captures installed pluginval success"
 }
 
 TEST_CASE("ValidationHarness run_validator records installed pluginval failures",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -955,7 +955,7 @@ TEST_CASE("ValidationHarness run_validator records installed pluginval failures"
 }
 
 TEST_CASE("ValidationHarness run_validator defaults clap-validator format",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -995,7 +995,7 @@ TEST_CASE("ValidationHarness run_validator defaults clap-validator format",
 }
 
 TEST_CASE("ValidationHarness run_validator defaults auval format",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -1031,7 +1031,7 @@ TEST_CASE("ValidationHarness run_validator defaults auval format",
 }
 
 TEST_CASE("ValidationHarness run_validator defaults vstvalidator format and trims CRLF versions",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -1111,7 +1111,7 @@ TEST_CASE("ValidationHarness screenshot passes when provider returns true",
 }
 
 TEST_CASE("ValidationHarness clearing screenshot provider restores skip behavior",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -1198,7 +1198,7 @@ TEST_CASE("ValidationHarness inspector passes with provider",
 }
 
 TEST_CASE("ValidationHarness clearing inspector provider restores skip behavior",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
 
@@ -1299,7 +1299,7 @@ TEST_CASE("ValidationHarness compare_screenshots differing files -> fail",
 }
 
 TEST_CASE("ValidationHarness report renders capture and diff payload sections",
-          "[harness][coverage]") {
+          "[harness]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({
         .diff_tolerance = 7,
@@ -1399,7 +1399,7 @@ TEST_CASE("ValidationStatus to_string covers all values", "[harness]") {
 }
 
 TEST_CASE("ValidationStatus to_string falls back to error for unknown values",
-          "[harness][coverage]") {
+          "[harness]") {
     using pulp::format::ValidationStatus;
     using pulp::format::to_string;
 

--- a/test/test_vendor_url.cpp
+++ b/test/test_vendor_url.cpp
@@ -34,7 +34,7 @@ TEST_CASE("copy preserves url + email", "[format][vendor-url]") {
 }
 
 TEST_CASE("PluginDescriptor bus helpers follow first bus and empty bus lists",
-          "[format][descriptor][coverage]") {
+          "[format][descriptor]") {
     PluginDescriptor d;
     REQUIRE(d.default_input_channels() == 2);
     REQUIRE(d.default_output_channels() == 2);
@@ -56,7 +56,7 @@ TEST_CASE("PluginDescriptor bus helpers follow first bus and empty bus lists",
 }
 
 TEST_CASE("PluginDescriptor modern capability flags default off",
-          "[format][vendor-url][coverage]") {
+          "[format][vendor-url]") {
     PluginDescriptor d;
     REQUIRE_FALSE(d.supports_mpe);
     REQUIRE_FALSE(d.supports_ump);

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -398,7 +398,7 @@ private:
 } // namespace
 
 TEST_CASE("VST3 adapter exposes parameter metadata and lifecycle values",
-          "[vst3][coverage][issue-493]") {
+          "[vst3][issue-493]") {
     TestVst3Config config;
     config.add_bypass_param = true;
     config.latency_samples = 128;
@@ -604,7 +604,7 @@ TEST_CASE("VST3 editor creation is disabled by automation env",
 }
 
 TEST_CASE("VST3 adapter process path maps host events, buses, and outputs",
-          "[vst3][process][coverage][issue-493]") {
+          "[vst3][process][issue-493]") {
     TestVst3Config config;
     config.mutate_gain_in_process = true;
     config.emit_midi_out = true;

--- a/test/test_wam_wclap.cpp
+++ b/test/test_wam_wclap.cpp
@@ -107,7 +107,7 @@ TEST_CASE("WamDescriptorData to_json", "[format][wam]") {
 }
 
 TEST_CASE("WamDescriptorData defaults serialize every advertised capability",
-          "[format][wam][coverage]") {
+          "[format][wam]") {
     WamDescriptorData desc;
     desc.name = "Default";
     auto json = desc.to_json();
@@ -136,7 +136,7 @@ TEST_CASE("WamProcessorBridge initialization", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge handles uninitialized and null-factory states",
-          "[format][wam][coverage]") {
+          "[format][wam]") {
     WamProcessorBridge uninitialized(create_test_wam);
     auto empty_desc = uninitialized.descriptor();
     REQUIRE(empty_desc.name.empty());
@@ -199,7 +199,7 @@ TEST_CASE("WamProcessorBridge audio processing", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge clamps processing to prepared channel count",
-          "[format][wam][coverage]") {
+          "[format][wam]") {
     WamProcessorBridge bridge(create_test_wam);
     bridge.initialize(48000.0, 128);
 
@@ -234,7 +234,7 @@ TEST_CASE("WamProcessorBridge MIDI scheduling", "[format][wam]") {
 }
 
 TEST_CASE("WamProcessorBridge ignores unsupported MIDI statuses",
-          "[format][wam][coverage]") {
+          "[format][wam]") {
     WamProcessorBridge bridge(create_test_wam);
     bridge.initialize(48000.0, 128);
 

--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -110,7 +110,7 @@ TEST_CASE("pulp-scan-worker reports usage when bundle path is missing",
 }
 
 TEST_CASE("pulp-scan-worker rejects extra positional arguments",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("extra-args");
     auto bundle = scratch.path / "Extra.vst3";
     auto ignored = scratch.path / "Ignored.vst3";
@@ -137,7 +137,7 @@ TEST_CASE("pulp-scan-worker rejects unsupported bundle extensions",
 }
 
 TEST_CASE("pulp-scan-worker rejects extension variants before scanning",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("extension-variants");
     auto upper_vst3 = scratch.path / "Upper.VST3";
     auto partial = scratch.path / "Almost.vst3.tmp";
@@ -160,7 +160,7 @@ TEST_CASE("pulp-scan-worker rejects extension variants before scanning",
 }
 
 TEST_CASE("pulp-scan-worker rejects missing extension targets before scanning",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("missing-extension");
     auto bundle_without_suffix = scratch.path / "Plugin";
     auto hidden_partial = scratch.path / ".Plugin.vst3.tmp";
@@ -183,7 +183,7 @@ TEST_CASE("pulp-scan-worker rejects missing extension targets before scanning",
 }
 
 TEST_CASE("pulp-scan-worker reports empty success for absent supported bundle paths",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("absent-supported-bundles");
     auto missing_vst3 = scratch.path / "Missing.vst3";
     auto missing_clap = scratch.path / "Missing.clap";
@@ -214,7 +214,7 @@ TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
 }
 
 TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("vst3-moduleinfo");
     auto bundle = scratch.path / "ModuleInfoProbe.vst3";
     fs::create_directories(bundle / "Contents" / "Resources");
@@ -244,7 +244,7 @@ TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
 }
 
 TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("vst3-siblings");
     auto target = scratch.path / "Target.vst3";
     auto sibling = scratch.path / "Sibling.vst3";
@@ -264,7 +264,7 @@ TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
 }
 
 TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("clap-fallback");
     auto bundle = scratch.path / "Fallback.clap";
     write_file(bundle, "not a dynamic library");
@@ -283,7 +283,7 @@ TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
 }
 
 TEST_CASE("pulp-scan-worker preserves fallback JSON fields for spaced CLAP paths",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("spaced-clap");
     auto bundle = scratch.path / "Space Name.clap";
     write_file(bundle, "not a dynamic library");
@@ -301,7 +301,7 @@ TEST_CASE("pulp-scan-worker preserves fallback JSON fields for spaced CLAP paths
 }
 
 TEST_CASE("pulp-scan-worker escapes fallback JSON descriptor strings",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
 #if defined(_WIN32)
     SUCCEED("Windows filenames cannot contain the control characters needed for this fallback-name escape path");
 #else
@@ -324,7 +324,7 @@ TEST_CASE("pulp-scan-worker escapes fallback JSON descriptor strings",
 }
 
 TEST_CASE("pulp-scan-worker test JSON escape helper covers control bytes",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     const std::string text = std::string("Quote\" Slash\\ Back") + '\b'
                            + " Form" + '\f' + " Line\nReturn\rTab\tUnit"
                            + '\x01' + "End";
@@ -333,7 +333,7 @@ TEST_CASE("pulp-scan-worker test JSON escape helper covers control bytes",
 }
 
 TEST_CASE("pulp-scan-worker escapes JSON control characters in fallback names",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
 #if defined(_WIN32)
     SUCCEED("Windows filenames cannot contain the control characters needed for this fallback-name escape path");
 #else
@@ -359,7 +359,7 @@ TEST_CASE("pulp-scan-worker escapes JSON control characters in fallback names",
 }
 
 TEST_CASE("pulp-scan-worker rejects known but unsupported plugin suffixes",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("unsupported-formats");
     auto component = scratch.path / "Legacy.component";
     auto lv2 = scratch.path / "Graph.lv2";
@@ -380,7 +380,7 @@ TEST_CASE("pulp-scan-worker rejects known but unsupported plugin suffixes",
 }
 
 TEST_CASE("pulp-scan-worker falls back cleanly for malformed VST3 moduleinfo",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("bad-vst3-moduleinfo");
     auto bundle = scratch.path / "Bad Metadata.vst3";
     fs::create_directories(bundle / "Contents" / "Resources");
@@ -399,7 +399,7 @@ TEST_CASE("pulp-scan-worker falls back cleanly for malformed VST3 moduleinfo",
 }
 
 TEST_CASE("pulp-scan-worker keeps CLAP fallback JSON scoped to the requested bundle",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("clap-siblings");
     auto target = scratch.path / "Target Clap.clap";
     auto sibling = scratch.path / "Sibling Clap.clap";
@@ -417,7 +417,7 @@ TEST_CASE("pulp-scan-worker keeps CLAP fallback JSON scoped to the requested bun
 }
 
 TEST_CASE("pulp-scan-worker reports one JSON object per target scan",
-          "[host][scan-worker][coverage]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("single-object");
     auto bundle = scratch.path / "Single.vst3";
     fs::create_directories(bundle / "Contents" / "Resources");
@@ -435,7 +435,7 @@ TEST_CASE("pulp-scan-worker reports one JSON object per target scan",
 }
 
 TEST_CASE("pulp-scan-worker matches relative bundle paths from the current directory",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("relative-vst3");
     CurrentPathGuard cwd(scratch.path);
     fs::create_directories("Relative.vst3/Contents/Resources");
@@ -453,7 +453,7 @@ TEST_CASE("pulp-scan-worker matches relative bundle paths from the current direc
 }
 
 TEST_CASE("pulp-scan-worker matches dot-prefixed bundle paths without leaking siblings",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("dot-relative-clap");
     CurrentPathGuard cwd(scratch.path);
     write_file("Target.clap", "not a dynamic library");
@@ -475,7 +475,7 @@ TEST_CASE("pulp-scan-worker matches dot-prefixed bundle paths without leaking si
 }
 
 TEST_CASE("pulp-scan-worker normalizes parent-directory segments before filtering",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("parent-segment-vst3");
     auto plugins = scratch.path / "plugins";
     auto nested = plugins / "nested";
@@ -499,7 +499,7 @@ TEST_CASE("pulp-scan-worker normalizes parent-directory segments before filterin
 }
 
 TEST_CASE("pulp-scan-worker normalizes CLAP parent segments before filtering",
-          "[host][scan-worker][coverage][requested]") {
+          "[host][scan-worker]") {
     ScratchDir scratch("parent-segment-clap");
     auto plugins = scratch.path / "plugins";
     auto nested = plugins / "nested";


### PR DESCRIPTION
## Summary

- Remove stale Catch2 selector metadata tags from 43 format, host, ship, design-import, inspector, MCP, platform, scan-cache, and scan-worker tests.
- Targeted tags only: `[coverage]`, `[codecov]`, and `[requested]`; no `[large]` tags were present in this slice.
- Preserve product/domain tags, issue IDs, test names, test bodies, visible strings, fixtures, generated artifacts, and runtime keys.

## Validation

- Release configure: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`.
- Focused Release build of all locally available affected targets completed before the rebase.
- Direct Catch2 binary runs passed for all locally available affected binaries; CMake-equivalent filters were used where needed (`pulp-test-design-import "~[network]"`, `pulp-test-host "~[flaky]"`).
- Post-rebase static checks on latest `origin/main` (`8930e5ed`) passed:
  - `git diff --check origin/main..HEAD`
  - stale-tag grep over touched files
  - selector-coupling grep over `.github`, `.shipyard`, `CMakeLists.txt`, `tools`, and non-C++/non-HPP `test` surfaces
  - `python3 tools/scripts/docs_noise_lint.py`
  - `python3 tools/scripts/hotspot_size_guard.py --warnings-as-errors --require-ceiling-reduction`
  - `python3 tools/scripts/skill_sync_check.py`
- Pre-push gates passed cleanly on branch push.

## Reviews

- RepoPrompt review: clean.
- Local autoreview: clean, no accepted/actionable findings; overall patch correctness `0.91`.
- Claude bridge review: `Clean.`

Version-Bump: sdk=skip reason="test selector tag cleanup only; no API or runtime behavior change"
Skill-Sync: skip reason="skill-sync reports no mapped paths touched"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale Catch2 selector tags across the test suite to reduce noise and keep filters focused. No code, API, or runtime behavior changes.

- **Refactors**
  - Removed `[coverage]`, `[codecov]`, and `[requested]` tags from 43 tests across format, host, ship, design-import, inspector, MCP, platform, scan-cache, and scan-worker.
  - Preserved domain tags (e.g., `[host]`, `[format]`) and issue IDs (e.g., `[issue-648]`); no changes to test logic or fixtures.

<sup>Written for commit e48a43e1a9262bdcaf11afe1bc5f0d7464a0efb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

