### PR TITLE
docs(test): clean audio signal selector tags

### DIFF
--- a/test/test_ab_compare.cpp
+++ b/test/test_ab_compare.cpp
@@ -92,7 +92,7 @@ TEST_CASE("ABCompare: clear + snapshot access", "[ui][ab-compare]") {
 }
 
 TEST_CASE("ABCompare: null store operations fail closed",
-          "[ui][ab-compare][coverage]") {
+          "[ui][ab-compare]") {
     ABCompare ab(nullptr);
 
     REQUIRE(ab.current() == ABCompare::Slot::A);
@@ -111,7 +111,7 @@ TEST_CASE("ABCompare: null store operations fail closed",
 }
 
 TEST_CASE("ABCompare: copy to same slot leaves snapshot unchanged",
-          "[ui][ab-compare][coverage]") {
+          "[ui][ab-compare]") {
     state::StateStore store;
     populate(store);
     ABCompare ab(&store);
@@ -132,7 +132,7 @@ TEST_CASE("ABCompare: copy to same slot leaves snapshot unchanged",
 }
 
 TEST_CASE("ABCompare: swapping empty and populated slots moves availability",
-          "[ui][ab-compare][coverage]") {
+          "[ui][ab-compare]") {
     state::StateStore store;
     populate(store);
     ABCompare ab(&store);

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -232,7 +232,7 @@ TEST_CASE("AsyncStream cancel drains pending writes with Closed", "[async_stream
 }
 
 TEST_CASE("AsyncStream write on pre-closed stream completes without queuing",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     backing->close();
 
@@ -325,7 +325,7 @@ TEST_CASE("AsyncStream zero-byte write dispatches completion without worker", "[
 }
 
 TEST_CASE("AsyncStream rejects null non-empty writes via callback",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
 
     AsyncStream::Options opts;
@@ -349,7 +349,7 @@ TEST_CASE("AsyncStream rejects null non-empty writes via callback",
 }
 
 TEST_CASE("AsyncStream start after stop refreshes cancellation state",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
 
@@ -381,7 +381,7 @@ TEST_CASE("AsyncStream start after stop refreshes cancellation state",
 }
 
 TEST_CASE("AsyncStream write on a closed backing stream completes without queueing",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->close();
@@ -409,7 +409,7 @@ TEST_CASE("AsyncStream write on a closed backing stream completes without queuei
 }
 
 TEST_CASE("AsyncStream write without a backing stream completes as closed",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     AsyncStream::Options opts;
     opts.auto_read = false;
     AsyncStream stream(nullptr, opts);
@@ -450,7 +450,7 @@ TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
 }
 
 TEST_CASE("AsyncStream cancellation token mirrors stream cancellation",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     AsyncStream::Options opts;
     opts.auto_read = false;
@@ -505,7 +505,7 @@ TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") 
 }
 
 TEST_CASE("AsyncStream repeated start and stop keep close callback single-shot",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
 
     AsyncStream::Options opts;
@@ -527,7 +527,7 @@ TEST_CASE("AsyncStream repeated start and stop keep close callback single-shot",
 }
 
 TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_write_chunk_limit(2);
@@ -574,7 +574,7 @@ TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
 }
 
 TEST_CASE("AsyncStream reports partial write errors and stops writer",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_write_chunk_limit(2);
@@ -615,7 +615,7 @@ TEST_CASE("AsyncStream reports partial write errors and stops writer",
 }
 
 TEST_CASE("AsyncStream read loop backs off on zero-byte reads before data",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_read_zero_ok_count(3);
@@ -644,7 +644,7 @@ TEST_CASE("AsyncStream read loop backs off on zero-byte reads before data",
 }
 
 TEST_CASE("AsyncStream read errors fire on_error and close fires once on stop",
-          "[async_stream][coverage]") {
+          "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_read_io_error(true);

--- a/test/test_audio_excerpt.cpp
+++ b/test/test_audio_excerpt.cpp
@@ -264,7 +264,7 @@ TEST_CASE("AudioSubsectionReader handles empty and past-end ranges",
 }
 
 TEST_CASE("AudioSubsectionReader zero-length ranges retain source shape",
-          "[audio][subsection][coverage]") {
+          "[audio][subsection]") {
     AudioFileData audio;
     audio.sample_rate = 96000;
     audio.channels = {{0.0f, 0.5f}, {1.0f, 1.5f}};

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -536,7 +536,7 @@ TEST_CASE("sample conversion no-ops leave sentinel outputs untouched",
 }
 
 TEST_CASE("int24 to float preserves sign-extension boundaries",
-          "[audio][convert][coverage]") {
+          "[audio][convert]") {
     const uint8_t packed[] = {
         0x01, 0x00, 0x00, // +1
         0xFE, 0xFF, 0xFF, // -2
@@ -554,7 +554,7 @@ TEST_CASE("int24 to float preserves sign-extension boundaries",
 }
 
 TEST_CASE("float to int32 scales fractional values symmetrically",
-          "[audio][convert][coverage]") {
+          "[audio][convert]") {
     const float src[] = {-0.75f, -0.25f, 0.25f, 0.75f};
     int32_t dst[4] = {};
 
@@ -567,7 +567,7 @@ TEST_CASE("float to int32 scales fractional values symmetrically",
 }
 
 TEST_CASE("float to integer conversion maps non-finite samples to silence",
-          "[audio][convert][coverage]") {
+          "[audio][convert]") {
     const float src[] = {
         std::numeric_limits<float>::quiet_NaN(),
         std::numeric_limits<float>::infinity(),
@@ -677,7 +677,7 @@ TEST_CASE("Read nonexistent file returns nullopt", "[audio][file]") {
 }
 
 TEST_CASE("WAV reader reports zero-frame metadata but rejects loading data",
-          "[audio][file][coverage]") {
+          "[audio][file]") {
     auto path = unique_temp_audio_path("_zero_frames.wav");
     std::filesystem::remove(path);
 
@@ -714,7 +714,7 @@ TEST_CASE("WAV reader reports zero-frame metadata but rejects loading data",
 }
 
 TEST_CASE("WAV reader rejects zero sample-rate metadata",
-          "[audio][file][coverage]") {
+          "[audio][file]") {
     auto path = unique_temp_audio_path("_read_zero_rate.wav");
     std::filesystem::remove(path);
 
@@ -777,7 +777,7 @@ TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empti
 }
 
 TEST_CASE("WAV writer rejects zero sample-rate data without creating a file",
-          "[audio][file][coverage]") {
+          "[audio][file]") {
     AudioFileData data;
     data.sample_rate = 0;
     data.channels = {{0.0f, 0.5f}};
@@ -790,7 +790,7 @@ TEST_CASE("WAV writer rejects zero sample-rate data without creating a file",
 }
 
 TEST_CASE("WAV and AIFF writers reject channel counts that cannot fit file headers",
-          "[audio][file][coverage]") {
+          "[audio][file]") {
     AudioFileData data;
     data.sample_rate = 44100;
     data.channels.resize(static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1u);
@@ -998,7 +998,7 @@ TEST_CASE("MemoryMappedAudioReader zero-fills destinations past EOF",
 }
 
 TEST_CASE("MemoryMappedAudioReader rejects invalid destinations before decoding",
-          "[audio][file][mmap][coverage]") {
+          "[audio][file][mmap]") {
     auto path = unique_temp_audio_path("_mmap_destinations.wav");
     std::filesystem::remove(path);
 
@@ -1332,7 +1332,7 @@ TEST_CASE("StreamingWriter writes 32-bit PCM and destructor finalizes header",
 }
 
 TEST_CASE("StreamingWriter finalizes empty files with zero data size",
-          "[audio][file][streaming][coverage]") {
+          "[audio][file][streaming]") {
     auto path = unique_temp_audio_path("_stream_empty.wav");
     std::filesystem::remove(path);
 
@@ -1352,7 +1352,7 @@ TEST_CASE("StreamingWriter finalizes empty files with zero data size",
 }
 
 TEST_CASE("StreamingWriter accumulates multiple interleaved writes before close",
-          "[audio][file][streaming][coverage]") {
+          "[audio][file][streaming]") {
     auto path = unique_temp_audio_path("_stream_multi_write.wav");
     std::filesystem::remove(path);
 
@@ -1380,7 +1380,7 @@ TEST_CASE("StreamingWriter accumulates multiple interleaved writes before close"
 }
 
 TEST_CASE("StreamingWriter successful reopen finalizes prior file and resets state",
-          "[audio][file][streaming][coverage]") {
+          "[audio][file][streaming]") {
     auto first_path = unique_temp_audio_path("_stream_reopen_first.wav");
     auto second_path = unique_temp_audio_path("_stream_reopen_second.wav");
     std::filesystem::remove(first_path);
@@ -1421,7 +1421,7 @@ TEST_CASE("StreamingWriter successful reopen finalizes prior file and resets sta
 }
 
 TEST_CASE("StreamingWriter writes deinterleaved mono through channel dispatch",
-          "[audio][file][streaming][coverage]") {
+          "[audio][file][streaming]") {
     auto path = unique_temp_audio_path("_stream_deinterleaved_mono.wav");
     std::filesystem::remove(path);
 
@@ -1488,7 +1488,7 @@ TEST_CASE("FormatRegistry exposes built-in audio codecs", "[audio][file][registr
 }
 
 TEST_CASE("FormatRegistry ignores null custom handlers",
-          "[audio][file][registry][coverage]") {
+          "[audio][file][registry]") {
     auto& registry = FormatRegistry::instance();
 
     const auto read_before = registry.supported_read_extensions();
@@ -1504,7 +1504,7 @@ TEST_CASE("FormatRegistry ignores null custom handlers",
 }
 
 TEST_CASE("FormatRegistry rejects missing and extension-only paths",
-          "[audio][file][registry][coverage]") {
+          "[audio][file][registry]") {
     auto& registry = FormatRegistry::instance();
 
     REQUIRE(registry.find_reader("") == nullptr);
@@ -1638,7 +1638,7 @@ TEST_CASE("FormatRegistry reads a valid MP3 fixture through the built-in reader"
 }
 
 TEST_CASE("FormatRegistry rejects paths without dispatchable extensions",
-          "[audio][file][registry][coverage]") {
+          "[audio][file][registry]") {
     auto& registry = FormatRegistry::instance();
 
     REQUIRE(registry.find_reader("") == nullptr);
@@ -1716,7 +1716,7 @@ TEST_CASE("FormatRegistry routes CoreAudio compressed containers on Apple",
 }
 
 TEST_CASE("CoreAudio reader decodes generated CAF fixtures on Apple",
-          "[audio][file][registry][coreaudio][coverage]") {
+          "[audio][file][registry][coreaudio]") {
     auto& registry = FormatRegistry::instance();
     auto* reader = registry.find_reader(".CAF");
     REQUIRE(reader != nullptr);
@@ -1929,7 +1929,7 @@ TEST_CASE("FormatRegistry writes and reads AIFF files", "[audio][file][registry]
 }
 
 TEST_CASE("AIFF writer rejects invalid source data without creating files",
-          "[audio][file][registry][aiff][coverage]") {
+          "[audio][file][registry][aiff]") {
     auto& registry = FormatRegistry::instance();
 
     SECTION("zero sample rate") {
@@ -2099,7 +2099,7 @@ TEST_CASE("AIFF reader skips malformed SSND chunks before valid data", "[audio][
 }
 
 TEST_CASE("AIFF reader honors SSND offsets and rejects invalid offsets",
-          "[audio][file][registry][aiff][coverage]") {
+          "[audio][file][registry][aiff]") {
     auto& registry = FormatRegistry::instance();
 
     SECTION("valid offset skips pad bytes before PCM") {
@@ -2212,7 +2212,7 @@ TEST_CASE("AIFF reader rejects invalid COMM metadata and unsupported PCM depths"
 }
 
 TEST_CASE("AIFF reader rejects malformed container headers and missing chunks",
-          "[audio][file][registry][aiff][coverage]") {
+          "[audio][file][registry][aiff]") {
     auto& registry = FormatRegistry::instance();
 
     SECTION("missing file") {
@@ -2310,7 +2310,7 @@ TEST_CASE("AIFF reader rejects malformed container headers and missing chunks",
 }
 
 TEST_CASE("AIFF reader covers padding metadata and signed extended rates",
-          "[audio][file][registry][aiff][coverage]") {
+          "[audio][file][registry][aiff]") {
     auto& registry = FormatRegistry::instance();
 
     SECTION("COMM extra bytes and odd SSND padding") {
@@ -2411,7 +2411,7 @@ TEST_CASE("AIFF reader covers padding metadata and signed extended rates",
 }
 
 TEST_CASE("AIFF writer rejects edge shapes and writes AIF extension",
-          "[audio][file][registry][aiff][coverage]") {
+          "[audio][file][registry][aiff]") {
     auto& registry = FormatRegistry::instance();
 
     SECTION("empty first channel") {

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -329,7 +329,7 @@ TEST_CASE("AudioFocusRegistry: publish with no subscribers still updates state",
 }
 
 TEST_CASE("AudioFocusRegistry: subscriber added during publish waits for next signal",
-          "[audio][focus][large]") {
+          "[audio][focus]") {
     AudioFocusRegistry::instance().reset_for_test();
 
     std::vector<AudioFocusState> first_seen;

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -183,7 +183,7 @@ TEST_CASE("audio model registry preserves direct URLs and rejects incomplete ref
 }
 
 TEST_CASE("audio model registry exposes stable CLAP model metadata",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     const auto& first = registered_models();
     const auto& second = registered_models();
     REQUIRE(&first == &second);
@@ -210,7 +210,7 @@ TEST_CASE("audio model registry exposes stable CLAP model metadata",
 }
 
 TEST_CASE("audio model registry lookup is exact and non-mutating",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     const auto& models = registered_models();
     const auto* model = find_registered_model("clap_music_audioset_v1");
     REQUIRE(model != nullptr);
@@ -229,7 +229,7 @@ TEST_CASE("audio model registry lookup is exact and non-mutating",
 }
 
 TEST_CASE("audio model registry resolves Hugging Face refs with nested files",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url("hf://org/repo/model.pt")
             == "https://huggingface.co/org/repo/resolve/main/model.pt");
     REQUIRE(resolve_checkpoint_url("hf://org/repo/checkpoints/music/model.bin")
@@ -243,7 +243,7 @@ TEST_CASE("audio model registry resolves Hugging Face refs with nested files",
 }
 
 TEST_CASE("audio model registry rejects malformed checkpoint refs",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url("hf://").empty());
     REQUIRE(resolve_checkpoint_url("hf:///repo/model.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org").empty());
@@ -259,7 +259,7 @@ TEST_CASE("audio model registry rejects malformed checkpoint refs",
 }
 
 TEST_CASE("audio model registry rejects unsafe Hugging Face file paths",
-          "[audio][tools][model-registry][coverage][requested]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url(std::string("hf://org/repo/path/")
                                    + static_cast<char>(0x1f) + "model.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo/\rmodel.pt").empty());
@@ -278,7 +278,7 @@ TEST_CASE("audio model registry rejects unsafe Hugging Face file paths",
 }
 
 TEST_CASE("audio model registry rejects unsafe Hugging Face owner and repo names",
-          "[audio][tools][model-registry][coverage][requested]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url(std::string("hf://org/re")
                                    + static_cast<char>(0x01)
                                    + "po/model.pt").empty());
@@ -289,7 +289,7 @@ TEST_CASE("audio model registry rejects unsafe Hugging Face owner and repo names
 }
 
 TEST_CASE("audio model registry preserves direct HTTP URLs byte-for-byte",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url("https://example.test/model.pt")
             == "https://example.test/model.pt");
     REQUIRE(resolve_checkpoint_url("http://example.test/model.pt")
@@ -302,7 +302,7 @@ TEST_CASE("audio model registry preserves direct HTTP URLs byte-for-byte",
 }
 
 TEST_CASE("audio model registry preserves URL bytes and rejects partial protocols",
-          "[audio][tools][model-registry][coverage]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url("https://cdn.example.test/model.pt#sha256")
             == "https://cdn.example.test/model.pt#sha256");
     REQUIRE(resolve_checkpoint_url("http://localhost:8080/checkpoints/music.pt?download=1")
@@ -318,7 +318,7 @@ TEST_CASE("audio model registry preserves URL bytes and rejects partial protocol
 }
 
 TEST_CASE("audio model registry preserves concrete Hugging Face file paths",
-          "[audio][tools][model-registry][coverage][requested]") {
+          "[audio][tools][model-registry]") {
     REQUIRE(resolve_checkpoint_url(" hf://org/repo/model.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo//").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo/\t").empty());
@@ -330,7 +330,7 @@ TEST_CASE("audio model registry preserves concrete Hugging Face file paths",
 }
 
 TEST_CASE("excerpt service validates request shape before scanning inputs",
-          "[audio][tools][excerpt-service][coverage][requested]") {
+          "[audio][tools][excerpt-service]") {
     TempDir temp;
     install_active_clap_model(temp);
     fs::create_directories(temp.path / "inputs");
@@ -1698,7 +1698,7 @@ TEST_CASE("excerpt find reports unsupported inputs after model resolution",
 }
 
 TEST_CASE("excerpt find records unreadable WAV inputs without writing dry-run bundles",
-          "[audio][tools][excerpt-service][coverage][requested]") {
+          "[audio][tools][excerpt-service]") {
     TempDir temp;
     auto checkpoint = install_active_clap_model(temp);
     auto corrupt_wav = temp.path / "corrupt.wav";
@@ -1729,7 +1729,7 @@ TEST_CASE("excerpt find records unreadable WAV inputs without writing dry-run bu
 }
 
 TEST_CASE("excerpt find reports bundle directory creation failures after ranking",
-          "[audio][tools][excerpt-service][coverage]") {
+          "[audio][tools][excerpt-service]") {
     TempDir temp;
     install_active_clap_model(temp);
     auto input = temp.path / "input.wav";
@@ -1758,7 +1758,7 @@ TEST_CASE("excerpt find reports bundle directory creation failures after ranking
 }
 
 TEST_CASE("excerpt find JSON serializer preserves failure diagnostics",
-          "[audio][tools][excerpt-service][coverage]") {
+          "[audio][tools][excerpt-service]") {
     ExcerptFindResult result;
     result.query = "missing model";
     result.requested_model_id = "clap_music_audioset_v1";
@@ -1782,7 +1782,7 @@ TEST_CASE("excerpt find JSON serializer preserves failure diagnostics",
 }
 
 TEST_CASE("excerpt find JSON serializer preserves ranked bundle metadata",
-          "[audio][tools][excerpt-service][coverage][requested]") {
+          "[audio][tools][excerpt-service]") {
     ExcerptFindResult result;
     result.ok = true;
     result.bundle_path = "/tmp/pulp-audio-bundle";
@@ -1827,7 +1827,7 @@ TEST_CASE("excerpt find JSON serializer preserves ranked bundle metadata",
 }
 
 TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
-          "[audio][tools][excerpt-service][model-registry][coverage][requested]") {
+          "[audio][tools][excerpt-service][model-registry]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
     write_text(checkpoint, "stub");
@@ -1881,7 +1881,7 @@ TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
 
 #if !defined(_WIN32)
 TEST_CASE("excerpt find rejects special files before model resolution",
-          "[audio][tools][excerpt-service][coverage][requested]") {
+          "[audio][tools][excerpt-service]") {
     TempDir temp;
     auto pipe_path = temp.path / "input.wav";
     REQUIRE(::mkfifo(pipe_path.c_str(), 0600) == 0);
@@ -1905,7 +1905,7 @@ TEST_CASE("excerpt find rejects special files before model resolution",
 #endif
 
 TEST_CASE("excerpt find writes stereo excerpt audio and manifest sidecars",
-          "[audio][tools][excerpt-service][coverage][requested]") {
+          "[audio][tools][excerpt-service]") {
     TempDir temp;
     auto checkpoint = install_active_clap_model(temp);
     auto input = temp.path / "Stereo Loop!.wav";

--- a/test/test_biquad.cpp
+++ b/test/test_biquad.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Biquad default coefficients are an identity bypass",
 }
 
 TEST_CASE("Biquad zero and negative block lengths are no-ops",
-          "[signal][biquad][coverage]") {
+          "[signal][biquad]") {
     Biquad filter;
     filter.set_coefficients(Biquad::Type::lowpass, 1000.0f, 0.707f, kSampleRate);
     filter.process(1.0f);
@@ -73,7 +73,7 @@ TEST_CASE("Biquad zero and negative block lengths are no-ops",
 }
 
 TEST_CASE("Biquad impulse responses stay pinned for representative filters",
-          "[signal][biquad][coverage]") {
+          "[signal][biquad]") {
     const std::array<BiquadImpulseCase, 8> cases{{
         {{Biquad::Type::lowpass, 600.0f, 0.707f, 0.0f}, {0.00146030f, 0.00567915f, 0.01088156f}},
         {{Biquad::Type::highpass, 4000.0f, 0.707f, 0.0f}, {0.68927898f, -0.49656902f, -0.27527589f}},
@@ -99,7 +99,7 @@ TEST_CASE("Biquad impulse responses stay pinned for representative filters",
 }
 
 TEST_CASE("Biquad extreme valid controls still produce finite sample output",
-          "[signal][biquad][coverage]") {
+          "[signal][biquad]") {
     const std::array<BiquadCase, 8> cases{{
         {Biquad::Type::lowpass, 20.0f, 0.01f, 0.0f},
         {Biquad::Type::highpass, 20000.0f, 25.0f, 0.0f},

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -324,7 +324,7 @@ TEST_CASE("output capture respects max byte limits",
 }
 
 TEST_CASE("zero max output bytes drains without capturing lines",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     std::vector<std::string> stdout_lines;
     std::vector<std::string> stderr_lines;
 
@@ -411,7 +411,7 @@ TEST_CASE("line callback buffers partial stdout without trailing newline",
 }
 
 TEST_CASE("line callback buffers partial stderr without trailing newline",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     std::vector<std::string> stderr_lines;
     ProcessOptions opts;
     opts.timeout_ms = 5000;
@@ -433,7 +433,7 @@ TEST_CASE("line callback buffers partial stderr without trailing newline",
 }
 
 TEST_CASE("move assignment transfers a running child process",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
 #ifdef _WIN32
@@ -457,7 +457,7 @@ TEST_CASE("move assignment transfers a running child process",
 }
 
 TEST_CASE("move constructor transfers a running child process",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
 #ifdef _WIN32
@@ -551,7 +551,7 @@ TEST_CASE("cancel after natural exit reports completed process result",
 
 #ifndef _WIN32
 TEST_CASE("process reuse clears timeout state from prior run",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
     ProcessOptions timeout_opts;
@@ -573,7 +573,7 @@ TEST_CASE("process reuse clears timeout state from prior run",
 }
 
 TEST_CASE("process reuse clears cancellation state from prior run",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
     REQUIRE(cp.start("sleep", {"30"}));
@@ -593,7 +593,7 @@ TEST_CASE("process reuse clears cancellation state from prior run",
 }
 
 TEST_CASE("start cancels a running child before launching replacement",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
     REQUIRE(cp.start("sleep", {"30"}));
@@ -611,7 +611,7 @@ TEST_CASE("start cancels a running child before launching replacement",
 }
 
 TEST_CASE("failed restart after completion does not retain stale child state",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
     REQUIRE(cp.start("/bin/sh", {"-c", "printf before-failure"}));
@@ -634,7 +634,7 @@ TEST_CASE("failed restart after completion does not retain stale child state",
 }
 
 TEST_CASE("argv arguments preserve empty strings spaces and punctuation",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ProcessOptions opts;
     opts.timeout_ms = 5000;
 
@@ -651,7 +651,7 @@ TEST_CASE("argv arguments preserve empty strings spaces and punctuation",
 }
 
 TEST_CASE("line callback emits empty lines and preserves order",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     std::vector<std::string> lines;
     ProcessOptions opts;
     opts.timeout_ms = 5000;
@@ -669,7 +669,7 @@ TEST_CASE("line callback emits empty lines and preserves order",
 }
 
 TEST_CASE("line callback joins a line split across drain passes",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     std::vector<std::string> lines;
     ProcessOptions opts;
     opts.timeout_ms = 5000;
@@ -689,7 +689,7 @@ TEST_CASE("line callback joins a line split across drain passes",
 }
 
 TEST_CASE("line callback honors output cap before later complete lines",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     std::vector<std::string> lines;
     ProcessOptions opts;
     opts.timeout_ms = 5000;
@@ -708,7 +708,7 @@ TEST_CASE("line callback honors output cap before later complete lines",
 }
 
 TEST_CASE("read_available_output drains stdout without losing stderr result",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
 
     ProcessOptions opts;
@@ -789,7 +789,7 @@ TEST_CASE("wait preserves output after is_running observes fast exit",
 
 #ifndef _WIN32
 TEST_CASE("ChildProcess destructor cancels a still-running POSIX child",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     {
         ChildProcess cp;
         REQUIRE(cp.start("sleep", {"10"}));
@@ -800,7 +800,7 @@ TEST_CASE("ChildProcess destructor cancels a still-running POSIX child",
 }
 
 TEST_CASE("ChildProcess move construction transfers a running POSIX child",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess source;
     REQUIRE(source.start("/bin/sh", {"-c", "printf moved"}));
 
@@ -812,7 +812,7 @@ TEST_CASE("ChildProcess move construction transfers a running POSIX child",
 }
 
 TEST_CASE("ChildProcess move assignment transfers a running POSIX child",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess source;
     REQUIRE(source.start("/bin/sh", {"-c", "printf assigned; exit 6"}));
 
@@ -825,7 +825,7 @@ TEST_CASE("ChildProcess move assignment transfers a running POSIX child",
 }
 
 TEST_CASE("cancel escalates when a POSIX child ignores SIGTERM",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
     REQUIRE(cp.start(
         "/bin/sh",
@@ -852,7 +852,7 @@ TEST_CASE("cancel escalates when a POSIX child ignores SIGTERM",
 }
 
 TEST_CASE("timeout escalates when a POSIX child ignores SIGTERM",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ProcessOptions opts;
     opts.timeout_ms = 100;
 
@@ -867,7 +867,7 @@ TEST_CASE("timeout escalates when a POSIX child ignores SIGTERM",
 }
 
 TEST_CASE("starting a POSIX replacement cancels a still-running child",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
     REQUIRE(cp.start(
         "/bin/sh",
@@ -897,7 +897,7 @@ TEST_CASE("starting a POSIX replacement cancels a still-running child",
 }
 
 TEST_CASE("starting a POSIX replacement drains a previously observed exit",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
     REQUIRE(cp.start("/bin/sh", {"-c", "printf first; exit 3"}));
 
@@ -918,7 +918,7 @@ TEST_CASE("starting a POSIX replacement drains a previously observed exit",
 }
 
 TEST_CASE("POSIX wait consumes cached fast-exit status after polling",
-          "[child_process][edge][coverage]") {
+          "[child_process][edge]") {
     ChildProcess cp;
     REQUIRE(cp.start("/bin/sh", {"-c", "printf cached-status; exit 9"}));
 

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -13,7 +13,7 @@ using namespace pulp::signal;
 using Catch::Matchers::WithinAbs;
 
 TEST_CASE("FastMath clamps saturation helper boundaries",
-          "[dsp][fast_math][coverage][large]") {
+          "[dsp][fast_math]") {
     REQUIRE_THAT(FastMath::clamp_unit(-2.0f), WithinAbs(-1.0f, 1e-6f));
     REQUIRE_THAT(FastMath::clamp_unit(-0.25f), WithinAbs(-0.25f, 1e-6f));
     REQUIRE_THAT(FastMath::clamp_unit(0.25f), WithinAbs(0.25f, 1e-6f));
@@ -21,7 +21,7 @@ TEST_CASE("FastMath clamps saturation helper boundaries",
 }
 
 TEST_CASE("FastMath soft clip covers linear and saturated regions",
-          "[dsp][fast_math][coverage][large]") {
+          "[dsp][fast_math]") {
     REQUIRE_THAT(FastMath::soft_clip(-2.0f), WithinAbs(-1.0f, 1e-6f));
     REQUIRE_THAT(FastMath::soft_clip(2.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(FastMath::soft_clip(0.0f), WithinAbs(0.0f, 1e-6f));
@@ -30,7 +30,7 @@ TEST_CASE("FastMath soft clip covers linear and saturated regions",
 }
 
 TEST_CASE("FastMath dB conversion covers silent and unity cases",
-          "[dsp][fast_math][coverage][large]") {
+          "[dsp][fast_math]") {
     REQUIRE_THAT(FastMath::db_to_gain(0.0f), WithinAbs(1.0f, 1e-5f));
     REQUIRE(FastMath::gain_to_db(0.0f) == -200.0f);
     REQUIRE(FastMath::gain_to_db(-1.0f) == -200.0f);
@@ -38,7 +38,7 @@ TEST_CASE("FastMath dB conversion covers silent and unity cases",
 }
 
 TEST_CASE("FastMath tanh covers clamps and odd symmetry",
-          "[dsp][fast_math][coverage][large]") {
+          "[dsp][fast_math]") {
     REQUIRE_THAT(FastMath::tanh(-5.0f), WithinAbs(-1.0f, 1e-6f));
     REQUIRE_THAT(FastMath::tanh(5.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(FastMath::tanh(0.0f), WithinAbs(0.0f, 1e-6f));
@@ -49,7 +49,7 @@ TEST_CASE("FastMath tanh covers clamps and odd symmetry",
 }
 
 TEST_CASE("FastMath pow and reciprocal helpers cover scalar edges",
-          "[dsp][fast_math][coverage][large]") {
+          "[dsp][fast_math]") {
     REQUIRE_THAT(FastMath::pow(0.0f, 2.0f), WithinAbs(0.0f, 1e-6f));
     REQUIRE_THAT(FastMath::pow(-2.0f, 3.0f), WithinAbs(0.0f, 1e-6f));
     REQUIRE_THAT(FastMath::pow(4.0f, 0.5f), WithinAbs(2.0f, 0.02f));
@@ -165,7 +165,7 @@ TEST_CASE("DryWetMixer latency delays dry path and reset clears history", "[dsp]
 }
 
 TEST_CASE("DryWetMixer can enable latency after prepare and leaves unmatched wet channels",
-          "[dsp][dry_wet][codecov]") {
+          "[dsp][dry_wet]") {
     DryWetMixer mixer;
     mixer.prepare(2, 4);
     mixer.set_wet_latency(1);
@@ -187,7 +187,7 @@ TEST_CASE("DryWetMixer can enable latency after prepare and leaves unmatched wet
 }
 
 TEST_CASE("DryWetMixer retuning latency clears stale delay history",
-          "[dsp][dry_wet][codecov]") {
+          "[dsp][dry_wet]") {
     DryWetMixer mixer;
     mixer.set_mix(0.0f);
     mixer.set_wet_latency(2);
@@ -225,7 +225,7 @@ TEST_CASE("DryWetMixer retuning latency clears stale delay history",
 }
 
 TEST_CASE("DryWetMixer handles nonpositive and over-channel latency edges",
-          "[dsp][dry_wet][codecov]") {
+          "[dsp][dry_wet]") {
     DryWetMixer mixer;
     mixer.set_mix(0.0f);
     mixer.set_wet_latency(-8);
@@ -276,7 +276,7 @@ TEST_CASE("DryWetMixer handles nonpositive and over-channel latency edges",
 }
 
 TEST_CASE("DryWetMixer handles empty dry pushes and grows prepared dry storage",
-          "[dsp][dry_wet][codecov]") {
+          "[dsp][dry_wet]") {
     DryWetMixer mixer;
     mixer.set_mix(0.0f);
     mixer.prepare(1, 2);
@@ -406,7 +406,7 @@ TEST_CASE("ProcessorDuplicator bounds channels and exposes channel state",
 }
 
 TEST_CASE("ProcessorDuplicator treats nonpositive channel prepares as empty",
-          "[dsp][duplicator][coverage]") {
+          "[dsp][duplicator]") {
     ProcessorDuplicator<CountingGain> dup;
     dup.prepare(-2, 44100.0f);
 
@@ -430,7 +430,7 @@ TEST_CASE("ProcessorDuplicator treats nonpositive channel prepares as empty",
 }
 
 TEST_CASE("ProcessorDuplicator skips null channels without disturbing neighbors",
-          "[dsp][duplicator][coverage]") {
+          "[dsp][duplicator]") {
     ProcessorDuplicator<CountingGain> dup;
     dup.prepare(3, 44100.0f);
     dup.for_each([](CountingGain& g) { g.gain = 2.0f; });
@@ -454,7 +454,7 @@ TEST_CASE("ProcessorDuplicator skips null channels without disturbing neighbors"
 }
 
 TEST_CASE("ProcessorDuplicator ignores null and nonpositive single-channel work",
-          "[dsp][duplicator][coverage]") {
+          "[dsp][duplicator]") {
     ProcessorDuplicator<CountingGain> dup;
     dup.prepare(2, 48000.0f);
     dup[0].gain = 3.0f;
@@ -479,7 +479,7 @@ TEST_CASE("ProcessorDuplicator ignores null and nonpositive single-channel work"
 }
 
 TEST_CASE("ProcessorDuplicator reapplies channel layout and sample rate on prepare",
-          "[dsp][duplicator][coverage]") {
+          "[dsp][duplicator]") {
     ProcessorDuplicator<CountingGain> dup;
     dup.prepare(2, 44100.0f);
     dup[0].gain = 0.5f;
@@ -515,7 +515,7 @@ TEST_CASE("ProcessorDuplicator reapplies channel layout and sample rate on prepa
 }
 
 TEST_CASE("ProcessorDuplicator reset visits every prepared channel",
-          "[dsp][duplicator][coverage]") {
+          "[dsp][duplicator]") {
     ProcessorDuplicator<CountingGain> dup;
     dup.prepare(3, 48000.0f);
 
@@ -637,7 +637,7 @@ TEST_CASE("Matrix4 scale and rotations transform vectors",
 }
 
 TEST_CASE("Matrix affine helpers compose transforms and preserve row-major layout",
-          "[dsp][matrix][coverage]") {
+          "[dsp][matrix]") {
     auto translate = translation_matrix(2.0f, -3.0f, 4.0f);
     auto scale = scale_matrix(3.0f, 4.0f, 5.0f);
     auto composed = translate * scale;
@@ -662,7 +662,7 @@ TEST_CASE("Matrix affine helpers compose transforms and preserve row-major layou
 }
 
 TEST_CASE("Matrix arithmetic covers cancellation, determinant signs, and inequality",
-          "[dsp][matrix][coverage]") {
+          "[dsp][matrix]") {
     Matrix2 a;
     a(0, 0) = 2.0f;  a(0, 1) = -3.0f;
     a(1, 0) = 4.0f;  a(1, 1) = 5.0f;

--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -27,7 +27,7 @@ using Catch::Matchers::WithinRel;
 // ── Gain and simple mixing ───────────────────────────────────────────────
 
 TEST_CASE("Gain converts dB and processes scalar and buffers",
-          "[signal][gain][codecov]") {
+          "[signal][gain]") {
     REQUIRE_THAT(db_to_linear(0.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(db_to_linear(6.0f), WithinRel(1.99526f, 1e-4f));
     REQUIRE_THAT(linear_to_db(1.0f), WithinAbs(0.0f, 1e-6f));
@@ -47,7 +47,7 @@ TEST_CASE("Gain converts dB and processes scalar and buffers",
 }
 
 TEST_CASE("SimpleMixer clamps mix and processes arrays",
-          "[signal][gain][mixer][codecov]") {
+          "[signal][gain][mixer]") {
     SimpleMixer mixer;
     mixer.set_mix(-1.0f);
     REQUIRE_THAT(mixer.mix(), WithinAbs(0.0f, 1e-6f));
@@ -70,7 +70,7 @@ TEST_CASE("SimpleMixer clamps mix and processes arrays",
 // ── WindowFunction ──────────────────────────────────────────────────────
 
 TEST_CASE("WindowFunction generates all supported window families",
-          "[signal][window][codecov]") {
+          "[signal][window]") {
     const auto rectangular = WindowFunction::generate(8, WindowFunction::Type::rectangular);
     REQUIRE(rectangular.size() == 8);
     for (float value : rectangular)
@@ -98,7 +98,7 @@ TEST_CASE("WindowFunction generates all supported window families",
 }
 
 TEST_CASE("WindowFunction applies bounded windows in place",
-          "[signal][window][codecov]") {
+          "[signal][window]") {
     float buffer[] = {1.0f, 2.0f, 3.0f, 4.0f};
     const std::vector<float> window = {1.0f, 0.5f, 0.25f};
 
@@ -113,7 +113,7 @@ TEST_CASE("WindowFunction applies bounded windows in place",
 // ── Oscillator ──────────────────────────────────────────────────────────
 
 TEST_CASE("Oscillator sine phase advances wraps and reset restores phase",
-          "[signal][oscillator][codecov]") {
+          "[signal][oscillator]") {
     Oscillator osc;
     osc.set_sample_rate(4.0f);
     osc.set_frequency(1.0f);
@@ -135,7 +135,7 @@ TEST_CASE("Oscillator sine phase advances wraps and reset restores phase",
 }
 
 TEST_CASE("Oscillator waveforms produce finite bounded startup samples",
-          "[signal][oscillator][codecov]") {
+          "[signal][oscillator]") {
     Oscillator osc;
     osc.set_sample_rate(16.0f);
     osc.set_frequency(1.0f);
@@ -157,7 +157,7 @@ TEST_CASE("Oscillator waveforms produce finite bounded startup samples",
 }
 
 TEST_CASE("Oscillator polyBLEP handles late-cycle discontinuities",
-          "[signal][oscillator][coverage]") {
+          "[signal][oscillator]") {
     Oscillator osc;
     osc.set_sample_rate(10.0f);
     osc.set_frequency(3.0f);
@@ -257,7 +257,7 @@ TEST_CASE("FirFilter empty coefficients pass samples through and reset safely",
 }
 
 TEST_CASE("FirFilter coefficient replacement clears stale delay samples",
-          "[signal][fir][coverage]") {
+          "[signal][fir]") {
     FirFilter fir;
     fir.set_coefficients({0.5f, 0.5f});
     REQUIRE_THAT(fir.process(1.0f), WithinAbs(0.5f, 1e-6f));
@@ -269,7 +269,7 @@ TEST_CASE("FirFilter coefficient replacement clears stale delay samples",
 }
 
 TEST_CASE("FirFilter highpass spectral inversion boosts center tap",
-          "[signal][fir][coverage]") {
+          "[signal][fir]") {
     auto lowpass = FirFilter::lowpass(5, 1000.0f, 48000.0f);
     auto highpass = FirFilter::highpass(5, 1000.0f, 48000.0f);
 
@@ -358,7 +358,7 @@ TEST_CASE("BallisticsFilter clamps time constants and processes buffers",
 }
 
 TEST_CASE("BallisticsFilter ignores invalid sample rates without unstable state",
-          "[signal][ballistics][coverage]") {
+          "[signal][ballistics]") {
     BallisticsFilter env;
     env.prepare(0.0f);
     env.set_attack_ms(10.0f);
@@ -372,7 +372,7 @@ TEST_CASE("BallisticsFilter ignores invalid sample rates without unstable state"
 }
 
 TEST_CASE("BallisticsFilter mode switch reports current envelope consistently",
-          "[signal][ballistics][coverage]") {
+          "[signal][ballistics]") {
     BallisticsFilter env;
     env.prepare(1000.0f);
     env.set_attack_ms(0.01f);
@@ -428,7 +428,7 @@ TEST_CASE("LogRampedValue skip advances correctly", "[signal][log_ramp]") {
 }
 
 TEST_CASE("SmoothedValue supports double ramps and terminal skips",
-          "[signal][smooth][coverage]") {
+          "[signal][smooth]") {
     SmoothedValue<double> value(2.0);
     value.set_ramp_time(0.004, 1000.0);
     value.set_target(10.0);
@@ -447,7 +447,7 @@ TEST_CASE("SmoothedValue supports double ramps and terminal skips",
 }
 
 TEST_CASE("SmoothedValue handles immediate ramps and inert skips",
-          "[signal][smooth][coverage]") {
+          "[signal][smooth]") {
     SmoothedValue<float> immediate(1.0f);
     immediate.set_ramp_time(0.0f, 48000.0f);
     immediate.set_target(4.0f);
@@ -488,7 +488,7 @@ TEST_CASE("LogRampedValue jumps for non-positive endpoints",
 }
 
 TEST_CASE("LogRampedValue ignores non-positive skips",
-          "[signal][log_ramp][coverage]") {
+          "[signal][log_ramp]") {
     LogRampedValue v(100.0f);
     v.set_ramp_time(0.01f, 1000.0f);
     v.set_target(200.0f);
@@ -503,7 +503,7 @@ TEST_CASE("LogRampedValue ignores non-positive skips",
 }
 
 TEST_CASE("LogRampedValue skip to exact ramp end snaps to target",
-          "[signal][log_ramp][coverage]") {
+          "[signal][log_ramp]") {
     LogRampedValue value(100.0f);
     value.set_ramp_time(0.004f, 1000.0f);
     value.set_target(1600.0f);
@@ -556,7 +556,7 @@ TEST_CASE("WaveShaper processes buffers in-place", "[signal][waveshaper][issue-6
 }
 
 TEST_CASE("WaveShaper invalid curve falls back to driven input",
-          "[signal][waveshaper][coverage]") {
+          "[signal][waveshaper]") {
     WaveShaper shaper;
     shaper.set_drive(1.5f);
     shaper.set_curve(static_cast<WaveShaper::Curve>(99));
@@ -638,7 +638,7 @@ TEST_CASE("ProcessorChain reset skips processors without reset methods",
 }
 
 TEST_CASE("ProcessorChain zero and negative length buffers are no-ops",
-          "[signal][chain][coverage]") {
+          "[signal][chain]") {
     ProcessorChain<ScaleBy2, AddOne> chain;
     float samples[] = {1.0f, 2.0f};
 
@@ -726,7 +726,7 @@ TEST_CASE("LookupTable indexed access clamps and zero-length buffers are no-ops"
 }
 
 TEST_CASE("LookupTable interpolates between adjacent entries",
-          "[signal][lookup][coverage]") {
+          "[signal][lookup]") {
     LookupTable table(3, 0.0f, 2.0f, [](float x) { return x * 10.0f; });
 
     REQUIRE(table.size() == 3);
@@ -736,7 +736,7 @@ TEST_CASE("LookupTable interpolates between adjacent entries",
 }
 
 TEST_CASE("LookupTable degenerate tables stay finite and indexable",
-          "[signal][lookup][coverage][large]") {
+          "[signal][lookup]") {
     LookupTable single(1, 4.0f, 9.0f, [](float x) { return x * 2.0f; });
     REQUIRE(single.size() == 1);
     REQUIRE_THAT(single.process(-100.0f), WithinAbs(8.0f, 1e-6f));
@@ -751,7 +751,7 @@ TEST_CASE("LookupTable degenerate tables stay finite and indexable",
 }
 
 TEST_CASE("LookupTable accepts reversed input ranges",
-          "[signal][lookup][coverage][large]") {
+          "[signal][lookup]") {
     LookupTable reversed(5, 1.0f, -1.0f, [](float x) { return x; });
 
     REQUIRE_THAT(reversed.process(-2.0f), WithinAbs(-1.0f, 1e-6f));
@@ -831,7 +831,7 @@ TEST_CASE("TptFilter cutoff clamping", "[signal][tpt]") {
 }
 
 TEST_CASE("TptFilter combined output resets to initial impulse response",
-          "[signal][tpt][coverage]") {
+          "[signal][tpt]") {
     TptFilter filter;
     filter.prepare(48000.0f);
     filter.set_cutoff(1200.0f);
@@ -850,7 +850,7 @@ TEST_CASE("TptFilter combined output resets to initial impulse response",
 // ── Visualization helpers ───────────────────────────────────────────────
 
 TEST_CASE("ColorMapper clamps values and switches color ramps",
-          "[signal][spectrogram][codecov]") {
+          "[signal][spectrogram]") {
     ColorMapper mapper(ColorRamp::grayscale);
 
     auto black = mapper.map(-1.0f);
@@ -880,7 +880,7 @@ TEST_CASE("ColorMapper clamps values and switches color ramps",
 }
 
 TEST_CASE("FrequencyAxis maps linear logarithmic and mel scales",
-          "[signal][spectrogram][codecov]") {
+          "[signal][spectrogram]") {
     FrequencyAxis axis;
     axis.configure(1024, 48000.0f, FrequencyScale::linear);
     REQUIRE(axis.num_bins() == 513);
@@ -905,7 +905,7 @@ TEST_CASE("FrequencyAxis maps linear logarithmic and mel scales",
 }
 
 TEST_CASE("Spectrogram helpers cover fallback ramps scales and zero-bin columns",
-          "[signal][spectrogram][coverage]") {
+          "[signal][spectrogram]") {
     ColorMapper mapper(static_cast<ColorRamp>(99));
     auto gray = mapper.map(0.5f);
     REQUIRE(gray.r == gray.g);
@@ -927,7 +927,7 @@ TEST_CASE("Spectrogram helpers cover fallback ramps scales and zero-bin columns"
 }
 
 TEST_CASE("SpectrogramBuffer scrolls columns and maps dB ranges",
-          "[signal][spectrogram][codecov]") {
+          "[signal][spectrogram]") {
     SpectrogramBuffer buffer;
     ColorMapper mapper(ColorRamp::grayscale);
     buffer.configure(3, 2);
@@ -990,7 +990,7 @@ TEST_CASE("SpectrogramBuffer clamps dimensions and tolerates missing magnitudes"
 }
 
 TEST_CASE("STFT emits frames converts dB and resets state",
-          "[signal][stft][codecov]") {
+          "[signal][stft]") {
     StftConfig config;
     config.fft_size = 256;
     config.hop_size = 64;
@@ -1026,7 +1026,7 @@ TEST_CASE("STFT emits frames converts dB and resets state",
 }
 
 TEST_CASE("AlignedBuffer resizes moves clears and copies bounded input",
-          "[signal][simd][codecov]") {
+          "[signal][simd]") {
     AlignedBuffer empty;
     REQUIRE(empty.empty());
     REQUIRE(empty.data() == nullptr);
@@ -1062,7 +1062,7 @@ TEST_CASE("AlignedBuffer resizes moves clears and copies bounded input",
 }
 
 TEST_CASE("AlignedBuffer partial copy preserves untouched suffix",
-          "[signal][simd][coverage]") {
+          "[signal][simd]") {
     AlignedBuffer buffer(4);
     float initial[] = {1.0f, 2.0f, 3.0f, 4.0f};
     buffer.copy_from(initial, 4);
@@ -1077,7 +1077,7 @@ TEST_CASE("AlignedBuffer partial copy preserves untouched suffix",
 }
 
 TEST_CASE("AlignedBuffer resize to same size preserves allocation contents",
-          "[signal][simd][coverage]") {
+          "[signal][simd]") {
     AlignedBuffer buffer(2);
     buffer[0] = 0.25f;
     buffer[1] = -0.5f;
@@ -1091,7 +1091,7 @@ TEST_CASE("AlignedBuffer resize to same size preserves allocation contents",
 }
 
 TEST_CASE("AlignedBuffer exposes const iteration and self move assignment",
-          "[signal][simd][coverage]") {
+          "[signal][simd]") {
     AlignedBuffer empty;
     empty.clear();
     REQUIRE(empty.empty());
@@ -1121,7 +1121,7 @@ TEST_CASE("AlignedBuffer exposes const iteration and self move assignment",
 }
 
 TEST_CASE("Interpolator kernels hit exact endpoints and smooth midpoints",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::linear(0.0f, 2.0f, 6.0f), WithinAbs(2.0f, 1e-6f));
     REQUIRE_THAT(Interpolator::linear(1.0f, 2.0f, 6.0f), WithinAbs(6.0f, 1e-6f));
     REQUIRE_THAT(Interpolator::linear(0.25f, 2.0f, 6.0f), WithinAbs(3.0f, 1e-6f));
@@ -1140,7 +1140,7 @@ TEST_CASE("Interpolator kernels hit exact endpoints and smooth midpoints",
 }
 
 TEST_CASE("Special functions cover sinc and Lanczos boundaries",
-          "[signal][math][coverage]") {
+          "[signal][math]") {
     REQUIRE_THAT(sinc(0.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(sinc(1.0f), WithinAbs(0.0f, 1e-6f));
 
@@ -1151,7 +1151,7 @@ TEST_CASE("Special functions cover sinc and Lanczos boundaries",
 }
 
 TEST_CASE("Special functions convert gain and MIDI reference points",
-          "[signal][math][coverage]") {
+          "[signal][math]") {
     REQUIRE_THAT(db_to_linear(0.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(linear_to_db(1.0f), WithinAbs(0.0f, 1e-6f));
     REQUIRE_THAT(linear_to_db(-1.0f), WithinAbs(-200.0f, 1e-6f));
@@ -1162,7 +1162,7 @@ TEST_CASE("Special functions convert gain and MIDI reference points",
 }
 
 TEST_CASE("Special functions wrap standard gamma and error functions",
-          "[signal][math][coverage]") {
+          "[signal][math]") {
     REQUIRE_THAT(bessel_i0(0.0f), WithinAbs(1.0f, 1e-6f));
     REQUIRE(bessel_i0(2.0f) > 2.0f);
 

--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -161,7 +161,7 @@ TEST_CASE("ActionBroadcaster handles empty actions and no-listener sends",
 }
 
 TEST_CASE("ActionBroadcaster skips empty listener callbacks",
-          "[events][async_updater][action_broadcaster][coverage]") {
+          "[events][async_updater][action_broadcaster]") {
     ActionBroadcaster broadcaster;
     std::vector<std::string> seen;
 
@@ -179,7 +179,7 @@ TEST_CASE("ActionBroadcaster skips empty listener callbacks",
 }
 
 TEST_CASE("ActionBroadcaster tolerates listener mutation during dispatch",
-          "[events][async_updater][action_broadcaster][coverage]") {
+          "[events][async_updater][action_broadcaster]") {
     ActionBroadcaster broadcaster;
     std::vector<std::string> seen;
     int second = -1;
@@ -209,7 +209,7 @@ TEST_CASE("ActionBroadcaster tolerates listener mutation during dispatch",
 }
 
 TEST_CASE("ActionBroadcaster snapshots listeners during dispatch",
-          "[events][async_updater][action_broadcaster][coverage]") {
+          "[events][async_updater][action_broadcaster]") {
     ActionBroadcaster broadcaster;
     std::vector<std::string> seen;
     int first_id = -1;
@@ -235,7 +235,7 @@ TEST_CASE("ActionBroadcaster snapshots listeners during dispatch",
 }
 
 TEST_CASE("ActionBroadcaster delays listeners added during dispatch",
-          "[events][async_updater][action_broadcaster][coverage]") {
+          "[events][async_updater][action_broadcaster]") {
     ActionBroadcaster broadcaster;
     std::vector<std::string> seen;
     int late_id = -1;
@@ -264,7 +264,7 @@ TEST_CASE("ActionBroadcaster delays listeners added during dispatch",
 }
 
 TEST_CASE("ActionBroadcaster tolerates null listeners",
-          "[events][async_updater][action_broadcaster][coverage]") {
+          "[events][async_updater][action_broadcaster]") {
     ActionBroadcaster broadcaster;
     std::vector<std::string> seen;
 
@@ -325,7 +325,7 @@ TEST_CASE("MultiTimer restart keeps one running entry per id",
 }
 
 TEST_CASE("MultiTimer supports zero and negative timer ids",
-          "[events][async_updater][multi_timer][coverage]") {
+          "[events][async_updater][multi_timer]") {
     RecordingMultiTimer timers;
 
     timers.start_timer(0, 1);
@@ -340,7 +340,7 @@ TEST_CASE("MultiTimer supports zero and negative timer ids",
 }
 
 TEST_CASE("MultiTimer restart after stop_all works for existing entries",
-          "[events][async_updater][multi_timer][coverage]") {
+          "[events][async_updater][multi_timer]") {
     RecordingMultiTimer timers;
 
     timers.start_timer(3, 10);

--- a/test/test_events_timer_helpers.cpp
+++ b/test/test_events_timer_helpers.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Timer one-shot deactivates after firing and can be restarted",
 }
 
 TEST_CASE("Timer start is idempotent while active",
-          "[events][timer][coverage]") {
+          "[events][timer]") {
     EventLoop loop;
     std::atomic<int> calls{0};
     Timer timer(loop, 10ms, [&] { calls.fetch_add(1); }, false);
@@ -63,7 +63,7 @@ TEST_CASE("Timer start is idempotent while active",
 }
 
 TEST_CASE("Timer stop cancels queued one-shot callback",
-          "[events][timer][coverage]") {
+          "[events][timer]") {
     EventLoop loop;
     std::atomic<int> calls{0};
     Timer timer(loop, 25ms, [&] { calls.fetch_add(1); }, false);
@@ -78,7 +78,7 @@ TEST_CASE("Timer stop cancels queued one-shot callback",
 }
 
 TEST_CASE("Timer interval can be changed before restart",
-          "[events][timer][coverage]") {
+          "[events][timer]") {
     EventLoop loop;
     std::atomic<int> calls{0};
     Timer timer(loop, 100ms, [&] { calls.fetch_add(1); }, false);
@@ -93,7 +93,7 @@ TEST_CASE("Timer interval can be changed before restart",
 }
 
 TEST_CASE("Timer with empty callback still tracks one-shot lifecycle",
-          "[events][timer][coverage]") {
+          "[events][timer]") {
     EventLoop loop;
     Timer timer(loop, 5ms, {}, false);
 
@@ -103,7 +103,7 @@ TEST_CASE("Timer with empty callback still tracks one-shot lifecycle",
 }
 
 TEST_CASE("Timer restart invalidates stale queued dispatches",
-          "[events][timer][coverage][issue-687]") {
+          "[events][timer][issue-687]") {
     EventLoop loop;
     std::atomic<int> calls{0};
     Timer timer(loop, 75ms, [&] { calls.fetch_add(1); }, false);
@@ -127,7 +127,7 @@ TEST_CASE("Timer restart invalidates stale queued dispatches",
 }
 
 TEST_CASE("Repeating timer can stop itself from its callback",
-          "[events][timer][coverage]") {
+          "[events][timer]") {
     EventLoop loop;
     std::atomic<int> calls{0};
     Timer* self = nullptr;

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -19,7 +19,7 @@ TEST_CASE("FastMath tanh approximation", "[signal][fast_math]") {
 }
 
 TEST_CASE("FastMath tanh clamps exactly beyond approximation range",
-          "[signal][fast_math][coverage]") {
+          "[signal][fast_math]") {
     REQUIRE(FastMath::tanh(-100.0f) == -1.0f);
     REQUIRE(FastMath::tanh(-4.0001f) == -1.0f);
     REQUIRE(FastMath::tanh(4.0001f) == 1.0f);
@@ -59,7 +59,7 @@ TEST_CASE("FastMath exp2 approximation", "[signal][fast_math]") {
 }
 
 TEST_CASE("FastMath exp2 preserves ordering across integer boundaries",
-          "[signal][fast_math][coverage]") {
+          "[signal][fast_math]") {
     const float below = FastMath::exp2(1.999f);
     const float exact = FastMath::exp2(2.0f);
     const float above = FastMath::exp2(2.001f);
@@ -70,7 +70,7 @@ TEST_CASE("FastMath exp2 preserves ordering across integer boundaries",
 }
 
 TEST_CASE("FastMath exp2 covers fractional octaves across zero",
-          "[signal][fast_math][coverage][large]") {
+          "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::exp2(-0.5f), WithinAbs(std::exp2(-0.5f), 0.01f));
     REQUIRE_THAT(FastMath::exp2(1.25f), WithinRel(std::exp2(1.25f), 0.01f));
     REQUIRE_THAT(FastMath::exp2(7.75f), WithinRel(std::exp2(7.75f), 0.01f));
@@ -84,14 +84,14 @@ TEST_CASE("FastMath log2 approximation", "[signal][fast_math]") {
 }
 
 TEST_CASE("FastMath log2 handles normalized power-of-two range",
-          "[signal][fast_math][coverage]") {
+          "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::log2(0.25f), WithinAbs(-2.0f, 0.02f));
     REQUIRE_THAT(FastMath::log2(16.0f), WithinAbs(4.0f, 0.02f));
     REQUIRE_THAT(FastMath::log2(1024.0f), WithinAbs(10.0f, 0.02f));
 }
 
 TEST_CASE("FastMath log2 tracks mantissa-heavy values",
-          "[signal][fast_math][coverage][large]") {
+          "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::log2(1.5f), WithinAbs(std::log2(1.5f), 0.02f));
     REQUIRE_THAT(FastMath::log2(3.25f), WithinAbs(std::log2(3.25f), 0.04f));
     REQUIRE_THAT(FastMath::log2(96.0f), WithinAbs(std::log2(96.0f), 0.03f));
@@ -114,7 +114,7 @@ TEST_CASE("FastMath pow and reciprocal guard edge inputs",
 }
 
 TEST_CASE("FastMath pow handles fractional and identity exponents",
-          "[signal][fast_math][coverage][large]") {
+          "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::pow(9.0f, 0.5f), WithinAbs(3.0f, 0.08f));
     REQUIRE_THAT(FastMath::pow(7.0f, 0.0f), WithinAbs(1.0f, 0.02f));
     REQUIRE_THAT(FastMath::pow(1.0f, 32.0f), WithinAbs(1.0f, 0.02f));
@@ -167,14 +167,14 @@ TEST_CASE("FastMath clamp_unit", "[signal][fast_math]") {
 }
 
 TEST_CASE("FastMath tanh is odd within unclamped range",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     for (float value : {0.125f, 0.75f, 2.5f, 3.75f}) {
         REQUIRE_THAT(FastMath::tanh(value), WithinAbs(-FastMath::tanh(-value), 1e-6f));
     }
 }
 
 TEST_CASE("FastMath exp2 and log2 round trip powers",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     for (float exponent : {-3.0f, -1.0f, 0.0f, 2.0f, 5.0f}) {
         const float value = FastMath::exp2(exponent);
         REQUIRE_THAT(FastMath::log2(value), WithinAbs(exponent, 0.02f));
@@ -182,7 +182,7 @@ TEST_CASE("FastMath exp2 and log2 round trip powers",
 }
 
 TEST_CASE("FastMath gain conversion round trips common levels",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     for (float db : {-24.0f, -12.0f, 0.0f, 12.0f}) {
         REQUIRE_THAT(FastMath::gain_to_db(FastMath::db_to_gain(db)),
                      WithinAbs(db, 1.2f));
@@ -190,7 +190,7 @@ TEST_CASE("FastMath gain conversion round trips common levels",
 }
 
 TEST_CASE("FastMath soft clip is monotonic across control points",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     float previous = FastMath::soft_clip(-2.0f);
     for (float value : {-1.5f, -1.0f, -0.25f, 0.0f, 0.25f, 1.0f, 1.5f, 2.0f}) {
         const float clipped = FastMath::soft_clip(value);
@@ -200,7 +200,7 @@ TEST_CASE("FastMath soft clip is monotonic across control points",
 }
 
 TEST_CASE("FastMath exp2 is monotonic across fractional octaves",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     float previous = FastMath::exp2(-2.0f);
     for (float exponent : {-1.5f, -0.25f, 0.0f, 0.5f, 1.25f, 2.0f}) {
         float next = FastMath::exp2(exponent);
@@ -210,7 +210,7 @@ TEST_CASE("FastMath exp2 is monotonic across fractional octaves",
 }
 
 TEST_CASE("FastMath log2 orders common gain ratios",
-          "[signal][fast_math][codecov]") {
+          "[signal][fast_math]") {
     REQUIRE(FastMath::log2(0.25f) < FastMath::log2(0.5f));
     REQUIRE(FastMath::log2(0.5f) < FastMath::log2(1.0f));
     REQUIRE(FastMath::log2(1.0f) < FastMath::log2(2.0f));

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -53,7 +53,7 @@ TEST_CASE("FilterDesign allpass passes DC", "[signal][filter_design]") {
 }
 
 TEST_CASE("FilterDesign allpass keeps unity magnitude at Nyquist",
-          "[signal][filter_design][coverage]") {
+          "[signal][filter_design]") {
     auto c = FilterDesign::allpass(5000.0f, 0.9f, 48000.0f);
     require_finite(c);
     REQUIRE_THAT(std::abs(nyquist_gain(c)), WithinAbs(1.0f, 0.01f));
@@ -157,7 +157,7 @@ TEST_CASE("FilterDesign butterworth edge orders are bounded and finite",
 }
 
 TEST_CASE("FilterDesign lowpass and highpass have complementary Nyquist behavior",
-          "[signal][filter_design][codecov]") {
+          "[signal][filter_design]") {
     auto low = FilterDesign::lowpass(1800.0f, 0.707f, 48000.0f);
     auto high = FilterDesign::highpass(1800.0f, 0.707f, 48000.0f);
 
@@ -168,7 +168,7 @@ TEST_CASE("FilterDesign lowpass and highpass have complementary Nyquist behavior
 }
 
 TEST_CASE("FilterDesign allpass keeps unity gain at DC and Nyquist",
-          "[signal][filter_design][codecov]") {
+          "[signal][filter_design]") {
     for (float q : {0.5f, 0.707f, 2.0f}) {
         auto c = FilterDesign::allpass(3200.0f, q, 48000.0f);
         require_finite(c);
@@ -178,7 +178,7 @@ TEST_CASE("FilterDesign allpass keeps unity gain at DC and Nyquist",
 }
 
 TEST_CASE("FilterDesign notch preserves endpoint gains across Q values",
-          "[signal][filter_design][codecov]") {
+          "[signal][filter_design]") {
     for (float q : {0.25f, 1.0f, 4.0f}) {
         auto c = FilterDesign::notch(2400.0f, q, 48000.0f);
         require_finite(c);
@@ -188,7 +188,7 @@ TEST_CASE("FilterDesign notch preserves endpoint gains across Q values",
 }
 
 TEST_CASE("FilterDesign butterworth odd orders truncate to complete biquads",
-          "[signal][filter_design][codecov]") {
+          "[signal][filter_design]") {
     auto low = FilterDesign::butterworth_lowpass(5, 1600.0f, 48000.0f);
     auto high = FilterDesign::butterworth_highpass(5, 1600.0f, 48000.0f);
     REQUIRE(low.size() == 2);
@@ -205,7 +205,7 @@ TEST_CASE("FilterDesign butterworth odd orders truncate to complete biquads",
 }
 
 TEST_CASE("FilterDesign near-Nyquist biquads remain finite",
-          "[signal][filter_design][coverage][large]") {
+          "[signal][filter_design]") {
     const float sample_rate = 48000.0f;
     const float near_nyquist = 0.49f * sample_rate;
 

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -117,21 +117,21 @@ TEST_CASE("i18n argument substitution also applies to missing-key fallback",
 }
 
 TEST_CASE("i18n argument substitution handles adjacent placeholders",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("compact", "{0}{1}{0}");
     REQUIRE(strings.translate("compact", {"A", "B"}) == "ABA");
 }
 
 TEST_CASE("i18n argument substitution treats double braces as literal text",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("template", "{{0}} {0}");
     REQUIRE(strings.translate("template", {"value"}) == "{value} value");
 }
 
 TEST_CASE("i18n argument substitution applies later indexes after earlier replacements",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("nested", "{0} {1}");
     REQUIRE(strings.translate("nested", {"{1}", "done"}) == "done done");
@@ -234,7 +234,7 @@ TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
 }
 
 TEST_CASE("i18n .strings parser accepts keys and values with spaces",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -249,7 +249,7 @@ TEST_CASE("i18n .strings parser accepts keys and values with spaces",
 }
 
 TEST_CASE("i18n .strings parser keeps entries without semicolons",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -262,7 +262,7 @@ TEST_CASE("i18n .strings parser keeps entries without semicolons",
 }
 
 TEST_CASE("i18n .strings parser permits empty keys",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -350,7 +350,7 @@ TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
 }
 
 TEST_CASE("i18n .po parser replaces duplicate msgids",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -367,7 +367,7 @@ TEST_CASE("i18n .po parser replaces duplicate msgids",
 }
 
 TEST_CASE("i18n .po parser ignores msgids without translations",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -383,7 +383,7 @@ TEST_CASE("i18n .po parser ignores msgids without translations",
 }
 
 TEST_CASE("i18n .po parser accepts empty msgid continuations",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -578,7 +578,7 @@ TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
 }
 
 TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -592,7 +592,7 @@ TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
 }
 
 TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -606,7 +606,7 @@ TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
 }
 
 TEST_CASE("i18n JSON parser tolerates missing closing brace after entries",
-          "[runtime][i18n][large]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Interpolator hermite impulse response spans adjacent samples", "[sign
 }
 
 TEST_CASE("Interpolator hermite preserves affine sample ramps",
-          "[signal][interp][coverage]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::hermite(0.25f, -1.0f, 1.0f, 3.0f, 5.0f),
                  WithinAbs(1.5f, 0.001f));
     REQUIRE_THAT(Interpolator::hermite(0.75f, -1.0f, 1.0f, 3.0f, 5.0f),
@@ -67,7 +67,7 @@ TEST_CASE("Interpolator lagrange for linear data", "[signal][interp]") {
 }
 
 TEST_CASE("Interpolator lagrange preserves quadratic curves",
-          "[signal][interp][coverage]") {
+          "[signal][interp]") {
     // Samples from f(x) = x^2 at x=-1,0,1,2.
     REQUIRE_THAT(Interpolator::lagrange(0.25f, 1.0f, 0.0f, 1.0f, 4.0f),
                  WithinAbs(0.0625f, 0.001f));
@@ -110,13 +110,13 @@ TEST_CASE("Interpolator sinc6 impulse response is symmetric at midpoint", "[sign
 }
 
 TEST_CASE("Interpolator linear preserves constants outside the unit interval",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::linear(-2.0f, -0.75f, -0.75f), WithinAbs(-0.75f, 1e-6f));
     REQUIRE_THAT(Interpolator::linear(3.0f, 4.5f, 4.5f), WithinAbs(4.5f, 1e-6f));
 }
 
 TEST_CASE("Interpolator hermite reproduces quadratic midpoint samples",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::hermite(0.5f, 1.0f, 0.0f, 1.0f, 4.0f),
                  WithinAbs(0.25f, 1e-6f));
     REQUIRE_THAT(Interpolator::hermite(0.25f, 4.0f, 1.0f, 0.0f, 1.0f),
@@ -124,7 +124,7 @@ TEST_CASE("Interpolator hermite reproduces quadratic midpoint samples",
 }
 
 TEST_CASE("Interpolator lagrange reproduces cubic samples",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::lagrange(0.25f, -1.0f, 0.0f, 1.0f, 8.0f),
                  WithinAbs(0.015625f, 1e-6f));
     REQUIRE_THAT(Interpolator::lagrange(0.75f, -8.0f, -1.0f, 0.0f, 1.0f),
@@ -132,7 +132,7 @@ TEST_CASE("Interpolator lagrange reproduces cubic samples",
 }
 
 TEST_CASE("Interpolator sinc6 zero input remains silent",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     for (float frac : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
         const float result = Interpolator::sinc6(frac, 0.0f, 0.0f, 0.0f,
                                                  0.0f, 0.0f, 0.0f);
@@ -142,7 +142,7 @@ TEST_CASE("Interpolator sinc6 zero input remains silent",
 }
 
 TEST_CASE("Interpolator hermite preserves linear ramps",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     REQUIRE_THAT(Interpolator::hermite(0.25f, -1.0f, 0.0f, 1.0f, 2.0f),
                  WithinAbs(0.25f, 1e-6f));
     REQUIRE_THAT(Interpolator::hermite(0.75f, 2.0f, 4.0f, 6.0f, 8.0f),
@@ -150,7 +150,7 @@ TEST_CASE("Interpolator hermite preserves linear ramps",
 }
 
 TEST_CASE("Interpolator sinc6 alternating samples stay finite",
-          "[signal][interp][codecov]") {
+          "[signal][interp]") {
     for (float frac : {0.125f, 0.375f, 0.625f, 0.875f}) {
         const float result = Interpolator::sinc6(frac, -1.0f, 1.0f, -1.0f,
                                                  1.0f, -1.0f, 1.0f);

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -86,7 +86,7 @@ TEST_CASE("JsonRpcPeer request/response over an in-memory channel", "[json_rpc]"
 }
 
 TEST_CASE("JsonRpcError factories expose spec codes and messages",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     const auto parse = JsonRpcError::parse_error();
     const auto invalid = JsonRpcError::invalid_request();
     const auto params = JsonRpcError::invalid_params();
@@ -104,7 +104,7 @@ TEST_CASE("JsonRpcError factories expose spec codes and messages",
 }
 
 TEST_CASE("JsonRpcResult factories separate success payloads from failures",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     const auto ok = JsonRpcResult::ok(R"({"ready":true})");
     REQUIRE(ok.result_json == R"({"ready":true})");
     REQUIRE_FALSE(ok.error.has_value());
@@ -173,7 +173,7 @@ TEST_CASE("JsonRpcPeer fires notification handler and expects no response", "[js
 }
 
 TEST_CASE("JsonRpcPeer delivers empty notification params when omitted",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer server(*pair.second);
 
@@ -245,7 +245,7 @@ TEST_CASE("JsonRpcPeer unregisters methods and notifications", "[json_rpc]") {
 }
 
 TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -269,7 +269,7 @@ TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
 }
 
 TEST_CASE("JsonRpcPeer destruction clears the channel message callback",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -390,7 +390,7 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
 }
 
 TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
 
@@ -405,7 +405,7 @@ TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
 }
 
 TEST_CASE("JsonRpcPeer destructor detaches its message callback",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     std::string reply;
     pair.second->on_message([&](const Message& message) {
@@ -421,7 +421,7 @@ TEST_CASE("JsonRpcPeer destructor detaches its message callback",
 }
 
 TEST_CASE("JsonRpcPeer omits params for empty request payloads",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -447,7 +447,7 @@ TEST_CASE("JsonRpcPeer omits params for empty request payloads",
 }
 
 TEST_CASE("JsonRpcPeer preserves string request ids in responses",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -469,7 +469,7 @@ TEST_CASE("JsonRpcPeer preserves string request ids in responses",
 }
 
 TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -499,7 +499,7 @@ TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
 }
 
 TEST_CASE("JsonRpcPeer defaults missing incoming error fields",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -527,7 +527,7 @@ TEST_CASE("JsonRpcPeer defaults missing incoming error fields",
 }
 
 TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -553,7 +553,7 @@ TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
 }
 
 TEST_CASE("JsonRpcPeer rejects requests with non-string method names",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -578,7 +578,7 @@ TEST_CASE("JsonRpcPeer rejects requests with non-string method names",
 }
 
 TEST_CASE("JsonRpcPeer ignores notifications with non-string method names",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -600,7 +600,7 @@ TEST_CASE("JsonRpcPeer ignores notifications with non-string method names",
 }
 
 TEST_CASE("JsonRpcPeer unregisters a replacement handler cleanly",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -633,7 +633,7 @@ TEST_CASE("JsonRpcPeer unregisters a replacement handler cleanly",
 }
 
 TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callbacks",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -658,7 +658,7 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
 }
 
 TEST_CASE("JsonRpcPeer forwards scalar and object params unchanged",
-          "[json_rpc][coverage][large]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -689,7 +689,7 @@ TEST_CASE("JsonRpcPeer forwards scalar and object params unchanged",
 }
 
 TEST_CASE("JsonRpcPeer ignores inert objects and unknown notifications without replies",
-          "[json_rpc][coverage][large]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -707,7 +707,7 @@ TEST_CASE("JsonRpcPeer ignores inert objects and unknown notifications without r
 }
 
 TEST_CASE("JsonRpcPeer rejects invalid request envelopes before dispatch",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -736,7 +736,7 @@ TEST_CASE("JsonRpcPeer rejects invalid request envelopes before dispatch",
 }
 
 TEST_CASE("JsonRpcPeer destructor releases the channel callback",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -769,7 +769,7 @@ TEST_CASE("JsonRpcPeer destructor releases the channel callback",
 }
 
 TEST_CASE("JsonRpcPeer consumes pending callbacks after the first response",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -798,7 +798,7 @@ TEST_CASE("JsonRpcPeer consumes pending callbacks after the first response",
 }
 
 TEST_CASE("JsonRpcPeer destructor clears the channel message callback",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     {
@@ -815,7 +815,7 @@ TEST_CASE("JsonRpcPeer destructor clears the channel message callback",
 }
 
 TEST_CASE("JsonRpcPeer tolerates sparse error responses",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -843,7 +843,7 @@ TEST_CASE("JsonRpcPeer tolerates sparse error responses",
 }
 
 TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -872,7 +872,7 @@ TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
 }
 
 TEST_CASE("JsonRpcPeer destructor clears the channel message handler",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -899,7 +899,7 @@ TEST_CASE("JsonRpcPeer destructor clears the channel message handler",
 }
 
 TEST_CASE("JsonRpcPeer accepts binary JSON and default error envelopes",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -946,7 +946,7 @@ TEST_CASE("JsonRpcPeer accepts binary JSON and default error envelopes",
 }
 
 TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> outbound;
@@ -976,7 +976,7 @@ TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
 }
 
 TEST_CASE("JsonRpcPeer escapes outbound method and notification names",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -1010,7 +1010,7 @@ TEST_CASE("JsonRpcPeer escapes outbound method and notification names",
 }
 
 TEST_CASE("JsonRpcPeer drops invalid notifications without invoking handlers",
-          "[json_rpc][coverage]") {
+          "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string unexpected_reply;

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -262,13 +262,13 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
 }
 
 TEST_CASE("BigInteger invalid decimal and hex parse as zero",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     REQUIRE(BigInteger::from_string("not-a-number").is_zero());
     REQUIRE(BigInteger::from_hex("not-hex").is_zero());
     REQUIRE(BigInteger::from_string("").is_zero());
 }
 
-TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][coverage][issue-656]") {
+TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][issue-656]") {
     auto value = BigInteger::from_hex("0100");
     REQUIRE(value.to_string() == "256");
     REQUIRE(value.to_hex() == "0100");
@@ -290,7 +290,7 @@ TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][co
 }
 
 TEST_CASE("BigInteger hex bit count and copy assignment",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     auto value = BigInteger::from_hex("0100");
     REQUIRE(value.to_hex() == "0100");
     REQUIRE(value.bit_count() == 9);
@@ -302,7 +302,7 @@ TEST_CASE("BigInteger hex bit count and copy assignment",
 }
 
 TEST_CASE("BigInteger move construction and move assignment leave values usable",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     BigInteger source(1234);
     BigInteger moved(std::move(source));
     REQUIRE(moved.to_string() == "1234");
@@ -315,7 +315,7 @@ TEST_CASE("BigInteger move construction and move assignment leave values usable"
 }
 
 TEST_CASE("BigInteger self assignment and identity arithmetic stay stable",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     BigInteger value(144);
     auto& same = value;
 
@@ -332,7 +332,7 @@ TEST_CASE("BigInteger self assignment and identity arithmetic stay stable",
 }
 
 TEST_CASE("BigInteger parses case-insensitive hex and decimal leading zeroes",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     auto hex = BigInteger::from_hex("00ff");
     REQUIRE(hex.to_string() == "255");
     REQUIRE(hex.to_hex() == "FF");
@@ -343,7 +343,7 @@ TEST_CASE("BigInteger parses case-insensitive hex and decimal leading zeroes",
 }
 
 TEST_CASE("BigInteger uint64 constructor preserves unsigned high values",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     BigInteger max_value(std::numeric_limits<std::uint64_t>::max());
 
     REQUIRE(max_value.to_string() == "18446744073709551615");
@@ -353,7 +353,7 @@ TEST_CASE("BigInteger uint64 constructor preserves unsigned high values",
 }
 
 TEST_CASE("BigInteger ordering covers equal and greater comparisons",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     BigInteger low(99);
     BigInteger same_low(99);
     BigInteger high(100);
@@ -366,7 +366,7 @@ TEST_CASE("BigInteger ordering covers equal and greater comparisons",
 }
 
 TEST_CASE("BigInteger comparison covers equal and greater-than paths",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     BigInteger low(255);
     auto same = BigInteger::from_hex("FF");
     BigInteger high(256);
@@ -380,7 +380,7 @@ TEST_CASE("BigInteger comparison covers equal and greater-than paths",
 }
 
 TEST_CASE("BigInteger preserves negative decimal values through arithmetic",
-          "[crypto][bigint][coverage]") {
+          "[crypto][bigint]") {
     auto negative = BigInteger::from_string("-42");
     auto positive = BigInteger(50);
 
@@ -407,7 +407,7 @@ TEST_CASE("LicenseValidator rejects undecodable payload", "[crypto][license]") {
 }
 
 TEST_CASE("LicenseValidator rejects impossible base64 payload lengths",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     REQUIRE(validator.validate("A.sig") == LicenseStatus::InvalidFormat);
     REQUIRE_FALSE(validator.validate_and_parse("A.sig"));
@@ -426,7 +426,7 @@ TEST_CASE("LicenseValidator parse payload", "[crypto][license]") {
 }
 
 TEST_CASE("LicenseValidator invalid public key keeps valid payload unsigned",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     validator.set_public_key("not a pem public key");
 
@@ -450,7 +450,7 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
 }
 
 TEST_CASE("LicenseValidator validate_and_parse includes optional machine and expiry fields",
-          "[crypto][license][coverage][issue-656]") {
+          "[crypto][license][issue-656]") {
     LicenseValidator validator;
 
     std::string payload = "{\"product_id\":\"PulpSuite\",\"email\":\"user@example.com\","
@@ -492,7 +492,7 @@ TEST_CASE("LicenseValidator validate_and_parse rejects malformed numeric timesta
 }
 
 TEST_CASE("LicenseValidator parse_payload handles optional fields and bad integers",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
 
     std::string payload =
@@ -535,7 +535,7 @@ TEST_CASE("LicenseValidator file not found", "[crypto][license]") {
 }
 
 TEST_CASE("LicenseValidator empty license file is invalid format",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     TemporaryFile tmp(".license");
 
     LicenseValidator validator;
@@ -558,7 +558,7 @@ TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license
 }
 
 TEST_CASE("LicenseValidator validate_file trims repeated CRLF endings",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     TemporaryFile tmp(".license");
     std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
     std::string key = base64_encode(payload) + "." + base64_encode("signature") + "\r\n\n";
@@ -596,7 +596,7 @@ TEST_CASE("LicenseValidator validate rejects empty payload section",
 }
 
 TEST_CASE("LicenseValidator validate rejects an empty signature section",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpSynth\"}";
 
@@ -604,14 +604,14 @@ TEST_CASE("LicenseValidator validate rejects an empty signature section",
 }
 
 TEST_CASE("LicenseValidator validate rejects malformed signature encoding",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
     REQUIRE(validator.validate(base64_encode(payload) + ".###") == LicenseStatus::InvalidSignature);
 }
 
 TEST_CASE("LicenseValidator validate rejects decoded payload missing product id",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"email\":\"user@example.com\",\"issued\":1700000000}";
     REQUIRE(validator.validate(base64_encode(payload) + "." + base64_encode("sig")) ==
@@ -620,7 +620,7 @@ TEST_CASE("LicenseValidator validate rejects decoded payload missing product id"
 }
 
 TEST_CASE("LicenseValidator validate_and_parse accepts minimal product payload",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     auto info = validator.validate_and_parse(base64_encode("{\"product_id\":\"PulpMini\"}") + ".sig");
     REQUIRE(info.has_value());
@@ -631,7 +631,7 @@ TEST_CASE("LicenseValidator validate_and_parse accepts minimal product payload",
 }
 
 TEST_CASE("LicenseValidator validate_and_parse ignores an empty signature section",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     auto info = validator.validate_and_parse(base64_encode("{\"product_id\":\"PulpParseOnly\"}") + ".");
 
@@ -640,7 +640,7 @@ TEST_CASE("LicenseValidator validate_and_parse ignores an empty signature sectio
 }
 
 TEST_CASE("LicenseValidator validate_and_parse keeps first dotted payload split",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpDot\"}";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig.with.dots");
@@ -650,7 +650,7 @@ TEST_CASE("LicenseValidator validate_and_parse keeps first dotted payload split"
 }
 
 TEST_CASE("LicenseValidator validate_and_parse rejects partial optional integers",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpMini\",\"issued\":123junk,\"expiry\":not-a-number}";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
@@ -658,7 +658,7 @@ TEST_CASE("LicenseValidator validate_and_parse rejects partial optional integers
 }
 
 TEST_CASE("LicenseValidator validate_and_parse accepts whitespace after optional integers",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpMini\",\"issued\":123 \t,\"expiry\":456 }";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
@@ -674,7 +674,7 @@ TEST_CASE("LicenseValidator validate_and_parse accepts whitespace after optional
 }
 
 TEST_CASE("LicenseValidator validate_and_parse accepts whitespace before optional integers",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     std::string payload = "{\"product_id\":\"PulpMini\",\"issued\": \n\t123,\"expiry\": 456}";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
@@ -688,7 +688,7 @@ TEST_CASE("LicenseValidator validate_and_parse accepts whitespace before optiona
 }
 
 TEST_CASE("LicenseValidator validate_file preserves interior whitespace",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     TemporaryFile tmp(".license");
     std::string payload = "{\"product_id\":\"PulpSynth\"}";
     std::string key = base64_encode(payload) + "." + base64_encode("sig") + "\n\n";
@@ -704,7 +704,7 @@ TEST_CASE("LicenseValidator validate_file preserves interior whitespace",
 }
 
 TEST_CASE("LicenseValidator validate_file preserves leading whitespace",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     TemporaryFile tmp(".license");
     std::string payload = "{\"product_id\":\"PulpSynth\"}";
     std::string key = " " + base64_encode(payload) + "." + base64_encode("sig") + "\n";
@@ -720,7 +720,7 @@ TEST_CASE("LicenseValidator validate_file preserves leading whitespace",
 }
 
 TEST_CASE("LicenseValidator machine check accepts copied machine id",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseValidator validator;
     LicenseInfo info;
     info.machine_id = std::string(machine_id());
@@ -728,7 +728,7 @@ TEST_CASE("LicenseValidator machine check accepts copied machine id",
 }
 
 TEST_CASE("LicenseGenerator emits nullopt for empty private key with complete info",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseInfo info;
     info.product_id = "PulpSynth";
     info.user_email = "user@example.com";
@@ -742,7 +742,7 @@ TEST_CASE("LicenseGenerator emits nullopt for empty private key with complete in
 }
 
 TEST_CASE("LicenseGenerator signs complete licenses that validate on this machine",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseInfo info;
     info.product_id = "PulpSynth";
     info.user_email = "user@example.com";
@@ -781,7 +781,7 @@ TEST_CASE("LicenseGenerator signs complete licenses that validate on this machin
 }
 
 TEST_CASE("LicenseValidator reports signed expiry and machine mismatch statuses",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseGenerator generator;
     generator.set_private_key(kTestPrivateKey);
 
@@ -807,7 +807,7 @@ TEST_CASE("LicenseValidator reports signed expiry and machine mismatch statuses"
 }
 
 TEST_CASE("LicenseGenerator signs minimal licenses without optional fields",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseInfo info;
     info.product_id = "PulpMiniSigned";
     info.issued_timestamp = 1700000000;
@@ -831,7 +831,7 @@ TEST_CASE("LicenseGenerator signs minimal licenses without optional fields",
 }
 
 TEST_CASE("LicenseValidator rejects tampered signed payloads",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseInfo info;
     info.product_id = "PulpTamper";
     info.issued_timestamp = 1700000000;
@@ -861,7 +861,7 @@ TEST_CASE("LicenseValidator rejects tampered signed payloads",
 }
 
 TEST_CASE("LicenseValidator validate_file accepts signed keys with trailing CRLF",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     LicenseInfo info;
     info.product_id = "PulpFileSigned";
     info.issued_timestamp = 1700000000;
@@ -884,14 +884,14 @@ TEST_CASE("LicenseValidator validate_file accepts signed keys with trailing CRLF
 }
 
 TEST_CASE("OnlineActivation treats empty server URL as failed request",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     REQUIRE_FALSE(OnlineActivation::activate("", "serial", "product"));
     REQUIRE_FALSE(OnlineActivation::deactivate("", "license"));
     REQUIRE(OnlineActivation::check_status("", "license") == LicenseStatus::NotFound);
 }
 
 TEST_CASE("OnlineActivation activate returns loopback license response",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     auto exchange = serve_loopback_http_response("license-key");
 
     auto license = OnlineActivation::activate(exchange.base_url, "serial-123", "PulpSynth");
@@ -905,7 +905,7 @@ TEST_CASE("OnlineActivation activate returns loopback license response",
 }
 
 TEST_CASE("OnlineActivation deactivate accepts successful loopback response",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     auto exchange = serve_loopback_http_response(R"({"ok":true})");
 
     REQUIRE(OnlineActivation::deactivate(exchange.base_url, "license-key"));
@@ -916,7 +916,7 @@ TEST_CASE("OnlineActivation deactivate accepts successful loopback response",
 }
 
 TEST_CASE("OnlineActivation check_status maps loopback response bodies",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     {
         auto exchange = serve_loopback_http_response(R"({"status":"valid"})");
         REQUIRE(OnlineActivation::check_status(exchange.base_url, "valid-key") == LicenseStatus::Valid);
@@ -941,7 +941,7 @@ TEST_CASE("OnlineActivation check_status maps loopback response bodies",
 }
 
 TEST_CASE("OnlineActivation treats non-2xx loopback responses as activation failures",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     {
         auto exchange = serve_loopback_http_status(403, R"({"error":"denied"})");
         REQUIRE_FALSE(OnlineActivation::activate(exchange.base_url, "serial", "product"));
@@ -977,14 +977,14 @@ TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]")
     REQUIRE_FALSE(generator.generate(info).has_value());
 }
 
-TEST_CASE("OnlineActivation rejects malformed server URLs without network", "[crypto][license][coverage][issue-656]") {
+TEST_CASE("OnlineActivation rejects malformed server URLs without network", "[crypto][license][issue-656]") {
     REQUIRE_FALSE(OnlineActivation::activate("not-a-url", "serial", "product").has_value());
     REQUIRE_FALSE(OnlineActivation::deactivate("not-a-url", "license"));
     REQUIRE(OnlineActivation::check_status("not-a-url", "license") == LicenseStatus::NotFound);
 }
 
 TEST_CASE("OnlineActivation handles successful loopback activation flows",
-          "[crypto][license][coverage]") {
+          "[crypto][license]") {
     httplib::Server server;
     server.Post("/activate", [](const httplib::Request&, httplib::Response& response) {
         response.set_content("license-key", "text/plain");

--- a/test/test_midi_buffer_sysex.cpp
+++ b/test/test_midi_buffer_sysex.cpp
@@ -298,7 +298,7 @@ TEST_CASE("MidiBuffer copies sysex sidecar independently",
 }
 
 TEST_CASE("MidiBuffer move construction preserves sidecar contents",
-          "[midi][buffer][sysex][coverage]") {
+          "[midi][buffer][sysex]") {
     MidiBuffer original;
     original.add(MidiEvent::note_on(0, 72, 100));
     original.add_sysex({0xF0, 0x7D, 0x05, 0xF7}, 96, 1.25);
@@ -314,7 +314,7 @@ TEST_CASE("MidiBuffer move construction preserves sidecar contents",
 }
 
 TEST_CASE("MidiBuffer moves sysex sidecar with short messages",
-          "[midi][buffer][sysex][coverage]") {
+          "[midi][buffer][sysex]") {
     MidiBuffer original;
     auto note = MidiEvent::note_on(1, 72, 110);
     note.sample_offset = 24;

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -43,7 +43,7 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
 }
 
 TEST_CASE("UmpBuffer sorts, iterates, and clears sample-accurate events",
-          "[midi][buffer][ump][coverage]") {
+          "[midi][buffer][ump]") {
     UmpBuffer ump;
     ump.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 96);
     ump.add(UmpEvent{UmpPacket::note_off_2(0, 1, 60, 0), 12});
@@ -91,7 +91,7 @@ TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits
 }
 
 TEST_CASE("MidiBuffer move assignment preserves attached UMP sidecar pointer",
-          "[midi][buffer][ump][coverage]") {
+          "[midi][buffer][ump]") {
     UmpBuffer sidecar;
     sidecar.add(UmpPacket::cc_2(0, 3, 74, 0x80000000u), 24);
 

--- a/test/test_midi_expansion.cpp
+++ b/test/test_midi_expansion.cpp
@@ -357,7 +357,7 @@ TEST_CASE("RpnParser reports NRPN increment and decrement metadata",
 }
 
 TEST_CASE("RpnParser reports highest non-null RPN parameter and maximum value",
-          "[midi][rpn][coverage]") {
+          "[midi][rpn]") {
     RpnParser rpn;
     uint8_t received_ch = 255;
     uint16_t received_param = 0;
@@ -380,7 +380,7 @@ TEST_CASE("RpnParser reports highest non-null RPN parameter and maximum value",
 }
 
 TEST_CASE("RpnParser suppresses increment while parameter is being reselected",
-          "[midi][rpn][coverage]") {
+          "[midi][rpn]") {
     RpnParser rpn;
     std::vector<uint16_t> params;
 
@@ -404,7 +404,7 @@ TEST_CASE("RpnParser suppresses increment while parameter is being reselected",
 }
 
 TEST_CASE("RpnParser reset clears selected parameters on every channel",
-          "[midi][rpn][coverage]") {
+          "[midi][rpn]") {
     RpnParser rpn;
     int calls = 0;
     rpn.on_rpn = [&](uint8_t, uint16_t, uint16_t) { ++calls; };
@@ -426,7 +426,7 @@ TEST_CASE("RpnParser reset clears selected parameters on every channel",
 }
 
 TEST_CASE("RpnParser combines data LSB with default zero MSB",
-          "[midi][rpn][coverage]") {
+          "[midi][rpn]") {
     RpnParser rpn;
     uint16_t received_value = 0xffff;
 
@@ -464,7 +464,7 @@ TEST_CASE("MidiKeyboardState note on vel=0 is note off", "[midi][keyboard]") {
 }
 
 TEST_CASE("MidiKeyboardState note on velocity zero fires note-off callback",
-          "[midi][keyboard][coverage]") {
+          "[midi][keyboard]") {
     MidiKeyboardState keys;
     std::vector<int> released;
     keys.on_note_off = [&](uint8_t channel, uint8_t note) {
@@ -625,7 +625,7 @@ TEST_CASE("MidiKeyboardState retrigger updates velocity without duplicating held
 }
 
 TEST_CASE("MidiKeyboardState tracks note range boundaries",
-          "[midi][keyboard][coverage]") {
+          "[midi][keyboard]") {
     MidiKeyboardState keys;
 
     keys.process(MidiEvent::note_on(15, 0, 1));

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -51,7 +51,7 @@ std::vector<uint8_t> read_bytes(const fs::path& path) {
 } // namespace
 
 TEST_CASE("MidiFileData aggregates empty and multi-track metadata",
-          "[midi][file][coverage]") {
+          "[midi][file]") {
     MidiFileData empty;
     REQUIRE(empty.duration_seconds() == Approx(0.0).margin(1e-9));
     REQUIRE(empty.total_events() == 0);
@@ -72,7 +72,7 @@ TEST_CASE("MidiFileData aggregates empty and multi-track metadata",
 }
 
 TEST_CASE("MidiFileData aggregates duration and event counts across tracks",
-          "[midi][file][coverage]") {
+          "[midi][file]") {
     MidiFileData data;
     REQUIRE(data.total_events() == 0);
     REQUIRE(data.duration_seconds() == Approx(0.0).margin(1e-9));
@@ -199,7 +199,7 @@ TEST_CASE("read_midi_file rejects truncated track chunks",
 }
 
 TEST_CASE("midi file helpers report missing and unwritable paths",
-          "[midi][file][coverage]") {
+          "[midi][file]") {
     TempDir tmp;
 
     REQUIRE_FALSE(read_midi_file((tmp.path / "missing.mid").string()).has_value());
@@ -373,7 +373,7 @@ TEST_CASE("write_midi_file preserves mixed short messages across tracks",
 }
 
 TEST_CASE("write_midi_file rejects missing parent directories",
-          "[midi][file][coverage]") {
+          "[midi][file]") {
     TempDir tmp;
     MidiFileData data;
     MidiTrack track;
@@ -386,7 +386,7 @@ TEST_CASE("write_midi_file rejects missing parent directories",
 }
 
 TEST_CASE("write_midi_file rejects directory destinations",
-          "[midi][file][coverage]") {
+          "[midi][file]") {
     TempDir tmp;
     MidiFileData data;
     MidiTrack track;

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -149,7 +149,7 @@ TEST_CASE("MpeConfig identifies lower and upper zone member boundaries",
 }
 
 TEST_CASE("MpeZone rejects disabled and non-standard manager layouts",
-          "[midi][mpe][codecov]") {
+          "[midi][mpe]") {
     MpeZone disabled_lower{0, 0};
     REQUIRE(disabled_lower.is_lower());
     REQUIRE_FALSE(disabled_lower.contains_channel(1));

--- a/test/test_multi_channel_meter.cpp
+++ b/test/test_multi_channel_meter.cpp
@@ -335,7 +335,7 @@ TEST_CASE("MultiChannelMeter treats non-finite samples as silence (no NaN poison
 }
 
 TEST_CASE("MultiChannelMeter accumulates short blocks until the emit threshold",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelMeter meter;
     meter.prepare(1000.0f, 1);  // 10-sample snapshot block
 
@@ -360,7 +360,7 @@ TEST_CASE("MultiChannelMeter accumulates short blocks until the emit threshold",
 }
 
 TEST_CASE("MultiChannelMeter first null channel clears stale stereo state",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelMeter meter;
     meter.prepare(100.0f, 2);
 
@@ -387,7 +387,7 @@ TEST_CASE("MultiChannelMeter first null channel clears stale stereo state",
 }
 
 TEST_CASE("MultiChannelMeter sanitizes non-finite stereo correlation samples",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelMeter meter;
     meter.prepare(100.0f, 2);
 
@@ -415,7 +415,7 @@ TEST_CASE("MultiChannelMeter sanitizes non-finite stereo correlation samples",
 }
 
 TEST_CASE("MultiChannelMeter zero sample rate still emits finite one-sample snapshots",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelMeter meter;
     meter.prepare(0.0f, 1);
 
@@ -432,7 +432,7 @@ TEST_CASE("MultiChannelMeter zero sample rate still emits finite one-sample snap
 }
 
 TEST_CASE("MultiChannelBallistics releases peaks RMS and clip holds independently",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelBallistics ballistics;
     ballistics.attack_time = 0.01f;
     ballistics.release_time = 0.01f;

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -110,7 +110,7 @@ TEST_CASE("NSD dispatches browse/register/unregister to installed backend",
 }
 
 TEST_CASE("NSD can browse again after stop",
-          "[events][service-discovery][coverage]") {
+          "[events][service-discovery]") {
     NetworkServiceDiscovery nsd;
     auto backend = std::make_unique<FakeBackend>();
     auto log = backend->log;
@@ -126,7 +126,7 @@ TEST_CASE("NSD can browse again after stop",
 }
 
 TEST_CASE("NSD unregister after backend removal is a no-op",
-          "[events][service-discovery][coverage]") {
+          "[events][service-discovery]") {
     NetworkServiceDiscovery nsd;
     auto backend = std::make_unique<FakeBackend>();
     auto log = backend->log;
@@ -527,7 +527,7 @@ TEST_CASE("NSD keys discoveries and loss by service name plus type",
 }
 
 TEST_CASE("NSD routes register and unregister to the current backend after swaps",
-          "[events][service-discovery][coverage]") {
+          "[events][service-discovery]") {
     NetworkServiceDiscovery nsd;
     auto first = std::make_unique<FakeBackend>();
     auto first_log = first->log;
@@ -554,7 +554,7 @@ TEST_CASE("NSD routes register and unregister to the current backend after swaps
 }
 
 TEST_CASE("NSD loss matching ignores services with the same type but different name",
-          "[events][service-discovery][coverage]") {
+          "[events][service-discovery]") {
     NetworkServiceDiscovery nsd;
     nsd.install_backend(std::make_unique<FakeBackend>());
 
@@ -641,7 +641,7 @@ TEST_CASE("MountedVolumeListChangeDetector start and stop are idempotent",
 }
 
 TEST_CASE("MountedVolumeListChangeDetector stop wakes a long poll promptly",
-          "[events][volume][lifecycle][coverage]") {
+          "[events][volume][lifecycle]") {
 #ifdef _WIN32
     SUCCEED("Windows drive probing can throw on unavailable runner drives; covered on POSIX.");
     return;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -182,7 +182,7 @@ TEST_CASE("IPv4 validation accepts private network examples",
 }
 
 TEST_CASE("IPv4 validation rejects non-canonical numeric address forms",
-          "[network_stream][ip-address][coverage]") {
+          "[network_stream][ip-address]") {
     REQUIRE_FALSE(is_valid_ipv4("127.1"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.1"));
     REQUIRE_FALSE(is_valid_ipv4("0300.0250.0001.0001"));
@@ -191,7 +191,7 @@ TEST_CASE("IPv4 validation rejects non-canonical numeric address forms",
 }
 
 TEST_CASE("IPv4 validation accepts canonical public resolver examples",
-          "[network_stream][ip-address][coverage]") {
+          "[network_stream][ip-address]") {
     REQUIRE(is_valid_ipv4("1.1.1.1"));
     REQUIRE(is_valid_ipv4("8.8.8.8"));
     REQUIRE(is_valid_ipv4("9.9.9.9"));
@@ -687,7 +687,7 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
 }
 
 TEST_CASE("TcpStream rejects null buffers while connected",
-          "[network_stream][tcp][coverage]") {
+          "[network_stream][tcp]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -724,7 +724,7 @@ TEST_CASE("TcpStream rejects null buffers while connected",
 // ── Socket edge cases ───────────────────────────────────────────────────
 
 TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp_ephemeral(receiver);
@@ -748,7 +748,7 @@ TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
 }
 
 TEST_CASE("Socket UDP send_to and receive_from fail before create",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket socket;
     std::array<std::uint8_t, 4> buffer{};
     std::string from_address = "unchanged";
@@ -761,7 +761,7 @@ TEST_CASE("Socket UDP send_to and receive_from fail before create",
 }
 
 TEST_CASE("Socket local_port reports bound UDP ephemeral port",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket socket;
     REQUIRE(socket.local_port() == 0);
     REQUIRE(socket.create(SocketType::UDP));
@@ -771,7 +771,7 @@ TEST_CASE("Socket local_port reports bound UDP ephemeral port",
 }
 
 TEST_CASE("Socket TCP loopback send receive and close",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -815,7 +815,7 @@ TEST_CASE("Socket TCP loopback send receive and close",
 }
 
 TEST_CASE("Socket move construction transfers open UDP handle",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket original;
     REQUIRE(original.create(SocketType::UDP));
     REQUIRE(original.is_open());
@@ -829,7 +829,7 @@ TEST_CASE("Socket move construction transfers open UDP handle",
 }
 
 TEST_CASE("Socket move assignment closes old handle and adopts new one",
-          "[network_stream][socket][coverage]") {
+          "[network_stream][socket]") {
     Socket old_socket;
     REQUIRE(old_socket.create(SocketType::UDP));
     REQUIRE(old_socket.bind("127.0.0.1", 0));
@@ -877,7 +877,7 @@ TEST_CASE("HttpStream status_code is 0 before fetch",
 }
 
 TEST_CASE("HttpStream reads a successful local response body in chunks",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -936,7 +936,7 @@ TEST_CASE("HttpStream reads a successful local response body in chunks",
 }
 
 TEST_CASE("http_get defaults missing URL path to slash",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -973,7 +973,7 @@ TEST_CASE("http_get defaults missing URL path to slash",
 }
 
 TEST_CASE("HttpStream post factory reads a successful local response",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -1019,7 +1019,7 @@ TEST_CASE("HttpStream post factory reads a successful local response",
 }
 
 TEST_CASE("http_download writes a successful local response to disk",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -1064,7 +1064,7 @@ TEST_CASE("http_download writes a successful local response to disk",
 }
 
 TEST_CASE("HttpStream default state supports zero reads and idempotent close",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     HttpStream stream;
     REQUIRE_FALSE(stream.is_open());
     REQUIRE(stream.eof());
@@ -1090,7 +1090,7 @@ TEST_CASE("HttpStream default state supports zero reads and idempotent close",
 }
 
 TEST_CASE("HttpStream rejects null read buffers before transport errors",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     HttpStream::Request req;
     req.url = "ftp://127.0.0.1/nope";
     req.timeout_seconds = 1;
@@ -1134,7 +1134,7 @@ TEST_CASE("HttpStream factories and refetch reset closed state to request result
 }
 
 TEST_CASE("http helpers reject invalid explicit ports",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     const auto zero_port = http_get("http://127.0.0.1:0/path", 1);
     REQUIRE(zero_port.status_code == 0);
     REQUIRE(zero_port.body.empty());
@@ -1159,7 +1159,7 @@ TEST_CASE("http helpers reject invalid explicit ports",
 }
 
 TEST_CASE("http helpers parse default ports without explicit port text",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     const auto default_http = http_get("http://127.0.0.1", 1);
     REQUIRE(default_http.body.find('\0') == std::string::npos);
     REQUIRE(default_http.error.find('\0') == std::string::npos);
@@ -1177,7 +1177,7 @@ TEST_CASE("http helpers parse default ports without explicit port text",
 }
 
 TEST_CASE("http_post reports connection failure on refused loopback port",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     const auto response = http_post("http://127.0.0.1:1/post",
                                     R"({"ok":false})",
                                     "application/json",
@@ -1190,7 +1190,7 @@ TEST_CASE("http_post reports connection failure on refused loopback port",
 }
 
 TEST_CASE("HttpResponse ok accepts only successful status codes",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     HttpResponse response;
     response.status_code = 199;
     REQUIRE_FALSE(response.ok());
@@ -1205,7 +1205,7 @@ TEST_CASE("HttpResponse ok accepts only successful status codes",
 }
 
 TEST_CASE("http_download returns false for non-ok responses and unwritable paths",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     REQUIRE_FALSE(http_download("http://127.0.0.1:0/artifact",
                                 (std::filesystem::temp_directory_path() /
                                  "pulp-invalid-download.bin").string(),
@@ -1244,7 +1244,7 @@ TEST_CASE("http_download returns false for non-ok responses and unwritable paths
 }
 
 TEST_CASE("HttpStream reads successful GET responses in chunks",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     httplib::Server server;
     server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
         response.status = 204;
@@ -1288,7 +1288,7 @@ TEST_CASE("HttpStream reads successful GET responses in chunks",
 }
 
 TEST_CASE("HttpStream POST factory exposes successful response bodies",
-          "[network_stream][http][coverage]") {
+          "[network_stream][http]") {
     httplib::Server server;
     server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
         response.status = 204;

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -148,7 +148,7 @@ TEST_CASE("OSC Message typed defaults cover every wrong-type accessor", "[osc][m
 }
 
 TEST_CASE("OSC Message defaults cover empty and wrong-type accessors",
-          "[osc][message][coverage]") {
+          "[osc][message]") {
     Message msg;
     REQUIRE(msg.get_int(0, -7) == -7);
     REQUIRE(msg.get_float(0, 2.5f) == 2.5f);
@@ -163,7 +163,7 @@ TEST_CASE("OSC Message defaults cover empty and wrong-type accessors",
 }
 
 TEST_CASE("OSC Message add overloads preserve fluent chaining and argument types",
-          "[osc][message][codecov]") {
+          "[osc][message]") {
     Message msg("/chain");
     auto* returned = &msg.add(7)
         .add(0.5f)
@@ -257,7 +257,7 @@ TEST_CASE("OSC 4-byte alignment", "[osc][codec]") {
 }
 
 TEST_CASE("OSC encode with no arguments emits an empty type-tag section",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     Message msg("/plain");
 
     auto data = encode(msg);
@@ -271,7 +271,7 @@ TEST_CASE("OSC encode with no arguments emits an empty type-tag section",
 }
 
 TEST_CASE("OSC decode accepts explicit comma tag with no arguments",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     std::vector<uint8_t> data;
     append_osc_string(data, "/empty-tags");
     append_osc_string(data, ",");
@@ -283,7 +283,7 @@ TEST_CASE("OSC decode accepts explicit comma tag with no arguments",
 }
 
 TEST_CASE("OSC decode ignores unknown type tags without adding arguments",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     std::vector<uint8_t> data;
     append_osc_string(data, "/unknown-tags");
     append_osc_string(data, ",TFNz");
@@ -295,7 +295,7 @@ TEST_CASE("OSC decode ignores unknown type tags without adding arguments",
 }
 
 TEST_CASE("OSC decode skips unknown tags without consuming later argument bytes",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     std::vector<uint8_t> data;
     append_osc_string(data, "/mixed");
     append_osc_string(data, ",xi");
@@ -308,7 +308,7 @@ TEST_CASE("OSC decode skips unknown tags without consuming later argument bytes"
 }
 
 TEST_CASE("OSC decode rejects truncated typed payloads as malformed",
-          "[osc][codec][coverage]") {
+          "[osc][codec]") {
     // A type tag string (",ifsb") with a truncated payload is malformed: the
     // decoder must fail closed to the empty-address sentinel rather than
     // fabricate 0/default args that would dispatch a real control change. The
@@ -325,7 +325,7 @@ TEST_CASE("OSC decode rejects truncated typed payloads as malformed",
 }
 
 TEST_CASE("OSC decode handles non-null-terminated bounded address payload",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     const std::vector<uint8_t> data{'/', 'b', 'a', 'r'};
 
     auto decoded = decode(data.data(), data.size());
@@ -335,7 +335,7 @@ TEST_CASE("OSC decode handles non-null-terminated bounded address payload",
 }
 
 TEST_CASE("OSC encode/decode preserves blob payloads at padding boundaries",
-          "[osc][codec][codecov]") {
+          "[osc][codec]") {
     Message msg("/blob-padding");
     msg.add(std::vector<uint8_t>{0x01, 0x02, 0x03});
     msg.add(std::vector<uint8_t>{0x04, 0x05, 0x06, 0x07});
@@ -352,7 +352,7 @@ TEST_CASE("OSC encode/decode preserves blob payloads at padding boundaries",
 }
 
 TEST_CASE("OSC decode preserves empty blob alignment before following arguments",
-          "[osc][codec][blob][codecov]") {
+          "[osc][codec][blob]") {
     Message msg("/zero-blob-next");
     msg.add(std::vector<uint8_t>{});
     msg.add(77);
@@ -440,7 +440,7 @@ TEST_CASE("OSC Sender rejects invalid hostnames", "[osc][udp][sender]") {
 }
 
 TEST_CASE("OSC Sender failed reconnect preserves the existing destination",
-          "[osc][udp][sender][codecov]") {
+          "[osc][udp][sender]") {
     std::atomic<int> handled{0};
 
     Receiver rx;
@@ -471,7 +471,7 @@ TEST_CASE("OSC Sender failed reconnect preserves the existing destination",
 }
 
 TEST_CASE("OSC Sender successful reconnect replaces the existing destination",
-          "[osc][udp][sender][codecov]") {
+          "[osc][udp][sender]") {
     std::atomic<int> first_receiver{0};
     std::atomic<int> second_receiver{0};
 
@@ -513,7 +513,7 @@ TEST_CASE("OSC Sender successful reconnect replaces the existing destination",
 }
 
 TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
-          "[osc][udp][sender][coverage]") {
+          "[osc][udp][sender]") {
     std::atomic<int> handled{0};
     Message received;
     std::mutex received_mutex;
@@ -551,7 +551,7 @@ TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
 }
 
 TEST_CASE("OSC Receiver routes direct messages through address-pattern listeners",
-          "[osc][udp][receiver][pattern][codecov]") {
+          "[osc][udp][receiver][pattern]") {
     std::atomic<int> all_messages{0};
     std::atomic<int> mix_messages{0};
     std::atomic<int> note_messages{0};
@@ -608,7 +608,7 @@ TEST_CASE("OSC Receiver routes direct messages through address-pattern listeners
 }
 
 TEST_CASE("OSC Sender sends typed bundles and Receiver dispatches bundle callbacks",
-          "[osc][udp][bundle][receiver][codecov]") {
+          "[osc][udp][bundle][receiver]") {
     std::atomic<int> bundle_callbacks{0};
     std::atomic<int> nested_bundle_callbacks{0};
     std::atomic<int> bundle_element_count{0};
@@ -682,7 +682,7 @@ TEST_CASE("OSC Sender sends typed bundles and Receiver dispatches bundle callbac
 }
 
 TEST_CASE("OSC Sender sends bundles after disconnect and reconnect",
-          "[osc][udp][bundle][sender][codecov]") {
+          "[osc][udp][bundle][sender]") {
     std::atomic<int> first_receiver{0};
     std::atomic<int> second_receiver{0};
 
@@ -734,7 +734,7 @@ TEST_CASE("OSC Sender sends bundles after disconnect and reconnect",
 }
 
 TEST_CASE("OSC Receiver dispatches empty bundles without message callbacks",
-          "[osc][udp][bundle][receiver][codecov]") {
+          "[osc][udp][bundle][receiver]") {
     std::atomic<int> empty_bundles{0};
     std::atomic<int> messages{0};
 
@@ -769,7 +769,7 @@ TEST_CASE("OSC Receiver dispatches empty bundles without message callbacks",
 }
 
 TEST_CASE("OSC Receiver accepts bundle datagrams larger than four kilobytes",
-          "[osc][udp][bundle][receiver][codecov]") {
+          "[osc][udp][bundle][receiver]") {
     std::atomic<int> bundle_callbacks{0};
     std::atomic<int> blob_size{0};
     std::atomic<int> blob_front{0};
@@ -826,7 +826,7 @@ TEST_CASE("OSC Receiver accepts bundle datagrams larger than four kilobytes",
 }
 
 TEST_CASE("OSC Sender disconnects idempotently and reconnects to loopback",
-          "[osc][udp][sender][codecov]") {
+          "[osc][udp][sender]") {
     std::atomic<int> handled{0};
 
     Receiver rx;
@@ -892,7 +892,7 @@ TEST_CASE("OSC Receiver drops invalid datagrams without invoking handler", "[osc
 }
 
 TEST_CASE("OSC Receiver reports malformed message and bundle packets",
-          "[osc][udp][receiver][error][codecov]") {
+          "[osc][udp][receiver][error]") {
     std::atomic<int> errors{0};
     std::atomic<int> malformed_messages{0};
     std::atomic<int> malformed_bundles{0};
@@ -948,7 +948,7 @@ TEST_CASE("OSC Receiver reports malformed message and bundle packets",
 }
 
 TEST_CASE("OSC Receiver reports empty UDP datagrams as malformed messages",
-          "[osc][udp][receiver][error][codecov]") {
+          "[osc][udp][receiver][error]") {
     std::atomic<int> errors{0};
     std::atomic<int> handled_messages{0};
 
@@ -977,7 +977,7 @@ TEST_CASE("OSC Receiver reports empty UDP datagrams as malformed messages",
 }
 
 TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
-          "[osc][udp][receiver][lifecycle][codecov]") {
+          "[osc][udp][receiver][lifecycle]") {
     {
         std::atomic<int> errors{0};
         std::atomic<bool> stop_returned{false};
@@ -1103,7 +1103,7 @@ TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
 }
 
 TEST_CASE("OSC Receiver stop short-circuits current datagram callback fanout",
-          "[osc][udp][receiver][lifecycle][codecov]") {
+          "[osc][udp][receiver][lifecycle]") {
     {
         std::atomic<int> bundles{0};
         std::atomic<int> messages{0};
@@ -1254,7 +1254,7 @@ TEST_CASE("OSC Receiver stop short-circuits current datagram callback fanout",
 }
 
 TEST_CASE("OSC Receiver can be destroyed from a receiver callback",
-          "[osc][udp][receiver][lifecycle][codecov]") {
+          "[osc][udp][receiver][lifecycle]") {
     struct Owner {
         Receiver rx;
     };
@@ -1292,7 +1292,7 @@ TEST_CASE("OSC Receiver can be destroyed from a receiver callback",
 }
 
 TEST_CASE("OSC Receiver with empty handler accepts datagrams until stopped",
-          "[osc][udp][receiver][codecov]") {
+          "[osc][udp][receiver]") {
     Receiver rx;
     REQUIRE(rx.listen(0, {}));
     REQUIRE(rx.is_listening());
@@ -1514,7 +1514,7 @@ TEST_CASE("OSC encode is deterministic for identical messages",
 }
 
 TEST_CASE("OSC encode preserves moved string and blob arguments",
-          "[osc][codec][coverage]") {
+          "[osc][codec]") {
     std::string label = "moved-label";
     std::vector<uint8_t> payload{0x10, 0x20, 0x30, 0x40};
 
@@ -1586,7 +1586,7 @@ TEST_CASE("OSC Sender::send without connect is rejected", "[osc][udp][sender]") 
 }
 
 TEST_CASE("OSC Sender::send bundle without connect is rejected",
-          "[osc][udp][sender][bundle][codecov]") {
+          "[osc][udp][sender][bundle]") {
     Sender tx;
     REQUIRE_FALSE(tx.is_connected());
 
@@ -1643,7 +1643,7 @@ TEST_CASE("OSC decode tolerates extra trailing padding bytes", "[osc][codec][iss
 }
 
 TEST_CASE("OSC decode keeps explicit defaults for out-of-range access",
-          "[osc][message][coverage]") {
+          "[osc][message]") {
     Message msg("/defaults");
     msg.add(12).add(std::string("name"));
 
@@ -1674,7 +1674,7 @@ TEST_CASE("OSC Receiver accepts an empty handler and stops cleanly",
 }
 
 TEST_CASE("OSC Receiver rejects binding to an already-used UDP port",
-          "[osc][udp][receiver][coverage]") {
+          "[osc][udp][receiver]") {
     Receiver first;
     REQUIRE(first.listen(0, [](const Message&) {}));
     const auto port = first.local_port();
@@ -1693,7 +1693,7 @@ TEST_CASE("OSC Receiver rejects binding to an already-used UDP port",
 // ── Bundles and address patterns ────────────────────────────────────────────
 
 TEST_CASE("OSC bundle serializes and restores nested messages and bundles",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     Bundle nested;
     Message nested_msg("/nested");
     nested_msg.add(std::string("ok"));
@@ -1722,7 +1722,7 @@ TEST_CASE("OSC bundle serializes and restores nested messages and bundles",
 }
 
 TEST_CASE("OSC bundle rejects malformed element boundaries",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     Bundle bundle;
     Message msg("/one");
     msg.add(1);
@@ -1744,7 +1744,7 @@ TEST_CASE("OSC bundle rejects malformed element boundaries",
 }
 
 TEST_CASE("OSC address pattern rejects incomplete classes and alternatives",
-          "[osc][pattern][codecov]") {
+          "[osc][pattern]") {
     REQUIRE(address_matches("/note/[0-9]", "/note/7"));
     REQUIRE(address_matches("/note/[!0-3]", "/note/8"));
     REQUIRE_FALSE(address_matches("/note/[!0-3]", "/note/2"));
@@ -1759,7 +1759,7 @@ TEST_CASE("OSC address pattern rejects incomplete classes and alternatives",
 }
 
 TEST_CASE("OSC address pattern covers boundary backtracking failures",
-          "[osc][pattern][coverage]") {
+          "[osc][pattern]") {
     REQUIRE(address_matches("/mix/*/tail", "/mix//tail"));
     REQUIRE_FALSE(address_matches("/mix/*/tail", "/mix/a/b/tail"));
     REQUIRE_FALSE(address_matches("/mix/*tail", "/mix/a/tail"));

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -63,7 +63,7 @@ TEST_CASE("OSC TimeTag keeps fractional unix seconds near one-second boundary",
 }
 
 TEST_CASE("OSC TimeTag converts fractional halves without losing the fraction",
-          "[osc][bundle][timetag][codecov]") {
+          "[osc][bundle][timetag]") {
     auto tt = TimeTag::from_unix(1000.5);
 
     REQUIRE(tt.seconds == 2208989800u);
@@ -72,7 +72,7 @@ TEST_CASE("OSC TimeTag converts fractional halves without losing the fraction",
 }
 
 TEST_CASE("OSC TimeTag converts positive sub-second unix times",
-          "[osc][bundle][timetag][codecov]") {
+          "[osc][bundle][timetag]") {
     auto tt = TimeTag::from_unix(0.25);
 
     REQUIRE(tt.seconds == 2208988800u);
@@ -120,7 +120,7 @@ TEST_CASE("OSC default BundleElement is an empty message element",
 }
 
 TEST_CASE("OSC BundleElement takes ownership of unique_ptr bundles",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     auto nested = std::make_unique<Bundle>();
     nested->timetag = TimeTag::from_unix(42.0);
     Message msg("/owned");
@@ -137,7 +137,7 @@ TEST_CASE("OSC BundleElement takes ownership of unique_ptr bundles",
 }
 
 TEST_CASE("OSC BundleElement message constructor preserves message content",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     Message msg("/direct");
     msg.add(11).add(std::string("payload"));
 
@@ -151,7 +151,7 @@ TEST_CASE("OSC BundleElement message constructor preserves message content",
 }
 
 TEST_CASE("OSC BundleElement value constructor copies nested bundle content",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     Bundle nested;
     Message msg("/value-copy");
     msg.add(std::string("payload"));
@@ -211,7 +211,7 @@ TEST_CASE("OSC Bundle serialize/deserialize round-trip", "[osc][bundle]") {
 }
 
 TEST_CASE("OSC Bundle serialize preserves non-immediate timetag bytes",
-          "[osc][bundle][codecov]") {
+          "[osc][bundle]") {
     Bundle bundle;
     bundle.timetag = {0x01020304u, 0xA0B0C0D0u};
 
@@ -280,7 +280,7 @@ TEST_CASE("Bundle::deserialize rejects data shorter than 16 bytes",
 }
 
 TEST_CASE("Bundle::deserialize rejects null data with bundle-sized length",
-          "[osc][bundle][deserialize-edge][codecov]") {
+          "[osc][bundle][deserialize-edge]") {
     REQUIRE_FALSE(Bundle::deserialize(nullptr, 16).has_value());
 }
 
@@ -353,7 +353,7 @@ TEST_CASE("Bundle::deserialize rejects malformed message element",
 }
 
 TEST_CASE("Bundle::deserialize rejects zero-sized elements",
-          "[osc][bundle][deserialize-edge][codecov]") {
+          "[osc][bundle][deserialize-edge]") {
     auto buf = make_empty_bundle_bytes();
     append_u32(buf, 0);
 
@@ -429,7 +429,7 @@ TEST_CASE("Bundle deep nesting (3 levels) round-trips",
 }
 
 TEST_CASE("Bundle round-trip preserves blob and float message arguments",
-          "[osc][bundle][roundtrip][codecov]") {
+          "[osc][bundle][roundtrip]") {
     Bundle bundle;
     Message msg("/mixed");
     msg.add(std::vector<uint8_t>{0xAA, 0xBB});
@@ -506,7 +506,7 @@ TEST_CASE("Address pattern star bounded by path separator",
 }
 
 TEST_CASE("Address pattern star backtracks within a path segment",
-          "[osc][bundle][pattern][codecov]") {
+          "[osc][bundle][pattern]") {
     REQUIRE(address_matches("/foo/*bar", "/foo/bar"));
     REQUIRE(address_matches("/foo/*bar", "/foo/bazbar"));
     REQUIRE(address_matches("/foo/a*c", "/foo/abc"));
@@ -515,7 +515,7 @@ TEST_CASE("Address pattern star backtracks within a path segment",
 }
 
 TEST_CASE("Address pattern handles class, star, and alternative boundaries",
-          "[osc][bundle][pattern][codecov]") {
+          "[osc][bundle][pattern]") {
     REQUIRE(address_matches("/[A-C]/x", "/B/x"));
     REQUIRE_FALSE(address_matches("/[C-A]/x", "/B/x"));
     REQUIRE_FALSE(address_matches("/[]/x", "/a/x"));
@@ -542,7 +542,7 @@ TEST_CASE("Malformed address patterns fail closed",
 }
 
 TEST_CASE("Address pattern alternatives reject empty branches",
-          "[osc][bundle][pattern][coverage]") {
+          "[osc][bundle][pattern]") {
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixSuffix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixOther"));
@@ -558,7 +558,7 @@ TEST_CASE("Address pattern alternatives support first and later branches",
 }
 
 TEST_CASE("Address pattern alternatives backtrack when a prefix branch fails",
-          "[osc][bundle][pattern][codecov]") {
+          "[osc][bundle][pattern]") {
     REQUIRE(address_matches("/{foo,foobar}/gain", "/foobar/gain"));
     REQUIRE(address_matches("/{a,ab,abc}/tail", "/abc/tail"));
     REQUIRE_FALSE(address_matches("/{foo,foobar}/gain", "/foobaz/gain"));

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -164,13 +164,13 @@ TEST_CASE("OscChannel send empty payload is rejected", "[osc_channel][lifecycle]
 }
 
 TEST_CASE("OscChannel open rejects invalid remote hosts",
-          "[osc_channel][lifecycle][codecov]") {
+          "[osc_channel][lifecycle]") {
     auto channel = OscChannel::open("999.999.999.999", 29876, 0);
     REQUIRE_FALSE(channel);
 }
 
 TEST_CASE("OscChannel open fails cleanly when requested local port is occupied",
-          "[osc_channel][lifecycle][coverage]") {
+          "[osc_channel][lifecycle]") {
     Receiver occupied;
     REQUIRE(occupied.listen(0, [](const Message&) {}));
     const auto local_port = occupied.local_port();
@@ -203,7 +203,7 @@ TEST_CASE("OscChannel send after close is rejected", "[osc_channel][lifecycle]")
 }
 
 TEST_CASE("OscChannel accepts error callback replacement without changing state",
-          "[osc_channel][lifecycle][coverage]") {
+          "[osc_channel][lifecycle]") {
     auto a = open_loopback_endpoint();
     if (!a) {
         SUCCEED("could not open loopback UDP pair; skipping");
@@ -247,7 +247,7 @@ TEST_CASE("OscChannel close is idempotent and on_closed fires exactly once",
 }
 
 TEST_CASE("OscChannel close uses the latest registered closed callback",
-          "[osc_channel][lifecycle][codecov]") {
+          "[osc_channel][lifecycle]") {
     auto a = open_loopback_endpoint();
     if (!a) {
         SUCCEED("could not open loopback UDP pair; skipping");
@@ -268,7 +268,7 @@ TEST_CASE("OscChannel close uses the latest registered closed callback",
 }
 
 TEST_CASE("OscChannel routes close callbacks through custom executor",
-          "[osc_channel][lifecycle][coverage]") {
+          "[osc_channel][lifecycle]") {
     std::vector<std::function<void()>> queued;
     OscChannelOptions options;
     options.executor = [&](std::function<void()> fn) {
@@ -333,7 +333,7 @@ TEST_CASE("OscChannel delivers raw send() bytes verbatim to the peer",
 }
 
 TEST_CASE("OscChannel leaves unhandled incoming messages as no-op deliveries",
-          "[osc_channel][raw][coverage]") {
+          "[osc_channel][raw]") {
     auto pair = open_loopback_pair();
     if (!pair) {
         SUCCEED("could not open loopback UDP pair; skipping");
@@ -358,7 +358,7 @@ TEST_CASE("OscChannel leaves unhandled incoming messages as no-op deliveries",
 }
 
 TEST_CASE("OscChannel message callback replacement uses latest callback",
-          "[osc_channel][raw][codecov]") {
+          "[osc_channel][raw]") {
     auto pair = open_loopback_pair();
     if (!pair) {
         SUCCEED("could not open loopback UDP pair; skipping");
@@ -401,7 +401,7 @@ TEST_CASE("OscChannel message callback replacement uses latest callback",
 }
 
 TEST_CASE("OscChannel routes received messages through custom executor",
-          "[osc_channel][raw][coverage]") {
+          "[osc_channel][raw]") {
     std::mutex queue_mu;
     std::vector<std::function<void()>> queued;
     OscChannelOptions options;

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Polynomial roots_quadratic complex roots", "[signal][poly]") {
 }
 
 TEST_CASE("Polynomial roots_quadratic reports repeated real roots",
-          "[signal][poly][coverage]") {
+          "[signal][poly]") {
     auto [r1, r2] = Polynomial::roots_quadratic(1.0f, -2.0f, 1.0f);
     REQUIRE_THAT(r1.real(), WithinAbs(1.0f, 0.001f));
     REQUIRE_THAT(r2.real(), WithinAbs(1.0f, 0.001f));
@@ -184,7 +184,7 @@ TEST_CASE("Mat3 determinant", "[signal][matrix]") {
 }
 
 TEST_CASE("Mat3 determinant and identity composition cover nontrivial matrices",
-          "[signal][matrix][coverage]") {
+          "[signal][matrix]") {
     Mat3 a{{{2.0f, -1.0f, 0.5f},
             {3.0f, 4.0f, -2.0f},
             {1.0f, 0.0f, 5.0f}}};
@@ -226,13 +226,13 @@ TEST_CASE("Polynomial eval_complex", "[signal][poly]") {
 }
 
 TEST_CASE("Polynomial eval handles higher order negative inputs",
-          "[signal][poly][codecov]") {
+          "[signal][poly]") {
     auto result = Polynomial::eval({-1.0f, 2.0f, -3.0f, 4.0f}, -2.0f);
     REQUIRE_THAT(result, WithinAbs(-49.0f, 0.001f));
 }
 
 TEST_CASE("Polynomial multiply handles constant factors",
-          "[signal][poly][codecov]") {
+          "[signal][poly]") {
     auto result = Polynomial::multiply({2.0f}, {1.0f, -3.0f, 5.0f});
     REQUIRE(result.size() == 3);
     REQUIRE_THAT(result[0], WithinAbs(2.0f, 0.001f));
@@ -241,7 +241,7 @@ TEST_CASE("Polynomial multiply handles constant factors",
 }
 
 TEST_CASE("Polynomial derivative handles cubic coefficients",
-          "[signal][poly][codecov]") {
+          "[signal][poly]") {
     auto result = Polynomial::derivative({-4.0f, 3.0f, -2.0f, 5.0f});
     REQUIRE(result.size() == 3);
     REQUIRE_THAT(result[0], WithinAbs(3.0f, 0.001f));
@@ -250,7 +250,7 @@ TEST_CASE("Polynomial derivative handles cubic coefficients",
 }
 
 TEST_CASE("Mat3 determinant handles singular and scaled matrices",
-          "[signal][matrix][codecov]") {
+          "[signal][matrix]") {
     Mat3 singular{{{1.0f, 2.0f, 3.0f}, {2.0f, 4.0f, 6.0f}, {0.0f, 1.0f, 0.0f}}};
     REQUIRE_THAT(singular.determinant(), WithinAbs(0.0f, 0.001f));
 
@@ -259,7 +259,7 @@ TEST_CASE("Mat3 determinant handles singular and scaled matrices",
 }
 
 TEST_CASE("Polynomial roots handle negative leading coefficient",
-          "[signal][poly][codecov]") {
+          "[signal][poly]") {
     auto [r1, r2] = Polynomial::roots_quadratic(-1.0f, 0.0f, 4.0f);
     REQUIRE_THAT(std::abs(r1.real()), WithinAbs(2.0f, 0.001f));
     REQUIRE_THAT(std::abs(r2.real()), WithinAbs(2.0f, 0.001f));
@@ -268,7 +268,7 @@ TEST_CASE("Polynomial roots handle negative leading coefficient",
 }
 
 TEST_CASE("Mat2 inverse handles negative determinants",
-          "[signal][matrix][codecov]") {
+          "[signal][matrix]") {
     Mat2 matrix{{{0.0f, 2.0f}, {3.0f, 0.0f}}};
     REQUIRE_THAT(matrix.determinant(), WithinAbs(-6.0f, 0.001f));
 
@@ -280,7 +280,7 @@ TEST_CASE("Mat2 inverse handles negative determinants",
 }
 
 TEST_CASE("Mat3 multiplication preserves identity on both sides",
-          "[signal][matrix][codecov]") {
+          "[signal][matrix]") {
     Mat3 matrix{{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}}};
     auto left = Mat3::identity() * matrix;
     auto right = matrix * Mat3::identity();

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -762,7 +762,7 @@ TEST_CASE("PresetManager navigation on empty preset list returns false",
 }
 
 TEST_CASE("PresetManager saved file includes metadata and parameter entries",
-          "[state][preset][large]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-metadata");
     StateStore store;
     setup_test_store(store);
@@ -784,7 +784,7 @@ TEST_CASE("PresetManager saved file includes metadata and parameter entries",
 }
 
 TEST_CASE("PresetManager saving the same name overwrites the user preset",
-          "[state][preset][large]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-overwrite");
     StateStore store;
     setup_test_store(store);
@@ -804,7 +804,7 @@ TEST_CASE("PresetManager saving the same name overwrites the user preset",
 }
 
 TEST_CASE("PresetManager direct path load reports stem in callback",
-          "[state][preset][large]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-direct-load-callback");
     StateStore store;
     setup_test_store(store);
@@ -826,7 +826,7 @@ TEST_CASE("PresetManager direct path load reports stem in callback",
 }
 
 TEST_CASE("PresetManager import creates the user preset directory",
-          "[state][preset][large]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-import-creates-dir");
     StateStore store;
     setup_test_store(store);
@@ -884,7 +884,7 @@ TEST_CASE("PresetManager import of duplicate destination preserves existing pres
 }
 
 TEST_CASE("PresetManager rename failure leaves current preset unchanged",
-          "[state][preset][large]") {
+          "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-rename-missing-current");
     StateStore store;
     setup_test_store(store);

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1178,7 +1178,7 @@ TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
 }
 
 TEST_CASE("base64 rejects URL-safe alphabet and misplaced padding across whitespace",
-          "[runtime][base64][large]") {
+          "[runtime][base64]") {
     REQUIRE_FALSE(base64_decode("SGVsbG8-").has_value());
     REQUIRE_FALSE(base64_decode("SGVsbG8_").has_value());
     REQUIRE_FALSE(base64_decode("YQ=\n=Z").has_value());
@@ -1246,7 +1246,7 @@ TEST_CASE("base64 decodes mixed full quartets and unpadded tails",
 }
 
 TEST_CASE("base64 covers full alphabet and padded binary tails",
-          "[runtime][base64][large]") {
+          "[runtime][base64]") {
     const uint8_t alphabet_bytes[] = {
         0x00, 0x10, 0x83, 0x10, 0x51, 0x87, 0x20, 0x92,
         0x8b, 0x30, 0xd3, 0x8f, 0x41, 0x14, 0x93, 0x51,
@@ -1270,7 +1270,7 @@ TEST_CASE("base64 covers full alphabet and padded binary tails",
 }
 
 TEST_CASE("base64 decode tolerates whitespace inside unpadded input",
-          "[runtime][base64][large]") {
+          "[runtime][base64]") {
     auto decoded = base64_decode("\n Y W J \t j Z A \r");
     REQUIRE(decoded.has_value());
     REQUIRE(std::string(decoded->begin(), decoded->end()) == "abcd");
@@ -1497,7 +1497,7 @@ TEST_CASE("Expression evaluator handles nested function calls",
 }
 
 TEST_CASE("Expression evaluator covers multi-argument builtins",
-          "[runtime][expression][large]") {
+          "[runtime][expression]") {
     REQUIRE(evaluate("min(5, 3)") == Catch::Approx(3.0));
     REQUIRE(evaluate("max(5, 3)") == Catch::Approx(5.0));
     REQUIRE(evaluate("pow(2, 5)") == Catch::Approx(32.0));
@@ -1506,7 +1506,7 @@ TEST_CASE("Expression evaluator covers multi-argument builtins",
 }
 
 TEST_CASE("Expression evaluator rejects incomplete multi-argument calls",
-          "[runtime][expression][large]") {
+          "[runtime][expression]") {
     REQUIRE_FALSE(evaluate("min(1)").has_value());
     REQUIRE_FALSE(evaluate("max(1)").has_value());
     REQUIRE_FALSE(evaluate("pow(2)").has_value());
@@ -1516,7 +1516,7 @@ TEST_CASE("Expression evaluator rejects incomplete multi-argument calls",
 // ── ScopeGuard ─────────────────────────────────────────────────────────
 
 TEST_CASE("ScopeGuard dismiss and move transfer ownership",
-          "[runtime][scope_guard][large]") {
+          "[runtime][scope_guard]") {
     int calls = 0;
     {
         auto guard = make_scope_guard([&] { ++calls; });
@@ -1533,7 +1533,7 @@ TEST_CASE("ScopeGuard dismiss and move transfer ownership",
 }
 
 TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
-          "[runtime][scope_guard][large]") {
+          "[runtime][scope_guard]") {
     int value = 0;
     {
         PULP_ON_SCOPE_EXIT(value = 42);
@@ -2025,7 +2025,7 @@ TEST_CASE("format_diff handles manually constructed operation order",
 }
 
 TEST_CASE("text_diff tie-breaks replacements as delete before insert",
-          "[runtime][text-diff][large]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("left\nmiddle\nright",
                           "left\ncenter\nright");
 
@@ -2041,7 +2041,7 @@ TEST_CASE("text_diff tie-breaks replacements as delete before insert",
 }
 
 TEST_CASE("text_diff preserves blank lines as diff entries",
-          "[runtime][text-diff][large]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("alpha\n\nomega",
                           "alpha\ninserted\n\nomega");
 
@@ -2057,7 +2057,7 @@ TEST_CASE("text_diff preserves blank lines as diff entries",
 }
 
 TEST_CASE("format_diff keeps empty inserted and deleted lines visible",
-          "[runtime][text-diff][large]") {
+          "[runtime][text-diff]") {
     const std::vector<DiffEntry> diff{
         {DiffOp::Equal, "context"},
         {DiffOp::Delete, ""},
@@ -2071,7 +2071,7 @@ TEST_CASE("format_diff keeps empty inserted and deleted lines visible",
 }
 
 TEST_CASE("text_diff treats trailing newline as no synthetic blank line",
-          "[runtime][text-diff][large]") {
+          "[runtime][text-diff]") {
     auto diff = text_diff("alpha\nbeta\n", "alpha\nbeta");
 
     REQUIRE(diff.size() == 2);

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -85,7 +85,7 @@ TEST_CASE("DelayLine handles empty, wraparound, and reset edges",
 }
 
 TEST_CASE("DelayLine zero max delay uses a stable single-sample buffer",
-          "[signal][delay][coverage]") {
+          "[signal][delay]") {
     DelayLine dl;
     dl.prepare(0);
 
@@ -103,7 +103,7 @@ TEST_CASE("DelayLine zero max delay uses a stable single-sample buffer",
 }
 
 TEST_CASE("DelayLine fractional reads interpolate across wrapped write positions",
-          "[signal][delay][coverage]") {
+          "[signal][delay]") {
     DelayLine dl;
     dl.prepare(3);
 
@@ -154,7 +154,7 @@ TEST_CASE("Gain linear setter and buffer processing", "[signal][gain][issue-645]
 }
 
 TEST_CASE("Gain dB conversion floors zero and negative linear values",
-          "[signal][gain][coverage]") {
+          "[signal][gain]") {
     REQUIRE_THAT(linear_to_db(0.0f), WithinAbs(-200.0f, 0.001f));
     REQUIRE_THAT(linear_to_db(-1.0f), WithinAbs(-200.0f, 0.001f));
 
@@ -170,7 +170,7 @@ TEST_CASE("Gain dB conversion floors zero and negative linear values",
 }
 
 TEST_CASE("Gain zero-length buffer calls leave sentinels untouched",
-          "[signal][gain][coverage]") {
+          "[signal][gain]") {
     Gain g;
     g.set_gain_linear(-2.0f);
 
@@ -216,7 +216,7 @@ TEST_CASE("SimpleMixer clamps mix and processes buffers",
 }
 
 TEST_CASE("SimpleMixer zero-length buffer processing leaves output untouched",
-          "[signal][mix][coverage]") {
+          "[signal][mix]") {
     SimpleMixer mixer;
     mixer.set_mix(0.5f);
 
@@ -229,7 +229,7 @@ TEST_CASE("SimpleMixer zero-length buffer processing leaves output untouched",
 }
 
 TEST_CASE("SimpleMixer scalar path clamps endpoint mixes",
-          "[signal][mix][coverage]") {
+          "[signal][mix]") {
     SimpleMixer mixer;
 
     mixer.set_mix(-0.25f);
@@ -388,7 +388,7 @@ TEST_CASE("SmoothedValue clamps one-sample ramps and partially skips",
 }
 
 TEST_CASE("SmoothedValue ignores non-positive skips",
-          "[signal][smooth][coverage]") {
+          "[signal][smooth]") {
     SmoothedValue<float> sv(0.0f);
     sv.set_ramp_time(0.01f, 1000.0f);
     sv.set_target(10.0f);
@@ -402,7 +402,7 @@ TEST_CASE("SmoothedValue ignores non-positive skips",
 }
 
 TEST_CASE("SmoothedValue double precision path reaches targets after skip",
-          "[signal][smooth][coverage]") {
+          "[signal][smooth]") {
     SmoothedValue<double> sv(2.0);
     sv.set_ramp_time(0.004, 1000.0);
     sv.set_target(6.0);
@@ -506,7 +506,7 @@ TEST_CASE("ADSR handles immediate stages, idle note_off, and reset",
 }
 
 TEST_CASE("ADSR retrigger continues from current release level",
-          "[signal][adsr][coverage]") {
+          "[signal][adsr]") {
     Adsr env;
     env.set_sample_rate(1000.0f);
     env.set_params({0.01f, 0.01f, 0.5f, 0.02f});
@@ -532,7 +532,7 @@ TEST_CASE("ADSR retrigger continues from current release level",
 }
 
 TEST_CASE("ADSR retrigger continues from current level",
-          "[signal][adsr][coverage]") {
+          "[signal][adsr]") {
     Adsr env;
     env.set_sample_rate(100.0f);
     env.set_params({0.1f, 0.2f, 0.25f, 0.1f});
@@ -550,7 +550,7 @@ TEST_CASE("ADSR retrigger continues from current level",
 }
 
 TEST_CASE("ADSR retrigger restarts attack from a partial level",
-          "[signal][adsr][coverage]") {
+          "[signal][adsr]") {
     Adsr env;
     env.set_sample_rate(1000.0f);
     env.set_params({0.1f, 0.1f, 0.25f, 0.1f});
@@ -923,7 +923,7 @@ TEST_CASE("Oscillator reset, phase wrap, and PolyBLEP edges are deterministic",
 }
 
 TEST_CASE("Oscillator zero frequency leaves phase fixed across waveforms",
-          "[signal][osc][coverage]") {
+          "[signal][osc]") {
     for (auto waveform : {
              Oscillator::Waveform::sine,
              Oscillator::Waveform::saw,
@@ -943,7 +943,7 @@ TEST_CASE("Oscillator zero frequency leaves phase fixed across waveforms",
 }
 
 TEST_CASE("Oscillator zero frequency leaves phase stationary",
-          "[signal][osc][coverage]") {
+          "[signal][osc]") {
     Oscillator osc;
     osc.set_sample_rate(48000.0f);
     osc.set_frequency(0.0f);
@@ -991,7 +991,7 @@ TEST_CASE("WaveShaper fold", "[signal][waveshaper]") {
 }
 
 TEST_CASE("WaveShaper handles zero and negative length buffers",
-          "[signal][waveshaper][coverage]") {
+          "[signal][waveshaper]") {
     WaveShaper ws;
     ws.set_curve(WaveShaper::Curve::hard_clip);
     ws.set_drive(8.0f);
@@ -1006,7 +1006,7 @@ TEST_CASE("WaveShaper handles zero and negative length buffers",
 }
 
 TEST_CASE("WaveShaper covers soft clip and sine fold curves",
-          "[signal][waveshaper][coverage]") {
+          "[signal][waveshaper]") {
     WaveShaper ws;
     ws.set_curve(WaveShaper::Curve::soft_clip);
     ws.set_drive(2.0f);
@@ -1026,7 +1026,7 @@ TEST_CASE("WaveShaper covers soft clip and sine fold curves",
 }
 
 TEST_CASE("WaveShaper fold reflects repeated positive and negative overshoot",
-          "[signal][waveshaper][coverage]") {
+          "[signal][waveshaper]") {
     WaveShaper ws;
     ws.set_curve(WaveShaper::Curve::fold);
     ws.set_drive(1.0f);
@@ -1042,7 +1042,7 @@ TEST_CASE("WaveShaper fold reflects repeated positive and negative overshoot",
 }
 
 TEST_CASE("WaveShaper buffer processing applies the selected curve in place",
-          "[signal][waveshaper][coverage]") {
+          "[signal][waveshaper]") {
     WaveShaper ws;
     ws.set_curve(WaveShaper::Curve::hard_clip);
     ws.set_drive(2.0f);
@@ -1113,7 +1113,7 @@ TEST_CASE("NoiseGate clamps range, instant timing, reset, and buffers",
 }
 
 TEST_CASE("NoiseGate ignores nonpositive buffer lengths",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(1000.0f);
     gate.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -24.0f});
@@ -1128,7 +1128,7 @@ TEST_CASE("NoiseGate ignores nonpositive buffer lengths",
 }
 
 TEST_CASE("NoiseGate sanitizes invalid params without amplifying quiet input",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(1000.0f);
     gate.set_params({
@@ -1151,7 +1151,7 @@ TEST_CASE("NoiseGate sanitizes invalid params without amplifying quiet input",
 }
 
 TEST_CASE("NoiseGate clamps timing and ratio to stable instantaneous behavior",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(1000.0f);
     gate.set_params({-20.0f, 0.25f, -1.0f, -10.0f, -48.0f});
@@ -1166,7 +1166,7 @@ TEST_CASE("NoiseGate clamps timing and ratio to stable instantaneous behavior",
 }
 
 TEST_CASE("NoiseGate invalid sample rates fall back to finite coefficients",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(-1.0f);
     gate.set_params({-20.0f, 20.0f, 0.5f, 50.0f, -24.0f});
@@ -1184,7 +1184,7 @@ TEST_CASE("NoiseGate invalid sample rates fall back to finite coefficients",
 }
 
 TEST_CASE("NoiseGate null buffers and valid buffers preserve callback safety",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(1000.0f);
     gate.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -24.0f});
@@ -1206,7 +1206,7 @@ TEST_CASE("NoiseGate null buffers and valid buffers preserve callback safety",
 }
 
 TEST_CASE("NoiseGate reset releases held attenuation after sanitized params",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(std::numeric_limits<float>::infinity());
     gate.set_params({-20.0f, 20.0f, 0.0f, 1000.0f, -18.0f});
@@ -1223,7 +1223,7 @@ TEST_CASE("NoiseGate reset releases held attenuation after sanitized params",
 }
 
 TEST_CASE("NoiseGate non-finite range falls back to bounded attenuation",
-          "[signal][gate][coverage]") {
+          "[signal][gate]") {
     NoiseGate gate;
     gate.set_sample_rate(std::numeric_limits<float>::quiet_NaN());
     gate.set_params({
@@ -1301,7 +1301,7 @@ TEST_CASE("Panner clamps and processes stereo in place",
 }
 
 TEST_CASE("Panner preserves equal-power mono energy and input sign",
-          "[signal][panner][coverage]") {
+          "[signal][panner]") {
     Panner pan;
     pan.set_pan(-0.25f);
 
@@ -1384,7 +1384,7 @@ TEST_CASE("Chorus dry mix, phase wrap, and reset are deterministic",
 }
 
 TEST_CASE("Chorus is safe before prepare and rejects non-finite mix",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus unprepared;
     unprepared.set_mix(1.0f);
     unprepared.set_depth(1.0f);
@@ -1409,7 +1409,7 @@ TEST_CASE("Chorus is safe before prepare and rejects non-finite mix",
 }
 
 TEST_CASE("Chorus wet zero-depth delay is centered and mono-compatible",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus chorus;
     chorus.prepare(1000.0f);
     chorus.set_rate(0.0f);
@@ -1433,7 +1433,7 @@ TEST_CASE("Chorus wet zero-depth delay is centered and mono-compatible",
 }
 
 TEST_CASE("Chorus clamps mix and delay to safe callback ranges",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus dry;
     dry.prepare(1000.0f);
     dry.set_mix(-1.0f);
@@ -1461,7 +1461,7 @@ TEST_CASE("Chorus clamps mix and delay to safe callback ranges",
 }
 
 TEST_CASE("Chorus depth clamps preserve modulation timing bounds",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus limited_depth;
     limited_depth.prepare(1000.0f);
     limited_depth.set_rate(0.0f);
@@ -1497,7 +1497,7 @@ TEST_CASE("Chorus depth clamps preserve modulation timing bounds",
 }
 
 TEST_CASE("Chorus reset clears delayed audio and restarts the same response",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus chorus;
     chorus.prepare(1000.0f);
     chorus.set_rate(0.0f);
@@ -1529,7 +1529,7 @@ TEST_CASE("Chorus reset clears delayed audio and restarts the same response",
 }
 
 TEST_CASE("Chorus invalid sample rates and fast modulation stay finite",
-          "[signal][chorus][coverage]") {
+          "[signal][chorus]") {
     Chorus chorus;
     chorus.prepare(0.0f);
     chorus.set_rate(std::numeric_limits<float>::infinity());
@@ -1608,7 +1608,7 @@ TEST_CASE("Phaser clamps stage and feedback settings and resets",
 }
 
 TEST_CASE("Phaser zero-length block processing is a no-op",
-          "[signal][phaser][coverage]") {
+          "[signal][phaser]") {
     Phaser phaser;
     phaser.set_sample_rate(48000.0f);
     phaser.set_mix(1.0f);
@@ -1621,7 +1621,7 @@ TEST_CASE("Phaser zero-length block processing is a no-op",
 }
 
 TEST_CASE("Phaser zero-length buffer processing is a no-op",
-          "[signal][phaser][coverage]") {
+          "[signal][phaser]") {
     Phaser phaser;
     phaser.set_sample_rate(48000.0f);
     phaser.set_rate(1.0f);
@@ -1707,7 +1707,7 @@ TEST_CASE("Reverb handles zero decay, damping clamp, dry mix, and reset",
 // ── Spectral display helpers ────────────────────────────────────────────────
 
 TEST_CASE("Signal target covers window families and bounded application",
-          "[signal][window][coverage]") {
+          "[signal][window]") {
     const auto rectangular = WindowFunction::generate(6, WindowFunction::Type::rectangular);
     REQUIRE(rectangular.size() == 6);
     REQUIRE_THAT(rectangular[3], WithinAbs(1.0f, 1e-6f));
@@ -1744,7 +1744,7 @@ TEST_CASE("Signal target covers window families and bounded application",
 }
 
 TEST_CASE("WindowFunction edge sizes and symmetry stay deterministic",
-          "[signal][window][coverage]") {
+          "[signal][window]") {
     REQUIRE(WindowFunction::generate(-3, WindowFunction::Type::blackman).empty());
 
     for (auto type : {WindowFunction::Type::hann,
@@ -1773,7 +1773,7 @@ TEST_CASE("WindowFunction edge sizes and symmetry stay deterministic",
 }
 
 TEST_CASE("WindowFunction applies only provided coefficients and honors Kaiser alpha",
-          "[signal][window][coverage]") {
+          "[signal][window]") {
     float partial[] = {2.0f, 4.0f, 8.0f, 16.0f};
     WindowFunction::apply(partial, {0.25f, 0.5f});
     REQUIRE_THAT(partial[0], WithinAbs(0.5f, 1e-6f));
@@ -1798,7 +1798,7 @@ TEST_CASE("WindowFunction applies only provided coefficients and honors Kaiser a
 }
 
 TEST_CASE("Signal target covers spectrogram ramps axes and scrolling columns",
-          "[signal][spectrogram][coverage]") {
+          "[signal][spectrogram]") {
     ColorMapper inferno(ColorRamp::inferno);
     const auto inferno_low = inferno.map(0.0f);
     const auto inferno_mid = inferno.map(0.5f);
@@ -1861,7 +1861,7 @@ TEST_CASE("Signal target covers spectrogram ramps axes and scrolling columns",
 }
 
 TEST_CASE("Signal target covers lookup table clamping and interpolation",
-          "[signal][lookup][coverage]") {
+          "[signal][lookup]") {
     LookupTable table(3, 0.0f, 1.0f, [](float x) { return x * 2.0f; });
 
     REQUIRE(table.size() == 3);
@@ -1872,7 +1872,7 @@ TEST_CASE("Signal target covers lookup table clamping and interpolation",
 }
 
 TEST_CASE("Signal target covers lookup table construction edge cases",
-          "[signal][lookup][coverage]") {
+          "[signal][lookup]") {
     LookupTable empty(0, -1.0f, 1.0f, [](float x) { return x * x; });
     REQUIRE(empty.empty());
     REQUIRE(empty.size() == 0);
@@ -1895,7 +1895,7 @@ TEST_CASE("Signal target covers lookup table construction edge cases",
 }
 
 TEST_CASE("Signal target covers lookup table reversed ranges and buffers",
-          "[signal][lookup][coverage]") {
+          "[signal][lookup]") {
     LookupTable reversed(5, 2.0f, -2.0f, [](float x) { return x * x; });
 
     REQUIRE(reversed.size() == 5);

--- a/test/test_signal_filters.cpp
+++ b/test/test_signal_filters.cpp
@@ -160,7 +160,7 @@ TEST_CASE("SVF covers bandpass notch buffer and reset paths",
 }
 
 TEST_CASE("SVF ignores nonpositive buffer lengths",
-          "[signal][svf][coverage]") {
+          "[signal][svf]") {
     Svf filter;
     filter.set_sample_rate(48000.0f);
     filter.set_frequency(1000.0f);
@@ -224,7 +224,7 @@ TEST_CASE("LadderFilter resets buffer state and clamps resonance inputs",
 }
 
 TEST_CASE("LadderFilter reset restores fresh-filter impulse response",
-          "[signal][ladder][coverage]") {
+          "[signal][ladder]") {
     auto impulse_response = [] {
         LadderFilter filter;
         filter.set_sample_rate(48000.0f);
@@ -256,7 +256,7 @@ TEST_CASE("LadderFilter reset restores fresh-filter impulse response",
 }
 
 TEST_CASE("LadderFilter ignores nonpositive buffer lengths",
-          "[signal][ladder][coverage]") {
+          "[signal][ladder]") {
     LadderFilter ladder;
     ladder.set_sample_rate(44100.0f);
     ladder.set_frequency(1200.0f);
@@ -352,7 +352,7 @@ TEST_CASE("LinkwitzRiley cutoff boundary processing stays finite",
 }
 
 TEST_CASE("LinkwitzRiley retuning after active history stays finite",
-          "[signal][lr][coverage]") {
+          "[signal][lr]") {
     LinkwitzRiley lr;
     lr.set_frequency(300.0f, 48000.0f);
     for (int i = 0; i < 32; ++i) {

--- a/test/test_signal_meter.cpp
+++ b/test/test_signal_meter.cpp
@@ -208,7 +208,7 @@ TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][me
 }
 
 TEST_CASE("MultiChannelBallistics clamps tiny levels and releases held peaks",
-          "[signal][meter][coverage]") {
+          "[signal][meter]") {
     MultiChannelBallistics ballistics;
     ballistics.peak_hold_time = 0.01f;
 

--- a/test/test_signal_spectral.cpp
+++ b/test/test_signal_spectral.cpp
@@ -190,7 +190,7 @@ TEST_CASE("FFT move preserves transform state", "[signal][fft][issue-645]") {
 }
 
 TEST_CASE("FFT move assignment replaces an existing transform",
-          "[signal][fft][coverage]") {
+          "[signal][fft]") {
     Fft source(8);
     Fft destination(16);
 
@@ -257,7 +257,7 @@ TEST_CASE("FFT forward_real preserves exact-bin conjugate symmetry", "[signal][f
 }
 
 TEST_CASE("FFT real transform exposes DC and Nyquist bins explicitly",
-          "[signal][fft][coverage]") {
+          "[signal][fft]") {
     constexpr int N = 16;
     Fft fft(N);
     std::vector<float> constant(N, 0.25f);
@@ -280,7 +280,7 @@ TEST_CASE("FFT real transform exposes DC and Nyquist bins explicitly",
 }
 
 TEST_CASE("FFT magnitude helpers tolerate empty ranges and preserve destination values",
-          "[signal][fft][coverage]") {
+          "[signal][fft]") {
     Fft fft(8);
     std::vector<std::complex<float>> bins(8, {1.0f, 0.0f});
     std::vector<float> linear = {7.0f, 8.0f};
@@ -375,7 +375,7 @@ TEST_CASE("Convolver reset clears buffered overlap", "[signal][convolver][issue-
 }
 
 TEST_CASE("Convolver unloaded and empty IR paths pass through safely",
-          "[signal][convolver][coverage]") {
+          "[signal][convolver]") {
     Convolver conv;
     REQUIRE_THAT(conv.process(0.375f), WithinAbs(0.375f, 1e-6f));
     REQUIRE_THAT(conv.process(-0.25f), WithinAbs(-0.25f, 1e-6f));
@@ -407,7 +407,7 @@ TEST_CASE("Convolver unloaded and empty IR paths pass through safely",
 }
 
 TEST_CASE("Convolver default block size and reload reset the buffered stream",
-          "[signal][convolver][coverage]") {
+          "[signal][convolver]") {
     Convolver conv;
     float identity[] = {1.0f};
     conv.load_ir(identity, 1);

--- a/test/test_simd.cpp
+++ b/test/test_simd.cpp
@@ -214,7 +214,7 @@ TEST_CASE("simd operations handle empty input", "[simd]") {
 }
 
 TEST_CASE("simd reductions return zero for empty max and min",
-          "[simd][coverage]") {
+          "[simd]") {
     float dummy = 42.0f;
     REQUIRE(simd_reduce_max(&dummy, 0) == 0.0f);
     REQUIRE(simd_reduce_min(&dummy, 0) == 0.0f);

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -1011,7 +1011,7 @@ TEST_CASE("CachedProperty destruction removes its StateTree listener",
 }
 
 TEST_CASE("CachedProperty bool ignores mismatched refresh values",
-          "[state][cached][large]") {
+          "[state][cached]") {
     auto tree = StateTree::create("params");
     tree->set("enabled", true);
     CachedProperty<bool> enabled(tree, "enabled", false);
@@ -1028,7 +1028,7 @@ TEST_CASE("CachedProperty bool ignores mismatched refresh values",
 }
 
 TEST_CASE("CachedProperty int64 move tracks later tree updates",
-          "[state][cached][large]") {
+          "[state][cached]") {
     auto tree = StateTree::create("params");
     tree->set("voices", int64_t(8));
     CachedProperty<int64_t> voices(tree, "voices", 1);

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -93,7 +93,7 @@ NamedPipePair open_named_pipe_pair(const std::filesystem::path& path) {
 }  // namespace
 
 TEST_CASE("StreamResult helper predicates classify errors",
-          "[stream][coverage]") {
+          "[stream]") {
     auto ok = StreamResult::make(3);
     REQUIRE(ok.ok());
     REQUIRE_FALSE(ok.would_block());
@@ -112,7 +112,7 @@ TEST_CASE("StreamResult helper predicates classify errors",
 }
 
 TEST_CASE("StreamResult factory preserves explicit zero-byte success",
-          "[stream][coverage]") {
+          "[stream]") {
     auto result = StreamResult::make(0);
     REQUIRE(result.ok());
     REQUIRE_FALSE(result.would_block());
@@ -121,7 +121,7 @@ TEST_CASE("StreamResult factory preserves explicit zero-byte success",
 }
 
 TEST_CASE("StreamResult closed failure has no transferred bytes",
-          "[stream][coverage]") {
+          "[stream]") {
     auto result = StreamResult::fail(StreamError::Closed);
     REQUIRE_FALSE(result.ok());
     REQUIRE_FALSE(result.would_block());
@@ -130,7 +130,7 @@ TEST_CASE("StreamResult closed failure has no transferred bytes",
 }
 
 TEST_CASE("StreamResult closed predicate only matches closed errors",
-          "[stream][coverage]") {
+          "[stream]") {
     auto closed = StreamResult::fail(StreamError::Closed);
     REQUIRE_FALSE(closed.ok());
     REQUIRE_FALSE(closed.would_block());
@@ -164,7 +164,7 @@ TEST_CASE("MemoryStream round-trip", "[stream]") {
 }
 
 TEST_CASE("MemoryStream default starts open and empty",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream;
     REQUIRE(stream.is_open());
     REQUIRE(stream.size() == 0);
@@ -194,7 +194,7 @@ TEST_CASE("MemoryStream partial read", "[stream]") {
 }
 
 TEST_CASE("MemoryStream read cursor remains at end after EOF",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{11, 22});
     std::uint8_t out[4]{};
 
@@ -208,7 +208,7 @@ TEST_CASE("MemoryStream read cursor remains at end after EOF",
 }
 
 TEST_CASE("MemoryStream rewind after EOF allows replay",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{4, 5, 6});
     std::uint8_t out[3]{};
 
@@ -223,7 +223,7 @@ TEST_CASE("MemoryStream rewind after EOF allows replay",
 }
 
 TEST_CASE("MemoryStream close is idempotent",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{1});
     stream.close();
     stream.close();
@@ -235,7 +235,7 @@ TEST_CASE("MemoryStream close is idempotent",
 }
 
 TEST_CASE("MemoryStream write copies caller storage",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream;
     std::uint8_t payload[] = {1, 2, 3};
     REQUIRE(stream.write(payload, sizeof(payload)).bytes == sizeof(payload));
@@ -248,7 +248,7 @@ TEST_CASE("MemoryStream write copies caller storage",
 }
 
 TEST_CASE("MemoryStream write preserves existing unread prefix",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{10, 20, 30});
     std::uint8_t out[2]{};
     REQUIRE(stream.read(out, 1).bytes == 1);
@@ -263,7 +263,7 @@ TEST_CASE("MemoryStream write preserves existing unread prefix",
 }
 
 TEST_CASE("MemoryStream clear is idempotent on open streams",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     stream.clear();
     stream.clear();
@@ -274,7 +274,7 @@ TEST_CASE("MemoryStream clear is idempotent on open streams",
 }
 
 TEST_CASE("MemoryStream zero-byte write on closed stream reports closed",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream;
     stream.close();
 
@@ -338,7 +338,7 @@ TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
 }
 
 TEST_CASE("MemoryStream clear does not reopen a closed stream",
-          "[stream][coverage][large]") {
+          "[stream]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     stream.close();
     stream.clear();
@@ -352,7 +352,7 @@ TEST_CASE("MemoryStream clear does not reopen a closed stream",
     REQUIRE(stream.write(&byte, 1).closed());
 }
 
-TEST_CASE("StreamResult helpers classify non-ok states", "[stream][coverage][issue-656]") {
+TEST_CASE("StreamResult helpers classify non-ok states", "[stream][issue-656]") {
     auto ok = StreamResult::make(3);
     REQUIRE(ok.ok());
     REQUIRE(ok.bytes == 3);
@@ -437,7 +437,7 @@ TEST_CASE("FileStream append and move keep handle ownership correct", "[stream]"
 }
 
 TEST_CASE("FileStream read-write mode tracks position and zero-byte I/O",
-          "[stream][coverage]") {
+          "[stream]") {
     auto path = make_temp_path("pulp_stream_readwrite");
     const std::uint8_t payload[] = {'r', 'w', '0'};
 
@@ -485,7 +485,7 @@ TEST_CASE("FileStream open failure leaves stream closed", "[stream]") {
     REQUIRE(r.closed());
 }
 
-TEST_CASE("FileStream zero-size operations and positions are stable", "[stream][coverage][issue-656]") {
+TEST_CASE("FileStream zero-size operations and positions are stable", "[stream][issue-656]") {
     auto path = make_temp_path("pulp_stream_position");
     const std::uint8_t payload[] = {'x', 'y', 'z'};
 
@@ -541,7 +541,7 @@ TEST_CASE("Stream polymorphic usage", "[stream]") {
 }
 
 TEST_CASE("FileStream ReadWrite mode tracks position and truncates on open",
-          "[stream][file][coverage][issue-641]") {
+          "[stream][file][issue-641]") {
     auto path = make_temp_path("pulp_stream_readwrite");
     const std::uint8_t first[] = {'o', 'l', 'd'};
     const std::uint8_t second[] = {'n', 'e', 'w', '!'};
@@ -575,7 +575,7 @@ TEST_CASE("FileStream ReadWrite mode tracks position and truncates on open",
 }
 
 TEST_CASE("MemoryStream clear keeps closed streams closed",
-          "[stream][memory][coverage][issue-641]") {
+          "[stream][memory][issue-641]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     stream.close();
     stream.clear();
@@ -590,7 +590,7 @@ TEST_CASE("MemoryStream clear keeps closed streams closed",
 }
 
 TEST_CASE("MemoryStream appends without rewinding the read cursor",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
     std::uint8_t out[4]{};
 
@@ -615,7 +615,7 @@ TEST_CASE("MemoryStream appends without rewinding the read cursor",
 }
 
 TEST_CASE("MemoryStream clear allows fresh writes from the beginning",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{9, 8, 7});
     std::uint8_t discarded[2]{};
     REQUIRE(stream.read(discarded, sizeof(discarded)).bytes == sizeof(discarded));
@@ -637,7 +637,7 @@ TEST_CASE("MemoryStream clear allows fresh writes from the beginning",
 }
 
 TEST_CASE("MemoryStream rejects null buffers for non-empty I/O",
-          "[stream][memory][coverage]") {
+          "[stream][memory]") {
     MemoryStream stream(std::vector<std::uint8_t>{1, 2});
     std::uint8_t byte = 9;
 
@@ -660,7 +660,7 @@ TEST_CASE("MemoryStream rejects null buffers for non-empty I/O",
 }
 
 TEST_CASE("MemoryStream default construction reports open empty stream",
-          "[stream][memory][coverage][large]") {
+          "[stream][memory]") {
     MemoryStream empty;
     REQUIRE(empty.is_open());
     REQUIRE(empty.size() == 0);
@@ -671,7 +671,7 @@ TEST_CASE("MemoryStream default construction reports open empty stream",
 }
 
 TEST_CASE("FileStream reopen closes the previous handle",
-          "[stream][file][coverage]") {
+          "[stream][file]") {
     auto first = make_temp_path("pulp_stream_reopen_first");
     auto second = make_temp_path("pulp_stream_reopen_second");
     const std::uint8_t a[] = {'a'};
@@ -704,7 +704,7 @@ TEST_CASE("FileStream reopen closes the previous handle",
 }
 
 TEST_CASE("FileStream move construction transfers open handle and closes source",
-          "[stream][file][coverage][large]") {
+          "[stream][file]") {
     auto path = make_temp_path("pulp_stream_move_construct");
     const std::uint8_t payload[] = {'m', 'o', 'v', 'e'};
 
@@ -727,7 +727,7 @@ TEST_CASE("FileStream move construction transfers open handle and closes source"
 }
 
 TEST_CASE("FileStream move assignment handles self and closed sources",
-          "[stream][file][coverage]") {
+          "[stream][file]") {
     auto path = make_temp_path("pulp_stream_self_move");
     const std::uint8_t payload[] = {'s', 'e', 'l', 'f'};
 
@@ -755,7 +755,7 @@ TEST_CASE("FileStream move assignment handles self and closed sources",
 }
 
 TEST_CASE("FileStream rejects null buffers for non-empty I/O",
-          "[stream][file][coverage]") {
+          "[stream][file]") {
     auto path = make_temp_path("pulp_stream_null_buffers");
     const std::uint8_t payload[] = {'o', 'k'};
 
@@ -788,7 +788,7 @@ TEST_CASE("FileStream rejects null buffers for non-empty I/O",
 }
 
 TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
-          "[stream][tcp][coverage][issue-641]") {
+          "[stream][tcp][issue-641]") {
     TcpStream first;
     TcpStream second;
     std::uint8_t byte = 0;
@@ -804,7 +804,7 @@ TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
 }
 
 TEST_CASE("HttpStream invalid URLs fail without external transport",
-          "[stream][http][coverage][issue-641]") {
+          "[stream][http][issue-641]") {
     HttpStream stream;
     HttpStream::Request request;
     request.url = "not-a-url";
@@ -825,7 +825,7 @@ TEST_CASE("HttpStream invalid URLs fail without external transport",
 }
 
 TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure",
-          "[stream][http][coverage]") {
+          "[stream][http]") {
     HttpStream stream;
     stream.close();
 
@@ -845,7 +845,7 @@ TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure"
 }
 
 TEST_CASE("PipeStream closed and null pipe states fail closed",
-          "[stream][pipe][coverage]") {
+          "[stream][pipe]") {
     PipeStream stream;
     std::uint8_t byte = 0;
 
@@ -885,7 +885,7 @@ TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_
 }
 
 TEST_CASE("PipeStream default and moved-empty streams fail closed",
-          "[stream][pipe][coverage]") {
+          "[stream][pipe]") {
     PipeStream stream;
     REQUIRE_FALSE(stream.is_open());
 
@@ -908,7 +908,7 @@ TEST_CASE("PipeStream default and moved-empty streams fail closed",
 }
 
 TEST_CASE("PipeStream closed streams still report closed before null-buffer checks",
-          "[stream][pipe][coverage]") {
+          "[stream][pipe]") {
     PipeStream stream;
 
     REQUIRE(stream.read(nullptr, 1).closed());
@@ -917,7 +917,7 @@ TEST_CASE("PipeStream closed streams still report closed before null-buffer chec
 
 #ifndef _WIN32
 TEST_CASE("PipeStream POSIX FIFO round-trips bytes",
-          "[stream][pipe][coverage]") {
+          "[stream][pipe]") {
     auto path = make_temp_path("pulp_pipe_stream_roundtrip");
     std::filesystem::remove(path);
 
@@ -1058,7 +1058,7 @@ TEST_CASE("NamedPipe POSIX client read waits through initial reply EOF",
 }
 
 TEST_CASE("PipeStream forwards reads and writes over a connected POSIX FIFO",
-          "[stream][pipe][coverage]") {
+          "[stream][pipe]") {
     auto path = make_temp_path("pulp_pipe_stream_roundtrip");
     std::filesystem::remove(path);
 

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -18,7 +18,7 @@ struct TransportState {
 };
 
 TEST_CASE("SeqLock default constructor publishes value-initialized snapshots",
-          "[runtime][seqlock][coverage]") {
+          "[runtime][seqlock]") {
     SeqLock<TransportState> lock;
 
     auto result = lock.read();
@@ -46,7 +46,7 @@ TEST_CASE("SeqLock basic read/write", "[runtime][seqlock]") {
 }
 
 TEST_CASE("SeqLock default value is readable before first write",
-          "[runtime][seqlock][coverage]") {
+          "[runtime][seqlock]") {
     SeqLock<TransportState> lock;
 
     auto result = lock.read();
@@ -58,7 +58,7 @@ TEST_CASE("SeqLock default value is readable before first write",
 }
 
 TEST_CASE("SeqLock explicit initial value is readable before first write",
-          "[runtime][seqlock][coverage]") {
+          "[runtime][seqlock]") {
     TransportState init;
     init.tempo = 96.0;
     init.beat_position = 12.25;
@@ -113,7 +113,7 @@ TEST_CASE("SeqLock concurrent stress test", "[runtime][seqlock]") {
 }
 
 TEST_CASE("SpscQueue failed push preserves queued item",
-          "[runtime][spsc][coverage]") {
+          "[runtime][spsc]") {
     SpscQueue<int, 1> q;
 
     REQUIRE(q.empty());
@@ -134,7 +134,7 @@ TEST_CASE("SpscQueue failed push preserves queued item",
 // ── TripleBuffer tests ────────────────────────────────────────────────────
 
 TEST_CASE("TripleBuffer default constructor exposes value-initialized front buffer",
-          "[runtime][triple_buffer][coverage]") {
+          "[runtime][triple_buffer]") {
     TripleBuffer<TransportState> buf;
 
     const auto& initial = buf.read();
@@ -155,7 +155,7 @@ TEST_CASE("TripleBuffer basic read/write", "[runtime][triple_buffer]") {
 }
 
 TEST_CASE("TripleBuffer default and initial reads are stable without dirty swaps",
-          "[runtime][triple_buffer][coverage]") {
+          "[runtime][triple_buffer]") {
     TripleBuffer<int> default_buf;
     REQUIRE(default_buf.read() == 0);
     REQUIRE(default_buf.read() == 0);
@@ -196,7 +196,7 @@ TEST_CASE("TripleBuffer reader gets latest value", "[runtime][triple_buffer]") {
 }
 
 TEST_CASE("TripleBuffer default and clean reads are stable",
-          "[runtime][triple_buffer][coverage]") {
+          "[runtime][triple_buffer]") {
     struct Snapshot {
         float left = 0.0f;
         float right = 0.0f;
@@ -270,7 +270,7 @@ TEST_CASE("TripleBuffer concurrent stress test", "[runtime][triple_buffer]") {
 // ── SpscQueue tests ───────────────────────────────────────────────────────
 
 TEST_CASE("SpscQueue reports capacity, empty state, and FIFO order",
-          "[runtime][spsc_queue][coverage]") {
+          "[runtime][spsc_queue]") {
     SpscQueue<int, 4> queue;
 
     REQUIRE(queue.capacity() == 4);
@@ -293,7 +293,7 @@ TEST_CASE("SpscQueue reports capacity, empty state, and FIFO order",
 }
 
 TEST_CASE("SpscQueue rejects pushes when full and accepts after pop",
-          "[runtime][spsc_queue][coverage]") {
+          "[runtime][spsc_queue]") {
     SpscQueue<int, 2> queue;
 
     REQUIRE(queue.try_push(1));
@@ -312,7 +312,7 @@ TEST_CASE("SpscQueue rejects pushes when full and accepts after pop",
 }
 
 TEST_CASE("SpscQueue full small buffer drains and reuses slots",
-          "[runtime][spsc][coverage]") {
+          "[runtime][spsc]") {
     SpscQueue<int, 2> queue;
 
     REQUIRE(queue.empty());
@@ -339,7 +339,7 @@ TEST_CASE("SpscQueue full small buffer drains and reuses slots",
 }
 
 TEST_CASE("SpscQueue supports rvalue item pushes",
-          "[runtime][spsc_queue][coverage]") {
+          "[runtime][spsc_queue]") {
     struct MoveTracked {
         int value = 0;
     };

--- a/test/test_sysex_accumulator.cpp
+++ b/test/test_sysex_accumulator.cpp
@@ -469,7 +469,7 @@ TEST_CASE("SysexAccumulator: reserved 0xF9/0xFD pass through mid-sysex",
 }
 
 TEST_CASE("SysexAccumulator: every realtime byte passes through mid-sysex",
-          "[midi][sysex][coverage]") {
+          "[midi][sysex]") {
     SysexAccumulator acc;
     Emit e;
     auto cb = make_callback(e);
@@ -492,7 +492,7 @@ TEST_CASE("SysexAccumulator: every realtime byte passes through mid-sysex",
 }
 
 TEST_CASE("SysexAccumulator: range feed reclassifies aborting status once",
-          "[midi][sysex][coverage]") {
+          "[midi][sysex]") {
     SysexAccumulator acc;
     Emit e;
     auto cb = make_callback(e);

--- a/test/test_test_signal.cpp
+++ b/test/test_test_signal.cpp
@@ -163,7 +163,7 @@ TEST_CASE("TestSignalSource: reset clears state", "[format][test_signal]") {
 }
 
 TEST_CASE("TestSignalSource: active flag follows config type",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     REQUIRE_FALSE(src.is_active());
 
@@ -178,7 +178,7 @@ TEST_CASE("TestSignalSource: active flag follows config type",
 }
 
 TEST_CASE("TestSignalSource: config returns the last audio-thread-applied config",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     auto initial = src.config();
     REQUIRE(initial.type == TestSignalType::none);
@@ -199,7 +199,7 @@ TEST_CASE("TestSignalSource: config returns the last audio-thread-applied config
 }
 
 TEST_CASE("TestSignalSource: deterministic sine samples at quarter-cycle boundaries",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 0.75f});
@@ -215,7 +215,7 @@ TEST_CASE("TestSignalSource: deterministic sine samples at quarter-cycle boundar
 }
 
 TEST_CASE("TestSignalSource: amplitude-only config changes keep phase continuity",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 1.0f});
@@ -234,7 +234,7 @@ TEST_CASE("TestSignalSource: amplitude-only config changes keep phase continuity
 }
 
 TEST_CASE("TestSignalSource: frequency changes reset sine phase",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 1.0f});
@@ -253,7 +253,7 @@ TEST_CASE("TestSignalSource: frequency changes reset sine phase",
 }
 
 TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_sample_rate(48000.0);
     src.set_config({TestSignalType::sine, 440.0f, 0.0f});
@@ -270,7 +270,7 @@ TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
 }
 
 TEST_CASE("TestSignalSource: zero-sized fills apply pending config without writing",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_sample_rate(4.0);
     src.set_config({TestSignalType::sine, 1.0f, 0.5f});
@@ -289,7 +289,7 @@ TEST_CASE("TestSignalSource: zero-sized fills apply pending config without writi
 }
 
 TEST_CASE("TestSignalSource: file mode without loaded data is silent and not playing",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
     REQUIRE(src.is_active());
@@ -309,7 +309,7 @@ TEST_CASE("TestSignalSource: file mode without loaded data is silent and not pla
 }
 
 TEST_CASE("TestSignalSource: loop flag toggles independently of loaded file state",
-          "[format][test_signal][coverage]") {
+          "[format][test_signal]") {
     TestSignalSource src;
     REQUIRE_FALSE(src.is_looping());
 
@@ -359,7 +359,7 @@ TEST_CASE("TestSignalSource: invalid file load and unload reset playback state",
 }
 
 TEST_CASE("TestSignalSource: loading a new file rewinds and stops existing playback",
-          "[format][test_signal][file][coverage]") {
+          "[format][test_signal][file]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
 
@@ -391,7 +391,7 @@ TEST_CASE("TestSignalSource: loading a new file rewinds and stops existing playb
 }
 
 TEST_CASE("TestSignalSource: reset stops file playback and rewinds without unloading",
-          "[format][test_signal][file][coverage]") {
+          "[format][test_signal][file]") {
     TestSignalSource src;
     src.set_config({TestSignalType::file, 440.0f, 1.0f});
 

--- a/test/test_transport_hook.cpp
+++ b/test/test_transport_hook.cpp
@@ -135,7 +135,7 @@ TEST_CASE("exception thrown by transport hook propagates to the caller",
 }
 
 TEST_CASE("tempo hook override receives host tempo changes",
-          "[processor][transport][coverage]") {
+          "[processor][transport]") {
     TempoAwareProcessor p;
 
     p.on_host_tempo_changed(120.0);
@@ -147,7 +147,7 @@ TEST_CASE("tempo hook override receives host tempo changes",
 }
 
 TEST_CASE("default tempo hook is a no-op",
-          "[processor][transport][coverage]") {
+          "[processor][transport]") {
     PlainProcessor p;
     p.on_host_tempo_changed(60.0);
     p.on_host_tempo_changed(240.0);
@@ -155,7 +155,7 @@ TEST_CASE("default tempo hook is a no-op",
 }
 
 TEST_CASE("exception thrown by tempo hook propagates to the caller",
-          "[processor][transport][coverage]") {
+          "[processor][transport]") {
     class ThrowingTempoProcessor : public PlainProcessor {
     public:
         void on_host_tempo_changed(double) override {

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Bias reports state and processes separate buffers",
 }
 
 TEST_CASE("Bias zero and negative length buffers are no-ops",
-          "[signal][bias][coverage]") {
+          "[signal][bias]") {
     pulp::signal::Bias bias;
     bias.set_bias(2.0f);
 
@@ -68,7 +68,7 @@ TEST_CASE("Bias zero and negative length buffers are no-ops",
 }
 
 TEST_CASE("Bias handles zero-length in-place buffers",
-          "[signal][bias][coverage][large]") {
+          "[signal][bias]") {
     pulp::signal::Bias bias;
     bias.set_bias(2.0f);
 
@@ -353,7 +353,7 @@ TEST_CASE("is_prime known values", "[runtime][primes]") {
 }
 
 TEST_CASE("is_prime rejects small and square composites",
-          "[runtime][primes][coverage]") {
+          "[runtime][primes]") {
     REQUIRE_FALSE(pulp::runtime::is_prime(0));
     REQUIRE_FALSE(pulp::runtime::is_prime(1));
     REQUIRE_FALSE(pulp::runtime::is_prime(9));
@@ -368,14 +368,14 @@ TEST_CASE("generate_prime", "[runtime][primes]") {
 }
 
 TEST_CASE("generate_prime rejects unsupported bit widths",
-          "[runtime][primes][coverage]") {
+          "[runtime][primes]") {
     REQUIRE(pulp::runtime::generate_prime(0) == 0);
     REQUIRE(pulp::runtime::generate_prime(1) == 0);
     REQUIRE(pulp::runtime::generate_prime(63) == 0);
 }
 
 TEST_CASE("generate_prime covers smallest supported bit widths",
-          "[runtime][primes][coverage][large]") {
+          "[runtime][primes]") {
     auto two_bit = pulp::runtime::generate_prime(2);
     REQUIRE(two_bit >= 2);
     REQUIRE(two_bit <= 3);
@@ -396,7 +396,7 @@ TEST_CASE("sieve_primes", "[runtime][primes]") {
 }
 
 TEST_CASE("sieve_primes handles small limits",
-          "[runtime][primes][coverage]") {
+          "[runtime][primes]") {
     REQUIRE(pulp::runtime::sieve_primes(0).empty());
     REQUIRE(pulp::runtime::sieve_primes(1).empty());
     REQUIRE(pulp::runtime::sieve_primes(2) == std::vector<uint32_t>{2});
@@ -404,7 +404,7 @@ TEST_CASE("sieve_primes handles small limits",
 }
 
 TEST_CASE("sieve_primes handles composite square boundaries",
-          "[runtime][primes][coverage][large]") {
+          "[runtime][primes]") {
     auto primes = pulp::runtime::sieve_primes(49);
 
     REQUIRE(primes.size() == 15);
@@ -496,7 +496,7 @@ TEST_CASE("Expression rejects malformed calls and trailing tokens", "[runtime][e
 }
 
 TEST_CASE("Expression rejects malformed numeric and grouping syntax",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     REQUIRE_FALSE(pulp::runtime::evaluate("").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate(".").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate("1e").has_value());
@@ -508,7 +508,7 @@ TEST_CASE("Expression rejects malformed numeric and grouping syntax",
 }
 
 TEST_CASE("Expression covers unary and nested function combinations",
-          "[runtime][expression][coverage]") {
+          "[runtime][expression]") {
     REQUIRE_THAT(*pulp::runtime::evaluate("-(-4)"), WithinAbs(4.0, 1e-10));
     REQUIRE_THAT(*pulp::runtime::evaluate("max(min(9, 4), abs(-3))"),
                  WithinAbs(4.0, 1e-10));

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -250,7 +250,7 @@ TEST_CASE("WebSocket accept_key rejects empty input gracefully",
 }
 
 TEST_CASE("WebSocketChannel rejects null and closed streams before handshake",
-          "[websocket][handshake][coverage]") {
+          "[websocket][handshake]") {
     REQUIRE(WebSocketChannel::connect(nullptr, "127.0.0.1", "/") == nullptr);
     REQUIRE(WebSocketChannel::accept(nullptr) == nullptr);
 
@@ -478,7 +478,7 @@ TEST_CASE("WebSocketChannel delivers binary send as binary message",
 }
 
 TEST_CASE("WebSocketChannel assembles fragmented text frames",
-          "[websocket][frame-kind][coverage]") {
+          "[websocket][frame-kind]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47701);
@@ -541,7 +541,7 @@ TEST_CASE("WebSocketChannel assembles fragmented text frames",
 }
 
 TEST_CASE("WebSocketChannel reports unknown frame opcodes",
-          "[websocket][frame-kind][coverage]") {
+          "[websocket][frame-kind]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47801);
@@ -598,7 +598,7 @@ TEST_CASE("WebSocketChannel reports unknown frame opcodes",
 }
 
 TEST_CASE("WebSocketChannel replies to ping frames with pong",
-          "[websocket][frame-kind][coverage]") {
+          "[websocket][frame-kind]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47901);
@@ -647,7 +647,7 @@ TEST_CASE("WebSocketChannel replies to ping frames with pong",
 }
 
 TEST_CASE("WebSocketChannel echoes close frames and closes",
-          "[websocket][frame-kind][coverage]") {
+          "[websocket][frame-kind]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 48001);

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -112,7 +112,7 @@ TEST_CASE("XmlDocument invalid XML", "[runtime][xml]") {
 }
 
 TEST_CASE("XmlDocument parse failure marks invalid and later success clears error",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     XmlDocument doc;
     REQUIRE(doc.parse(R"(<root name="before"><child>old</child></root>)"));
     REQUIRE(doc.is_valid());
@@ -131,7 +131,7 @@ TEST_CASE("XmlDocument parse failure marks invalid and later success clears erro
 }
 
 TEST_CASE("XmlDocument load_file failure clears prior state and save_file reports bad paths",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     TemporaryFile tmp(".xml");
 
     XmlDocument doc;
@@ -151,7 +151,7 @@ TEST_CASE("XmlDocument load_file failure clears prior state and save_file report
 }
 
 TEST_CASE("XmlDocument empty document queries are inert",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     XmlDocument doc;
 
     REQUIRE_FALSE(doc.is_valid());
@@ -168,7 +168,7 @@ TEST_CASE("XmlDocument empty document queries are inert",
 }
 
 TEST_CASE("XmlDocument move construction and assignment preserve parsed state",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     XmlDocument original;
     REQUIRE(original.parse(R"(<root name="first"><child>value</child></root>)"));
 
@@ -206,7 +206,7 @@ TEST_CASE("xml_generate creates document", "[runtime][xml]") {
 }
 
 TEST_CASE("xml_generate handles empty and repeated elements",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     auto xml = xml_generate("metadata", {
         {"tag", "alpha"},
         {"tag", "beta"},
@@ -242,7 +242,7 @@ TEST_CASE("xml_generate escapes text content", "[runtime][xml]") {
 }
 
 TEST_CASE("xml_generate supports empty roots and escaped element names from callers",
-          "[runtime][xml][coverage]") {
+          "[runtime][xml]") {
     auto empty = xml_generate("empty", {});
     XmlDocument empty_doc;
     REQUIRE(empty_doc.parse(empty));
@@ -288,7 +288,7 @@ TEST_CASE("gzip empty input", "[runtime][zip]") {
 }
 
 TEST_CASE("gzip_compress writes a deterministic empty RFC 1952 member",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     auto compressed = gzip_compress("", 9);
     REQUIRE(compressed.has_value());
     REQUIRE(compressed->size() >= 18);
@@ -358,7 +358,7 @@ TEST_CASE("gzip binary data round-trip", "[runtime][zip]") {
 }
 
 TEST_CASE("gzip_decompress_string preserves embedded NUL bytes",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::vector<uint8_t> original = {
         'p', 'u', 'l', 'p', 0x00, 'b', 'i', 'n', 0x00, 0xff,
     };
@@ -372,7 +372,7 @@ TEST_CASE("gzip_decompress_string preserves embedded NUL bytes",
 }
 
 TEST_CASE("deflate compression levels round-trip edge settings",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string payload = "level check level check level check";
     for (int level : {0, 9}) {
         INFO("level: " << level);
@@ -387,7 +387,7 @@ TEST_CASE("deflate compression levels round-trip edge settings",
 }
 
 TEST_CASE("zip helpers reject malformed deflate and zlib input",
-          "[runtime][zip][coverage][large]") {
+          "[runtime][zip]") {
     const uint8_t malformed[] = {0xde, 0xad, 0xbe, 0xef};
     const std::vector<uint8_t> malformed_raw = {0xff, 0x00, 0x7a, 0x13, 0x42};
     REQUIRE_FALSE(deflate_decompress(malformed, sizeof(malformed)).has_value());
@@ -396,7 +396,7 @@ TEST_CASE("zip helpers reject malformed deflate and zlib input",
 }
 
 TEST_CASE("deflate empty payload round-trips through raw helpers",
-          "[runtime][zip][coverage][large]") {
+          "[runtime][zip]") {
     auto compressed = deflate_compress(nullptr, 0);
     REQUIRE(compressed.has_value());
 
@@ -406,7 +406,7 @@ TEST_CASE("deflate empty payload round-trips through raw helpers",
 }
 
 TEST_CASE("deflate_decompress rejects truncated raw streams",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string payload = "truncated raw deflate payload";
     auto compressed = deflate_compress(
         reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
@@ -418,7 +418,7 @@ TEST_CASE("deflate_decompress rejects truncated raw streams",
 }
 
 TEST_CASE("deflate_decompress rejects empty raw streams without growth",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     REQUIRE_FALSE(deflate_decompress(nullptr, 0).has_value());
 
     const uint8_t unused = 0;
@@ -426,7 +426,7 @@ TEST_CASE("deflate_decompress rejects empty raw streams without growth",
 }
 
 TEST_CASE("deflate_decompress grows for highly compressed raw streams",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string payload(96 * 1024, 'z');
     const auto* bytes = reinterpret_cast<const uint8_t*>(payload.data());
 
@@ -442,7 +442,7 @@ TEST_CASE("deflate_decompress grows for highly compressed raw streams",
 }
 
 TEST_CASE("gzip_decompress grows for highly compressed RFC 1952 members",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string payload(128 * 1024, 'g');
 
     auto compressed = gzip_compress(payload, 9);
@@ -464,7 +464,7 @@ TEST_CASE("gzip_decompress grows for highly compressed RFC 1952 members",
 }
 
 TEST_CASE("gzip_decompress rejects tiny gzip-looking prefixes",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const uint8_t unused = 0;
     REQUIRE_FALSE(gzip_decompress(&unused, 0).has_value());
 
@@ -481,7 +481,7 @@ TEST_CASE("gzip_decompress rejects tiny gzip-looking prefixes",
 }
 
 TEST_CASE("gzip_decompress rejects complete headers without trailers",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::vector<uint8_t> fixed_header_only = {
         0x1f, 0x8b, 0x08, 0x00,
         0x00, 0x00, 0x00, 0x00,
@@ -501,7 +501,7 @@ TEST_CASE("gzip_decompress rejects complete headers without trailers",
 }
 
 TEST_CASE("gzip_decompress rejects suffixes that start like partial members",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     auto compressed = gzip_compress(std::string{"suffix boundary"});
     REQUIRE(compressed.has_value());
     REQUIRE(compressed->size() > 18);
@@ -611,7 +611,7 @@ TEST_CASE("gzip_decompress accepts optional RFC 1952 header fields", "[runtime][
 }
 
 TEST_CASE("gzip_decompress accepts FTEXT flag and empty optional strings",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string original = "text flag payload";
     auto compressed = gzip_compress(original);
     REQUIRE(compressed.has_value());
@@ -690,7 +690,7 @@ TEST_CASE("gzip_decompress rejects gzip input with corrupt trailer ISIZE", "[run
 }
 
 TEST_CASE("gzip_decompress rejects truncated member trailers and empty members",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     const std::string original = "truncated gzip trailer payload";
     auto compressed = gzip_compress(original);
     REQUIRE(compressed.has_value());
@@ -758,7 +758,7 @@ TEST_CASE("gzip_decompress rejects trailing garbage after the last member",
 }
 
 TEST_CASE("gzip_decompress rejects an invalid concatenated member header",
-          "[runtime][zip][coverage]") {
+          "[runtime][zip]") {
     auto first = gzip_compress(std::string{"first"});
     REQUIRE(first.has_value());
 


### PR DESCRIPTION
## Summary

- Remove stale Catch2 selector metadata tags from 46 audio, signal, runtime, MIDI, OSC, stream, network, and adjacent utility tests.
- Targeted tags only: `[coverage]`, `[codecov]`, `[requested]`, and `[large]`.
- Preserve product/domain tags, issue IDs, test names, test bodies, visible strings, fixtures, runtime keys, and generated artifacts.

## Validation

- Release configure: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`.
- Focused Release build of all locally available affected targets passed after correcting the target name from `pulp-test-sync-primitives` to `pulp-test-sync`.
- Direct Catch2 binary runs passed for all 46 affected binaries.
- Post-rebase static checks on latest `origin/main` passed:
  - `git diff --check origin/main..HEAD`
  - stale-tag grep over touched files
  - selector-coupling grep over `.github`, `.shipyard`, `CMakeLists.txt`, `tools`, and non-C++/non-HPP `test` surfaces
  - `python3 tools/scripts/docs_noise_lint.py`
  - `python3 tools/scripts/hotspot_size_guard.py --warnings-as-errors --require-ceiling-reduction`
  - `python3 tools/scripts/skill_sync_check.py`
- Pre-push gates passed cleanly on branch push.

## Reviews

- RepoPrompt review: clean; it raised a selector-coupling verification caveat, addressed by the local coupling grep above.
- Local autoreview: clean, no accepted/actionable findings; overall patch correctness `0.97`.
- Claude bridge review: `Clean.`

Version-Bump: sdk=skip reason="test selector tag cleanup only; no API or runtime behavior change"
Skill-Sync: skip reason="skill-sync reports no mapped paths touched"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale Catch2 selector tags from 46 tests across audio, signal, runtime, MIDI, OSC, stream, and network modules. Cleans up test selection with no code or runtime behavior changes.

- **Refactors**
  - Removed only `[coverage]`, `[codecov]`, `[requested]`, and `[large]`.
  - Preserved domain tags, issue IDs, test names, and bodies.
  - No API changes; builds and tests remain unchanged.

<sup>Written for commit 52702038b3f5bb8113e65206c85e64be40b8860a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

