### PR TITLE
docs(test): clean UI render selector tags

### DIFF
--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -180,7 +180,7 @@ TEST_CASE("find_by_role_and_label returns nullptr when absent",
 }
 
 TEST_CASE("snapshot preserves depth-first order and first matching view pointer",
-          "[a11y][harness][coverage]") {
+          "[a11y][harness]") {
     Probe root;
 
     auto group = std::make_unique<Probe>();
@@ -296,7 +296,7 @@ TEST_CASE("Accessibility snapshot surfaces ARIA state attributes",
 }
 
 TEST_CASE("Accessibility value interface default strings clamp and fall back",
-          "[a11y][coverage][issue-654]") {
+          "[a11y][issue-654]") {
     Probe root;
 
     auto high = std::make_unique<RangeProbe>(30.0);
@@ -323,7 +323,7 @@ TEST_CASE("Accessibility value interface default strings clamp and fall back",
 }
 
 TEST_CASE("Accessibility helper interfaces expose default selection behavior",
-          "[a11y][coverage][issue-654]") {
+          "[a11y][issue-654]") {
     TextProbe text("abcdef");
     REQUIRE(text.get_character_count() == 6);
     REQUIRE(text.get_selection() == std::pair<int, int>{0, 0});

--- a/test/test_animation.cpp
+++ b/test/test_animation.cpp
@@ -168,7 +168,7 @@ TEST_CASE("ValueAnimation advance returns false when not animating", "[view][ani
 // ── KeyframeAnimation tests ──────────────────────────────────────────────────
 
 TEST_CASE("KeyframeAnimation sorts keyframes and interpolates local spans",
-          "[view][animation][keyframe][coverage]") {
+          "[view][animation][keyframe]") {
     KeyframeAnimation anim;
     anim.set_keyframes({{1.0f, 100.0f}, {0.0f, 0.0f}, {0.25f, 40.0f}});
     anim.set_duration(1.0f);
@@ -180,7 +180,7 @@ TEST_CASE("KeyframeAnimation sorts keyframes and interpolates local spans",
 }
 
 TEST_CASE("KeyframeAnimation honors reverse direction and forwards fill",
-          "[view][animation][keyframe][coverage]") {
+          "[view][animation][keyframe]") {
     KeyframeAnimation anim;
     anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 10.0f}});
     anim.set_duration(1.0f);
@@ -195,7 +195,7 @@ TEST_CASE("KeyframeAnimation honors reverse direction and forwards fill",
 }
 
 TEST_CASE("KeyframeAnimation alternate direction flips odd iterations",
-          "[view][animation][keyframe][coverage]") {
+          "[view][animation][keyframe]") {
     KeyframeAnimation anim;
     anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 10.0f}});
     anim.set_duration(1.0f);
@@ -210,7 +210,7 @@ TEST_CASE("KeyframeAnimation alternate direction flips odd iterations",
 }
 
 TEST_CASE("KeyframeAnimation start resets a previously finished animation",
-          "[view][animation][keyframe][coverage]") {
+          "[view][animation][keyframe]") {
     KeyframeAnimation anim;
     anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 1.0f}});
     anim.set_duration(0.1f);
@@ -225,7 +225,7 @@ TEST_CASE("KeyframeAnimation start resets a previously finished animation",
 }
 
 TEST_CASE("KeyframeAnimation pause resume stop and invalid inputs keep value",
-          "[view][animation][keyframe][coverage]") {
+          "[view][animation][keyframe]") {
     KeyframeAnimation anim;
     anim.set_duration(1.0f);
     anim.start();

--- a/test/test_animator_set.cpp
+++ b/test/test_animator_set.cpp
@@ -63,7 +63,7 @@ TEST_CASE("AnimatorSetBuilder reset", "[view][animation]") {
 }
 
 TEST_CASE("AnimatorSetBuilder empty and ignored parallel inputs are safe",
-          "[view][animation][coverage]") {
+          "[view][animation]") {
     auto empty = AnimatorSetBuilder().build_runner();
     REQUIRE(empty.finished());
     REQUIRE(empty.advance(0.016f));
@@ -81,7 +81,7 @@ TEST_CASE("AnimatorSetBuilder empty and ignored parallel inputs are safe",
 }
 
 TEST_CASE("AnimatorSetBuilder parallel group updates members until all finish",
-          "[view][animation][coverage]") {
+          "[view][animation]") {
     float fast = 0.0f;
     float slow = 0.0f;
     auto runner = AnimatorSetBuilder()
@@ -129,7 +129,7 @@ TEST_CASE("Vector3D arithmetic", "[view][3d]") {
 }
 
 TEST_CASE("Vector3D subtraction and zero normalization are stable",
-          "[view][3d][coverage]") {
+          "[view][3d]") {
     Vector3D a{3, 2, 1};
     Vector3D b{1, 5, -2};
 
@@ -176,7 +176,7 @@ TEST_CASE("Quaternion multiply identity", "[view][3d]") {
 }
 
 TEST_CASE("Quaternion rotates vectors and normalizes zero quaternions",
-          "[view][3d][coverage]") {
+          "[view][3d]") {
     auto quarter_turn = Quaternion::from_axis_angle({0, 0, 1}, 3.14159265f * 0.5f);
     auto rotated = quarter_turn.rotate({1, 0, 0});
     REQUIRE(rotated.x == Catch::Approx(0.0f).margin(0.001f));
@@ -191,7 +191,7 @@ TEST_CASE("Quaternion rotates vectors and normalizes zero quaternions",
 }
 
 TEST_CASE("Quaternion slerp handles near and opposite hemispheres",
-          "[view][3d][coverage]") {
+          "[view][3d]") {
     const auto identity = Quaternion::identity();
     const auto near = Quaternion::from_axis_angle({0, 1, 0}, 0.001f);
     auto blended_near = Quaternion::slerp(identity, near, 0.5f);
@@ -204,7 +204,7 @@ TEST_CASE("Quaternion slerp handles near and opposite hemispheres",
 }
 
 TEST_CASE("Draggable3DOrientation drag lifecycle updates and resets orientation",
-          "[view][3d][coverage]") {
+          "[view][3d]") {
     Draggable3DOrientation orientation;
     const auto initial = orientation.orientation();
 

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -107,7 +107,7 @@ TEST_CASE("KeyShortcut parses named keys and rejects invalid function keys",
 }
 
 TEST_CASE("KeyShortcut parses modifiers independent of their order",
-          "[view][keys][coverage]") {
+          "[view][keys]") {
     auto ks = KeyShortcut::from_string("Shift+Meta+Cmd+A");
     REQUIRE(ks.key == KeyCode::a);
     REQUIRE((ks.modifiers & kModShift) != 0);
@@ -138,7 +138,7 @@ TEST_CASE("KeyShortcut to_string round-trips", "[view][keys]") {
 }
 
 TEST_CASE("KeyShortcut parser accepts out-of-order modifiers once",
-          "[view][keys][coverage]") {
+          "[view][keys]") {
     auto ks = KeyShortcut::from_string("Shift+Cmd+A");
     REQUIRE(ks.key == KeyCode::a);
     REQUIRE((ks.modifiers & kModCmd) != 0);
@@ -297,7 +297,7 @@ TEST_CASE("KeyMapping no-op branches leave commands intact", "[view][keys]") {
 }
 
 TEST_CASE("KeyMapping handles commands without actions",
-          "[view][keys][coverage]") {
+          "[view][keys]") {
     KeyMapping km;
     km.add_command({1, "No Action", "File",
                     KeyShortcut::from_string("Cmd+N"), {}, {}, false});
@@ -336,7 +336,7 @@ TEST_CASE("KeyMapping save/load binding edge paths", "[view][keys]") {
 }
 
 TEST_CASE("KeyMapping save_bindings fails when parent is missing",
-          "[view][keys][coverage]") {
+          "[view][keys]") {
     KeyMapping km;
     km.add_command({1, "Save", "File",
                     KeyShortcut::from_string("Cmd+S"), [] {}, {}, false});
@@ -402,7 +402,7 @@ TEST_CASE("MenuBar set_key_mapping preserves command metadata",
 }
 
 TEST_CASE("MenuBar add_menu preserves submenu and disabled item metadata",
-          "[view][menu][coverage]") {
+          "[view][menu]") {
     MenuBar menu;
     menu.add_menu("View", {
         {"Zoom", {}, {}, true, false, {
@@ -436,7 +436,7 @@ TEST_CASE("NativeToolbar add items and separator", "[view][toolbar]") {
 }
 
 TEST_CASE("NativeToolbar stores callable item actions",
-          "[view][toolbar][coverage]") {
+          "[view][toolbar]") {
     NativeToolbar tb;
     int calls = 0;
     tb.add_item({"render", "Render", "play", [&] { ++calls; }});
@@ -513,7 +513,7 @@ TEST_CASE("AppSettings invalid typed values return null or false",
 }
 
 TEST_CASE("AppSettings numeric getters reject partial parses",
-          "[view][settings][coverage][large]") {
+          "[view][settings]") {
     AppSettings settings("PulpTest");
     settings.set_string("int_suffix", "256samples");
     settings.set_string("int_decimal", "256.5");
@@ -585,7 +585,7 @@ TEST_CASE("AppSettings saves and loads from platform settings root",
 }
 
 TEST_CASE("AppSettings load keeps parsed prefix from malformed JSON",
-          "[view][settings][coverage]") {
+          "[view][settings]") {
     auto root = make_temp_root("pulp-app-settings-malformed");
 
 #if defined(_WIN32)
@@ -614,7 +614,7 @@ TEST_CASE("AppSettings load keeps parsed prefix from malformed JSON",
 }
 
 TEST_CASE("AppSettings load clears stale values from an empty settings file",
-          "[view][settings][coverage]") {
+          "[view][settings]") {
     auto root = make_temp_root("pulp-app-settings-empty");
 
 #if defined(_WIN32)
@@ -643,7 +643,7 @@ TEST_CASE("AppSettings load clears stale values from an empty settings file",
 }
 
 TEST_CASE("AppSettings load clears stale values before partial parse",
-          "[view][settings][coverage]") {
+          "[view][settings]") {
     auto root = make_temp_root("pulp-app-settings-partial");
 
 #if defined(_WIN32)

--- a/test/test_appearance_tracker.cpp
+++ b/test/test_appearance_tracker.cpp
@@ -42,7 +42,7 @@ TEST_CASE("AppearanceTracker callback fires on lock", "[view][appearance]") {
 }
 
 TEST_CASE("AppearanceTracker replacing callback uses latest handler only",
-          "[view][appearance][coverage]") {
+          "[view][appearance]") {
     AppearanceTracker tracker;
     int first_calls = 0;
     std::vector<Appearance> latest;
@@ -58,7 +58,7 @@ TEST_CASE("AppearanceTracker replacing callback uses latest handler only",
 }
 
 TEST_CASE("AppearanceTracker callbacks follow repeated locks and locked poll no-op",
-          "[view][appearance][coverage][issue-493]") {
+          "[view][appearance][issue-493]") {
     AppearanceTracker tracker;
     std::vector<Appearance> received;
 
@@ -130,7 +130,7 @@ TEST_CASE("ThemeManager callback fires on theme change", "[view][appearance]") {
 }
 
 TEST_CASE("ThemeManager replacing callback uses latest handler only",
-          "[view][appearance][coverage]") {
+          "[view][appearance]") {
     ThemeManager mgr;
     int first_calls = 0;
     std::vector<uint8_t> latest_red;
@@ -154,7 +154,7 @@ TEST_CASE("ThemeManager replacing callback uses latest handler only",
 }
 
 TEST_CASE("ThemeManager callbacks cover locked theme poll and unlock",
-          "[view][appearance][coverage][issue-493]") {
+          "[view][appearance][issue-493]") {
     ThemeManager mgr;
 
     Theme light;

--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -76,7 +76,7 @@ TEST_CASE("AssetManager cache clear", "[view][assets]") {
 }
 
 TEST_CASE("Asset data wrappers report validity and byte size",
-          "[view][assets][coverage][issue-651]") {
+          "[view][assets][issue-651]") {
     ImageData image;
     image.pixels = {1, 2, 3, 4};
     image.width = 1;
@@ -150,7 +150,7 @@ TEST_CASE("AssetManager register and retrieve shader", "[view][assets]") {
 }
 
 TEST_CASE("AssetManager replacing cached shader keeps cache usage accurate",
-          "[view][assets][coverage][issue-651]") {
+          "[view][assets][issue-651]") {
     auto& mgr = AssetManager::instance();
     const auto old_max = mgr.max_cache_size();
     mgr.clear_cache();
@@ -173,7 +173,7 @@ TEST_CASE("AssetManager replacing cached shader keeps cache usage accurate",
 }
 
 TEST_CASE("AssetManager replacing cached shader keeps cache accounting stable",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     const auto old_max = mgr.max_cache_size();
     mgr.clear_cache();
@@ -242,7 +242,7 @@ TEST_CASE("AssetManager embedded shader loads into shader cache", "[view][assets
 }
 
 TEST_CASE("AssetManager embedded shader loader returns cached source on repeat",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.clear_cache();
 
@@ -262,7 +262,7 @@ TEST_CASE("AssetManager embedded shader loader returns cached source on repeat",
 }
 
 TEST_CASE("AssetManager shader lookup finds cached file shader by path",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.clear_cache();
 
@@ -345,7 +345,7 @@ TEST_CASE("AssetManager fallback skips families without embedded data", "[view][
 }
 
 TEST_CASE("AssetManager embedded font loader populates and reuses cache",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.clear_cache();
 
@@ -367,7 +367,7 @@ TEST_CASE("AssetManager embedded font loader populates and reuses cache",
 }
 
 TEST_CASE("AssetManager missing family without fallback returns invalid font",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.set_font_fallback({});
 
@@ -396,7 +396,7 @@ TEST_CASE("AssetManager load image from memory with PNG header", "[view][assets]
 }
 
 TEST_CASE("AssetManager image memory loading handles invalid and short buffers",
-          "[view][assets][coverage][issue-651]") {
+          "[view][assets][issue-651]") {
     auto& mgr = AssetManager::instance();
 
     static const uint8_t short_png[] = {0x89, 0x50, 0x4E};
@@ -431,7 +431,7 @@ TEST_CASE("AssetManager load image from embedded", "[view][assets]") {
 }
 
 TEST_CASE("AssetManager embedded image loader reuses cached decode",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.clear_cache();
 
@@ -527,7 +527,7 @@ TEST_CASE("AssetManager data URI base64 decode", "[view][assets]") {
 }
 
 TEST_CASE("AssetManager data URI decodes PNG dimensions with ignored characters",
-          "[view][assets][coverage][issue-651]") {
+          "[view][assets][issue-651]") {
     auto& mgr = AssetManager::instance();
 
     auto img = mgr.load_image_from_data_uri(
@@ -596,7 +596,7 @@ TEST_CASE("AssetManager blob from embedded", "[view][assets]") {
 }
 
 TEST_CASE("AssetManager embedded blob loader returns cached bytes",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     mgr.clear_cache();
 
@@ -616,7 +616,7 @@ TEST_CASE("AssetManager embedded blob loader returns cached bytes",
 }
 
 TEST_CASE("AssetManager shrinking cache budget trims existing entries",
-          "[view][assets][coverage]") {
+          "[view][assets]") {
     auto& mgr = AssetManager::instance();
     const auto old_max = mgr.max_cache_size();
     mgr.clear_cache();
@@ -684,7 +684,7 @@ TEST_CASE("AssetManager blob file cache and misses", "[view][assets]") {
 }
 
 TEST_CASE("AssetManager font file loading derives family names and uses cache",
-          "[view][assets][coverage][issue-651]") {
+          "[view][assets][issue-651]") {
     auto& mgr = AssetManager::instance();
     const auto old_max = mgr.max_cache_size();
     mgr.clear_cache();

--- a/test/test_atk_mapping.cpp
+++ b/test/test_atk_mapping.cpp
@@ -18,7 +18,7 @@ TEST_CASE("role_to_atk returns stable ATK role IDs", "[a11y][atk]") {
 }
 
 TEST_CASE("ATK mapping falls back for unknown role values",
-          "[a11y][atk][coverage]") {
+          "[a11y][atk]") {
     auto unknown = static_cast<View::AccessRole>(999);
     REQUIRE(role_to_atk(unknown) == kRoleUnknown);
 

--- a/test/test_attributed_string.cpp
+++ b/test/test_attributed_string.cpp
@@ -309,7 +309,7 @@ TEST_CASE("GlyphArrangement hit testing and cursor positions", "[canvas][layout]
 }
 
 TEST_CASE("AttributedString append preserves empty spans between text",
-          "[canvas][text][coverage]") {
+          "[canvas][text]") {
     AttributedString str;
     str.append("left");
     str.append("");
@@ -323,7 +323,7 @@ TEST_CASE("AttributedString append preserves empty spans between text",
 }
 
 TEST_CASE("AttributedString set_font overwrites styled span fonts only",
-          "[canvas][text][coverage]") {
+          "[canvas][text]") {
     AttributedString str;
     TextSpan span;
     span.text = "styled";
@@ -340,7 +340,7 @@ TEST_CASE("AttributedString set_font overwrites styled span fonts only",
 }
 
 TEST_CASE("AttributedString set_color preserves font attributes",
-          "[canvas][text][coverage]") {
+          "[canvas][text]") {
     AttributedString str;
     TextSpan span;
     span.text = "styled";
@@ -358,7 +358,7 @@ TEST_CASE("AttributedString set_color preserves font attributes",
 }
 
 TEST_CASE("TextLayout preserves style on wrapped span fragments",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     AttributedString str;
     TextSpan span;
     span.text = "alpha beta";
@@ -384,7 +384,7 @@ TEST_CASE("TextLayout preserves style on wrapped span fragments",
 }
 
 TEST_CASE("TextLayout consecutive newlines create blank layout lines",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     AttributedString str("top\n\nbottom");
 
     auto layout = layout_attributed_string(str, 1000.0f, 13.0f);
@@ -397,7 +397,7 @@ TEST_CASE("TextLayout consecutive newlines create blank layout lines",
 }
 
 TEST_CASE("TextLayout forced break keeps full unspaced text",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     AttributedString str;
     str.append("abcdef", 10.0f, Color::rgba8(1, 1, 1));
 
@@ -410,7 +410,7 @@ TEST_CASE("TextLayout forced break keeps full unspaced text",
 }
 
 TEST_CASE("TextLayout span-specific font size affects width and height",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     AttributedString str;
     str.append("wide", 20.0f, Color::rgba8(1, 1, 1));
     str.append("narrow", 10.0f, Color::rgba8(2, 2, 2));
@@ -426,7 +426,7 @@ TEST_CASE("TextLayout span-specific font size affects width and height",
 }
 
 TEST_CASE("GlyphArrangement totals use widest line and last descent",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     GlyphArrangement layout;
 
     TextLine short_line;
@@ -447,7 +447,7 @@ TEST_CASE("GlyphArrangement totals use widest line and last descent",
 }
 
 TEST_CASE("GlyphArrangement hit_test uses half-advance thresholds",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     GlyphArrangement layout;
     TextLine line;
     line.ascent = 8.0f;
@@ -464,7 +464,7 @@ TEST_CASE("GlyphArrangement hit_test uses half-advance thresholds",
 }
 
 TEST_CASE("GlyphArrangement position_for_index scans later lines",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     GlyphArrangement layout;
 
     TextLine first;
@@ -482,7 +482,7 @@ TEST_CASE("GlyphArrangement position_for_index scans later lines",
 }
 
 TEST_CASE("Parallelogram from_rect_shear contains skewed interior points",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     auto p = Parallelogram::from_rect_shear(0.0f, 0.0f, 10.0f, 10.0f, 3.0f);
 
     REQUIRE(p.contains(5.0f, 5.0f));
@@ -492,7 +492,7 @@ TEST_CASE("Parallelogram from_rect_shear contains skewed interior points",
 }
 
 TEST_CASE("Parallelogram negative shear contains expected interior",
-          "[canvas][layout][coverage]") {
+          "[canvas][layout]") {
     auto p = Parallelogram::from_rect_shear(10.0f, 20.0f, 12.0f, 8.0f, -4.0f);
 
     REQUIRE(p.contains(12.0f, 24.0f));

--- a/test/test_auto_ui.cpp
+++ b/test/test_auto_ui.cpp
@@ -66,7 +66,7 @@ TEST_CASE("AutoUi builds from parameter store", "[view][auto_ui]") {
     REQUIRE(grid->child_count() == 3);  // Gain + Mix + Bypass
 }
 
-TEST_CASE("AutoUi builds empty parameter grids", "[view][auto_ui][coverage]") {
+TEST_CASE("AutoUi builds empty parameter grids", "[view][auto_ui]") {
     StateStore store;
     auto root = AutoUi::build(store);
     REQUIRE(root != nullptr);
@@ -237,7 +237,7 @@ TEST_CASE("AutoUi generated controls write changes back to the store",
 }
 
 TEST_CASE("AutoUi generated controls expose toggle state and formatted values",
-          "[view][auto_ui][coverage][issue-493]") {
+          "[view][auto_ui][issue-493]") {
     StateStore store;
     store.add_parameter(make_param(1, "Frequency", "Hz", {0.0f, 1000.0f, 500.0f}));
     store.add_parameter(make_param(2, "Drive", "dB", {0.0f, 80.0f, 50.0f}));
@@ -269,7 +269,7 @@ TEST_CASE("AutoUi generated controls expose toggle state and formatted values",
 }
 
 TEST_CASE("AutoUi sync updates generated toggles and existing faders",
-          "[view][auto_ui][coverage][issue-493]") {
+          "[view][auto_ui][issue-493]") {
     StateStore store;
     store.add_parameter(make_param(1, "Bypass", "", {0.0f, 1.0f, 0.0f, 1.0f}));
     store.add_parameter(make_param(2, "Level", "", {0.0f, 1.0f, 0.0f}));
@@ -299,7 +299,7 @@ TEST_CASE("AutoUi sync updates generated toggles and existing faders",
 }
 
 TEST_CASE("AutoUi sync ignores unmatched widget identifiers",
-          "[view][auto_ui][coverage]") {
+          "[view][auto_ui]") {
     StateStore store;
     store.add_parameter(make_param(1, "Level", "", {0.0f, 1.0f, 0.0f}));
 

--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -174,7 +174,7 @@ TEST_CASE("DirtyTracker ignores invalid viewport dimensions for promotion",
 }
 
 TEST_CASE("DirtyTracker invalid viewport height disables promotion",
-          "[render][dirty][coverage][large]") {
+          "[render][dirty]") {
     DirtyTracker dt;
     dt.set_viewport(100, 0, 0.01f);
     dt.clear();
@@ -212,7 +212,7 @@ TEST_CASE("DirtyTracker coalesces nearby non-overlapping rects", "[render][dirty
 }
 
 TEST_CASE("DirtyTracker coalesces sparse overlaps through the intersects path",
-          "[render][dirty][coverage][large]") {
+          "[render][dirty]") {
     DirtyTracker dt;
     dt.clear();
 
@@ -241,7 +241,7 @@ TEST_CASE("Rect intersection", "[render][dirty]") {
 }
 
 TEST_CASE("Rect intersection rejects each separating axis independently",
-          "[render][dirty][coverage][large]") {
+          "[render][dirty]") {
     DirtyTracker::Rect a{10, 10, 10, 10};
     DirtyTracker::Rect left{0, 12, 5, 5};
     DirtyTracker::Rect above{12, 0, 5, 5};

--- a/test/test_effects.cpp
+++ b/test/test_effects.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Shadow effect with RecordingCanvas", "[canvas][effects]") {
 }
 
 TEST_CASE("apply_shadow records generic canvas setup commands",
-          "[canvas][effects][coverage]") {
+          "[canvas][effects]") {
     RecordingCanvas canvas;
     ShadowEffect shadow;
     shadow.offset_x = 6.0f;
@@ -92,7 +92,7 @@ TEST_CASE("apply_shadow records generic canvas setup commands",
 }
 
 TEST_CASE("direct blur and color adjustment calls are generic no-ops",
-          "[canvas][effects][coverage]") {
+          "[canvas][effects]") {
     RecordingCanvas canvas;
 
     apply_blur(canvas, BlurEffect{2.0f, 5.0f});
@@ -102,7 +102,7 @@ TEST_CASE("direct blur and color adjustment calls are generic no-ops",
 }
 
 TEST_CASE("effect layers can be nested and restore in order",
-          "[canvas][effects][coverage]") {
+          "[canvas][effects]") {
     RecordingCanvas canvas;
 
     begin_effect_layer(canvas, BlurEffect{1.0f, 2.0f});

--- a/test/test_file_browser.cpp
+++ b/test/test_file_browser.cpp
@@ -74,7 +74,7 @@ float x_for_exact_text(const RecordingCanvas& canvas, const std::string& text) {
 } // namespace
 
 TEST_CASE("FileBrowser set_root handles nonexistent roots without drawing entries",
-          "[view][file-browser][coverage][issue-493][issue-641]") {
+          "[view][file-browser][issue-493][issue-641]") {
     TempDir tmp("missing-root");
     const auto missing = tmp.path / "missing";
 
@@ -91,7 +91,7 @@ TEST_CASE("FileBrowser set_root handles nonexistent roots without drawing entrie
 }
 
 TEST_CASE("FileBrowser filters hidden files and sorts directories before files",
-          "[view][file-browser][coverage][issue-493][issue-641]") {
+          "[view][file-browser][issue-493][issue-641]") {
     TempDir tmp("filter-sort");
     std::filesystem::create_directory(tmp.path / "ZetaDir");
     std::filesystem::create_directory(tmp.path / "AlphaDir");
@@ -128,7 +128,7 @@ TEST_CASE("FileBrowser filters hidden files and sorts directories before files",
 }
 
 TEST_CASE("FileBrowser paint clips rows and keeps directories through filters",
-          "[view][file-browser][coverage][issue-655]") {
+          "[view][file-browser][issue-655]") {
     TempDir tmp("filter-clip");
     std::filesystem::create_directory(tmp.path / "Samples");
     write_file(tmp.path / "alpha.wav");
@@ -151,7 +151,7 @@ TEST_CASE("FileBrowser paint clips rows and keeps directories through filters",
 }
 
 TEST_CASE("FileBrowser navigate refreshes entries for the new directory",
-          "[view][file-browser][coverage]") {
+          "[view][file-browser]") {
     TempDir tmp("navigate");
     std::filesystem::create_directory(tmp.path / "samples");
     write_file(tmp.path / "root.wav");
@@ -180,7 +180,7 @@ TEST_CASE("FileBrowser navigate refreshes entries for the new directory",
 }
 
 TEST_CASE("FileBrowser non-wildcard filters keep directories and reject files",
-          "[view][file-browser][coverage]") {
+          "[view][file-browser]") {
     TempDir tmp("non-wildcard-filter");
     std::filesystem::create_directory(tmp.path / "Presets");
     write_file(tmp.path / "alpha.wav");
@@ -199,7 +199,7 @@ TEST_CASE("FileBrowser non-wildcard filters keep directories and reject files",
 }
 
 TEST_CASE("FileBrowser navigating to a regular file is a safe empty listing",
-          "[view][file-browser][coverage]") {
+          "[view][file-browser]") {
     TempDir tmp("file-as-root");
     const auto file = tmp.path / "single.wav";
     write_file(file);
@@ -217,7 +217,7 @@ TEST_CASE("FileBrowser navigating to a regular file is a safe empty listing",
 }
 
 TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
-          "[view][file-tree][coverage][issue-493][issue-641]") {
+          "[view][file-tree][issue-493][issue-641]") {
     TempDir tmp("tree");
     std::filesystem::create_directories(tmp.path / "alpha" / "deeper");
     std::filesystem::create_directories(tmp.path / "zeta");
@@ -256,7 +256,7 @@ TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
 }
 
 TEST_CASE("FileTree missing roots clear previously painted nodes",
-          "[view][file-tree][coverage]") {
+          "[view][file-tree]") {
     TempDir tmp("tree-missing-root");
     write_file(tmp.path / "visible.txt");
 
@@ -278,7 +278,7 @@ TEST_CASE("FileTree missing roots clear previously painted nodes",
 }
 
 TEST_CASE("MultiDocumentPanel remove_document preserves active document callbacks",
-          "[view][multi-document][coverage][issue-493][issue-641]") {
+          "[view][multi-document][issue-493][issue-641]") {
     SECTION("removing the active first document reports the replacement at the same index") {
         MultiDocumentPanel panel;
         std::vector<int> active_changes;
@@ -340,7 +340,7 @@ TEST_CASE("MultiDocumentPanel remove_document preserves active document callback
 }
 
 TEST_CASE("MultiDocumentPanel paint reflects active tab and empty state",
-          "[view][multi-document][coverage][issue-655]") {
+          "[view][multi-document][issue-655]") {
     MultiDocumentPanel empty;
     empty.set_bounds({0, 0, 200, 80});
     RecordingCanvas empty_canvas;

--- a/test/test_frame_clock.cpp
+++ b/test/test_frame_clock.cpp
@@ -172,7 +172,7 @@ TEST_CASE("FrameClock zero dt is valid", "[view][frame_clock]") {
 }
 
 TEST_CASE("FrameClock subscriber added during tick starts on the next frame",
-          "[view][frame_clock][coverage]") {
+          "[view][frame_clock]") {
     FrameClock clock;
     int first_calls = 0;
     int added_calls = 0;
@@ -201,7 +201,7 @@ TEST_CASE("FrameClock subscriber added during tick starts on the next frame",
 }
 
 TEST_CASE("FrameClock subscriber can unsubscribe itself while returning true",
-          "[view][frame_clock][coverage]") {
+          "[view][frame_clock]") {
     FrameClock clock;
     int id = 0;
     int calls = 0;
@@ -220,7 +220,7 @@ TEST_CASE("FrameClock subscriber can unsubscribe itself while returning true",
 }
 
 TEST_CASE("FrameClock false-return compaction preserves later active subscribers",
-          "[view][frame_clock][coverage]") {
+          "[view][frame_clock]") {
     FrameClock clock;
     int first = 0;
     int second = 0;

--- a/test/test_gpu_render_time.cpp
+++ b/test/test_gpu_render_time.cpp
@@ -153,7 +153,7 @@ TEST_CASE("RenderPassManager frame GPU time is independent of per-pass GPU time"
 }
 
 TEST_CASE("RenderPassManager handles empty pass endings and disabled budgets",
-          "[render][gpu-render-time][render-pass][coverage]") {
+          "[render][gpu-render-time][render-pass]") {
     RenderPassManager rpm;
     REQUIRE(rpm.budget() == 16.67f);
     REQUIRE(rpm.frame_count() == 0);

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -322,7 +322,7 @@ TEST_CASE("set_pass_gpu_time rejects a negative duration",
 }
 
 TEST_CASE("RenderPassManager begin_frame clears stale frame state",
-          "[render][gpu-timestamps][coverage]") {
+          "[render][gpu-timestamps]") {
     RenderPassManager rpm;
     rpm.set_budget(1.0f);
     rpm.begin_frame();

--- a/test/test_graph_editor_view.cpp
+++ b/test/test_graph_editor_view.cpp
@@ -205,7 +205,7 @@ TEST_CASE("GraphEditorView modifier drags create feedback and midi edges",
 }
 
 TEST_CASE("GraphEditorView reverse modifier drags create feedback and midi edges",
-          "[view][graph_editor][coverage][issue-655]") {
+          "[view][graph_editor][issue-655]") {
     SignalGraph feedback_graph;
     const auto feedback_input = feedback_graph.add_input_node(1, "Input");
     const auto feedback_output = feedback_graph.add_output_node(1, "Output");
@@ -255,7 +255,7 @@ TEST_CASE("GraphEditorView selection and miss handling are stable",
 }
 
 TEST_CASE("GraphEditorView paints unnamed nodes and clears drag ghost after miss",
-          "[view][graph_editor][coverage][issue-655]") {
+          "[view][graph_editor][issue-655]") {
     SignalGraph graph;
     const auto input = graph.add_input_node(1, "");
     const auto output = graph.add_output_node(1, "Output");

--- a/test/test_hot_reload.cpp
+++ b/test/test_hot_reload.cpp
@@ -202,7 +202,7 @@ TEST_CASE("HotReloader directory watching", "[view][hotreload]") {
 }
 
 TEST_CASE("HotReloader seeds observed JS files and ignores stale events",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_seed");
     auto entry = tmp_dir / "main.js";
     auto module = tmp_dir / "module.mjs";
@@ -233,7 +233,7 @@ TEST_CASE("HotReloader seeds observed JS files and ignores stale events",
 }
 
 TEST_CASE("HotReloader file seed skips non-JS files and missing paths",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_non_js");
     auto text_file = tmp_dir / "notes.txt";
     write_js_file(text_file, "not javascript");
@@ -247,7 +247,7 @@ TEST_CASE("HotReloader file seed skips non-JS files and missing paths",
 }
 
 TEST_CASE("HotReloader file watcher ignores unsupported changes",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_direct_filter");
     auto entry = tmp_dir / "main.js";
     auto text_file = tmp_dir / "notes.txt";
@@ -273,7 +273,7 @@ TEST_CASE("HotReloader file watcher ignores unsupported changes",
 }
 
 TEST_CASE("HotReloader module file change reloads directory entry",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_direct_module");
     auto entry = tmp_dir / "main.js";
     auto module = tmp_dir / "module.mjs";
@@ -298,7 +298,7 @@ TEST_CASE("HotReloader module file change reloads directory entry",
 }
 
 TEST_CASE("HotReloader pending reload without callback still drains",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_no_callback");
     auto entry = tmp_dir / "main.js";
     write_js_file(entry, "// entry");
@@ -315,7 +315,7 @@ TEST_CASE("HotReloader pending reload without callback still drains",
 }
 
 TEST_CASE("HotReloader empty or missing entry files do not schedule reloads",
-          "[view][hotreload][codecov]") {
+          "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_empty_entry");
     auto entry = tmp_dir / "main.js";
     auto module = tmp_dir / "module.mjs";

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -43,7 +43,7 @@ TEST_CASE("miss then hit", "[view][image-cache]") {
 }
 
 TEST_CASE("decoder replacement does not invalidate cached image entries",
-          "[view][image-cache][coverage][large]") {
+          "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> first_calls{0};
     std::atomic<int> second_calls{0};
@@ -149,7 +149,7 @@ TEST_CASE("clear invokes releaser for every entry",
 }
 
 TEST_CASE("clear preserves cache counters while removing entries",
-          "[view][image-cache][coverage]") {
+          "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> calls{0};
     c.set_decoder(make_fake_decoder(calls));
@@ -179,7 +179,7 @@ TEST_CASE("clear preserves cache counters while removing entries",
 }
 
 TEST_CASE("clear without a releaser drops entries safely",
-          "[view][image-cache][coverage]") {
+          "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> calls{0};
     c.set_decoder(make_fake_decoder(calls));
@@ -198,7 +198,7 @@ TEST_CASE("clear without a releaser drops entries safely",
 }
 
 TEST_CASE("clear on an empty cache is a no-op and preserves counters",
-          "[view][image-cache][coverage]") {
+          "[view][image-cache]") {
     ImageCache c;
     REQUIRE(c.stats().entry_count == 0);
     REQUIRE(c.stats().hits == 0);
@@ -216,7 +216,7 @@ TEST_CASE("clear on an empty cache is a no-op and preserves counters",
 }
 
 TEST_CASE("entry exactly matching byte budget remains cached",
-          "[view][image-cache][coverage]") {
+          "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> calls{0};
     c.set_decoder(make_fake_decoder(calls));
@@ -243,7 +243,7 @@ TEST_CASE("zero budget disables trimming", "[view][image-cache]") {
 }
 
 TEST_CASE("lowering byte budget trims least recently used entries",
-          "[view][image-cache][coverage][issue-493]") {
+          "[view][image-cache][issue-493]") {
     ImageCache c;
     std::atomic<int> calls{0};
     std::vector<void*> released;

--- a/test/test_image_convolution.cpp
+++ b/test/test_image_convolution.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Identity kernel supports explicit row stride", "[canvas][convolution]
 }
 
 TEST_CASE("Convolution preserves padded row stride bytes",
-          "[canvas][convolution][coverage]") {
+          "[canvas][convolution]") {
     ImageConvolutionKernel identity(1);
     identity.set(0, 0, 1.0f);
 
@@ -218,7 +218,7 @@ TEST_CASE("Standard kernel weights cover blur edge and emboss paths",
 }
 
 TEST_CASE("Standard kernels process a single pixel via edge clamping",
-          "[canvas][convolution][coverage]") {
+          "[canvas][convolution]") {
     auto pixel = make_solid_image(1, 1, 20, 40, 60);
     ImageConvolutionKernel::gaussian_blur_3().apply(pixel.data(), 1, 1);
     REQUIRE(pixel[0] == 20);
@@ -234,7 +234,7 @@ TEST_CASE("Standard kernels process a single pixel via edge clamping",
 }
 
 TEST_CASE("Single-pixel convolution clamps repeated edge samples",
-          "[canvas][convolution][coverage]") {
+          "[canvas][convolution]") {
     uint8_t sharpened[4] = {40, 80, 120, 77};
     auto sharpen = ImageConvolutionKernel::sharpen();
     sharpen.apply(sharpened, 1, 1);

--- a/test/test_image_view_cache.cpp
+++ b/test/test_image_view_cache.cpp
@@ -255,7 +255,7 @@ TEST_CASE("object-position: percentage offsets the centred dst",
 }
 
 TEST_CASE("object-fit unknown keyword falls back to fill",
-          "[widgets][image][object-fit][coverage]") {
+          "[widgets][image][object-fit]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 100, "stretchy");
@@ -274,7 +274,7 @@ TEST_CASE("object-fit unknown keyword falls back to fill",
 }
 
 TEST_CASE("object-position: length tokens offset by slack",
-          "[widgets][image][object-position][coverage]") {
+          "[widgets][image][object-position]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "25px 10px");
@@ -291,7 +291,7 @@ TEST_CASE("object-position: length tokens offset by slack",
 }
 
 TEST_CASE("object-position: malformed numeric tokens fall back to center",
-          "[widgets][image][object-position][coverage]") {
+          "[widgets][image][object-position]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "25pxjunk 10em");
@@ -308,7 +308,7 @@ TEST_CASE("object-position: malformed numeric tokens fall back to center",
 }
 
 TEST_CASE("object-position: non-finite numeric tokens fall back to center",
-          "[widgets][image][object-position][coverage]") {
+          "[widgets][image][object-position]") {
     using Catch::Matchers::WithinAbs;
     ImageView v;
     configure_view(v, 200, 150, "contain", "1e999% 25%");

--- a/test/test_input_events.cpp
+++ b/test/test_input_events.cpp
@@ -65,7 +65,7 @@ TEST_CASE("KeyEvent modifier queries", "[view][input]") {
 }
 
 TEST_CASE("KeyEvent combined modifier helpers stay independent",
-          "[view][input][coverage]") {
+          "[view][input]") {
     KeyEvent e;
     e.modifiers = kModShift | kModCtrl | kModAlt | kModCmd;
 
@@ -133,7 +133,7 @@ TEST_CASE("MouseEvent pen pointer type with stylus data", "[view][input][pointer
 }
 
 TEST_CASE("MouseEvent unknown pointer type falls back to mouse string",
-          "[view][input][pointer][coverage]") {
+          "[view][input][pointer]") {
     MouseEvent e;
     e.pointer_type = static_cast<PointerType>(99);
     e.pointer_id = 3;

--- a/test/test_modal.cpp
+++ b/test/test_modal.cpp
@@ -32,7 +32,7 @@ TEST_CASE("ModalOverlay dismiss on Escape", "[view][modal]") {
 }
 
 TEST_CASE("ModalOverlay ignores key releases and handles Escape without callback",
-          "[view][modal][coverage][issue-493]") {
+          "[view][modal][issue-493]") {
     ModalOverlay modal;
 
     KeyEvent release;
@@ -57,7 +57,7 @@ TEST_CASE("ModalOverlay paints backdrop", "[view][modal]") {
 }
 
 TEST_CASE("ModalOverlay paint applies backdrop alpha to fill color",
-          "[view][modal][coverage][issue-493]") {
+          "[view][modal][issue-493]") {
     ModalOverlay modal;
     modal.set_bounds({0, 0, 320, 200});
     modal.backdrop_opacity = 0.25f;
@@ -86,7 +86,7 @@ TEST_CASE("ModalOverlay dismiss_on_backdrop_click flag", "[view][modal]") {
 }
 
 TEST_CASE("ModalOverlay backdrop mouse dismissal respects hit target and flag",
-          "[view][modal][coverage][issue-493]") {
+          "[view][modal][issue-493]") {
     ModalOverlay modal;
     modal.set_bounds({0, 0, 200, 120});
 
@@ -126,7 +126,7 @@ TEST_CASE("ModalOverlay non-Escape key not handled", "[view][modal]") {
 }
 
 TEST_CASE("ModalOverlay backdrop click dismisses only outside children",
-          "[view][modal][coverage][issue-653]") {
+          "[view][modal][issue-653]") {
     ModalOverlay modal;
     modal.set_bounds({0, 0, 200, 100});
     auto child = std::make_unique<View>();
@@ -154,7 +154,7 @@ TEST_CASE("ModalOverlay backdrop click dismisses only outside children",
 }
 
 TEST_CASE("ModalOverlay ignores mouse-up and missing dismiss callback",
-          "[view][modal][coverage][issue-653]") {
+          "[view][modal][issue-653]") {
     ModalOverlay modal;
     modal.set_bounds({0, 0, 80, 40});
 

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -278,7 +278,7 @@ TEST_CASE("CostSample zeroes render fields when no probe is wired",
 }
 
 TEST_CASE("Cost buffer sink tolerates a null destination",
-          "[motion-cost][coverage]") {
+          "[motion-cost]") {
     auto sink = make_cost_buffer_sink(nullptr);
 
     CostSample s;
@@ -382,7 +382,7 @@ TEST_CASE("CostSample JSONL serialization round-trips a stream", "[motion-cost]"
 }
 
 TEST_CASE("load_cost_stream rejects missing or unsupported headers",
-          "[motion-cost][coverage]") {
+          "[motion-cost]") {
     REQUIRE(load_cost_stream(unique_path("missing")).empty());
 
     const std::string no_header = unique_path("no-header");

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -136,7 +136,7 @@ TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
 }
 
 TEST_CASE("MotionPreferences policy callback may re-enter preferences",
-          "[motion-preferences][coverage]") {
+          "[motion-preferences]") {
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();
     prefs.set_override(MotionPolicy::Full);
@@ -175,7 +175,7 @@ TEST_CASE("motion_policy_to_string / from_string round-trip",
 }
 
 TEST_CASE("apply_motion_policy_to_duration follows override and scale",
-          "[motion-preferences][coverage]") {
+          "[motion-preferences]") {
     using namespace pulp::view;
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -221,7 +221,7 @@ TEST_CASE("MotionScrubber scrub_to / play are no-ops when no fixture loaded",
 }
 
 TEST_CASE("MotionScrubber owns only passive replay protocol methods",
-          "[motion-scrubber][protocol][coverage][requested]") {
+          "[motion-scrubber][protocol]") {
     REQUIRE(MotionScrubber::owns_method("Motion.loadFixture"));
     REQUIRE(MotionScrubber::owns_method("Motion.scrubTo"));
     REQUIRE(MotionScrubber::owns_method("Motion.play"));
@@ -239,7 +239,7 @@ TEST_CASE("MotionScrubber owns only passive replay protocol methods",
 }
 
 TEST_CASE("MotionScrubber failed fixture load clears stale replay state",
-          "[motion-scrubber][coverage][requested]") {
+          "[motion-scrubber]") {
     FrameClock clock;
     const auto good_path = record_sample_fixture("failed-load-reset", clock);
     const auto bad_path = tmp_fixture_path("bad-version");
@@ -272,7 +272,7 @@ TEST_CASE("MotionScrubber failed fixture load clears stale replay state",
 }
 
 TEST_CASE("MotionScrubber sink removal and pause keep state deterministic",
-          "[motion-scrubber][coverage][requested]") {
+          "[motion-scrubber]") {
     FrameClock clock;
     const auto path = record_sample_fixture("sink-removal", clock);
 

--- a/test/test_motion_swift_bridge.cpp
+++ b/test/test_motion_swift_bridge.cpp
@@ -127,7 +127,7 @@ TEST_CASE("pulp_motion_publish_components emits sorted multi-component events",
 }
 
 TEST_CASE("pulp_motion_publish_components tolerates empty and null inputs",
-          "[motion][swift-bridge][coverage]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     const char* keys[1] = {"x"};
@@ -141,7 +141,7 @@ TEST_CASE("pulp_motion_publish_components tolerates empty and null inputs",
 }
 
 TEST_CASE("pulp_motion bridge normalizes null C strings",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     pulp_motion_publish_value(nullptr, nullptr, 0.0, 0.001, 3);
@@ -154,7 +154,7 @@ TEST_CASE("pulp_motion bridge normalizes null C strings",
 }
 
 TEST_CASE("pulp_motion bridge normalizes null provenance and geometry names",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     pulp_motion_set_ambient_provenance(nullptr, nullptr, nullptr, 0);
@@ -301,7 +301,7 @@ TEST_CASE("pulp_motion_update_geometry with a non-default metric also emits",
 }
 
 TEST_CASE("pulp_motion_update_geometry keeps frame metrics on the sampled trace only",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     const int id = pulp_motion_register_geometry_trace("FrameOnly", 60);
@@ -321,7 +321,7 @@ TEST_CASE("pulp_motion_update_geometry keeps frame metrics on the sampled trace 
 }
 
 TEST_CASE("pulp_motion geometry registry survives coordinator reset",
-          "[motion][swift-bridge][coverage]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     const int first = pulp_motion_register_geometry_trace("ViewA", 30);
@@ -344,7 +344,7 @@ TEST_CASE("pulp_motion geometry registry survives coordinator reset",
 }
 
 TEST_CASE("pulp_motion geometry bridge ignores unknown trace ids",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     pulp_motion_update_geometry(123456, "frame", 1.0, 2.0, 3.0, 4.0);
@@ -356,7 +356,7 @@ TEST_CASE("pulp_motion geometry bridge ignores unknown trace ids",
 }
 
 TEST_CASE("pulp_motion geometry bridge detaches one trace without silencing others",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     BridgeFixture fx;
 
     const int first = pulp_motion_register_geometry_trace("First", 60);
@@ -384,7 +384,7 @@ TEST_CASE("pulp_motion geometry bridge detaches one trace without silencing othe
 }
 
 TEST_CASE("PulpBridge state ABI rejects invalid buffers without touching callers",
-          "[motion][swift-bridge][coverage][requested]") {
+          "[motion][swift-bridge]") {
     int untouched_size = 1234;
     REQUIRE(pulp_state_serialize(nullptr) == nullptr);
     REQUIRE(untouched_size == 1234);

--- a/test/test_msdf_atlas.cpp
+++ b/test/test_msdf_atlas.cpp
@@ -24,7 +24,7 @@ TEST_CASE("MsdfAtlas default state is empty", "[canvas][msdf][issue-641]") {
 }
 
 TEST_CASE("MsdfAtlas move operations preserve channel mode and glyph lookup",
-          "[canvas][msdf][coverage][issue-650]") {
+          "[canvas][msdf][issue-650]") {
     MsdfAtlas original;
     REQUIRE(original.build("stub", {U'A', U'B'}, 18, 3, 128,
                            /*include_alpha*/ true));
@@ -75,7 +75,7 @@ TEST_CASE("MsdfAtlas empty build records base size and channel mode",
 }
 
 TEST_CASE("MsdfAtlas rebuild resets channels and overflow failure clears glyphs",
-          "[canvas][msdf][coverage][issue-650]") {
+          "[canvas][msdf][issue-650]") {
     MsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'A'}, 20, 2, 128,
                         /*include_alpha*/ true));

--- a/test/test_path_to_sdf.cpp
+++ b/test/test_path_to_sdf.cpp
@@ -86,7 +86,7 @@ TEST_CASE("path_to_sdf: mask threshold treats 127 outside and 128 inside",
 }
 
 TEST_CASE("path_to_sdf: one-pixel islands saturate in both directions",
-          "[canvas][sdf][path][coverage][issue-650]") {
+          "[canvas][sdf][path][issue-650]") {
     std::uint8_t mask[9] = {
         0, 0, 0,
         0, 255, 0,

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -172,7 +172,7 @@ TEST_CASE("EqCurveView empty hit does not start a drag", "[view][eq_curve][issue
 }
 
 TEST_CASE("EqCurveView paint covers disabled grid and disabled band handles",
-          "[view][eq_curve][coverage][issue-652]") {
+          "[view][eq_curve][issue-652]") {
     EqCurveView eq;
     eq.set_bounds({0, 0, 240, 120});
     eq.set_show_grid(false);
@@ -188,7 +188,7 @@ TEST_CASE("EqCurveView paint covers disabled grid and disabled band handles",
 }
 
 TEST_CASE("EqCurveView set_band updates valid indices",
-          "[view][eq_curve][coverage]") {
+          "[view][eq_curve]") {
     EqCurveView eq;
     eq.add_band({500.0f, -3.0f, 0.8f, EqCurveView::FilterType::peak, true});
 
@@ -203,7 +203,7 @@ TEST_CASE("EqCurveView set_band updates valid indices",
 }
 
 TEST_CASE("EqCurveView paint covers grid spectrum and enabled handles",
-          "[view][eq_curve][coverage]") {
+          "[view][eq_curve]") {
     EqCurveView eq;
     eq.set_bounds({0, 0, 240, 120});
     const float spectrum[] = {-18.0f, -12.0f, -24.0f, -6.0f};
@@ -223,7 +223,7 @@ TEST_CASE("EqCurveView paint covers grid spectrum and enabled handles",
 }
 
 TEST_CASE("EqCurveView forwards rich mouse events to the base pointer hook",
-          "[view][eq_curve][coverage]") {
+          "[view][eq_curve]") {
     EqCurveView eq;
     int forwarded = 0;
     eq.on_pointer_event = [&](const MouseEvent& event) {
@@ -326,7 +326,7 @@ TEST_CASE("MidiKeyboard vertical drag releases previous notes and misses",
 }
 
 TEST_CASE("MidiKeyboard drag releases old notes and supports vertical range",
-          "[view][midi_keyboard][coverage][issue-652]") {
+          "[view][midi_keyboard][issue-652]") {
     MidiKeyboard kb;
     kb.set_range(80, 60);
     REQUIRE(kb.first_note() == 80);
@@ -378,7 +378,7 @@ TEST_CASE("MidiKeyboard paint emits note names and active highlight color",
 }
 
 TEST_CASE("MidiKeyboard forwards rich mouse events to the base pointer hook",
-          "[view][midi_keyboard][coverage]") {
+          "[view][midi_keyboard]") {
     MidiKeyboard kb;
     int forwarded = 0;
     Point last{};
@@ -395,7 +395,7 @@ TEST_CASE("MidiKeyboard forwards rich mouse events to the base pointer hook",
 }
 
 TEST_CASE("MidiKeyboard overlapping black keys win hit testing",
-          "[view][midi_keyboard][coverage]") {
+          "[view][midi_keyboard]") {
     MidiKeyboard kb;
     kb.set_range(60, 61);
     kb.set_bounds({0, 0, 100, 80});
@@ -530,7 +530,7 @@ TEST_CASE("ColorPicker paint positions alpha cursor from normalized alpha",
 }
 
 TEST_CASE("ColorPicker paint draws configured swatches",
-          "[view][color_picker][coverage]") {
+          "[view][color_picker]") {
     ColorPicker picker;
     picker.set_bounds({0, 0, 200, 260});
     picker.set_swatches({
@@ -550,7 +550,7 @@ TEST_CASE("ColorPicker paint draws configured swatches",
 }
 
 TEST_CASE("ColorPicker forwards rich mouse events to the base pointer hook",
-          "[view][color_picker][coverage]") {
+          "[view][color_picker]") {
     ColorPicker picker;
     int forwarded = 0;
     picker.on_pointer_event = [&](const MouseEvent& event) {
@@ -565,7 +565,7 @@ TEST_CASE("ColorPicker forwards rich mouse events to the base pointer hook",
 }
 
 TEST_CASE("ColorPicker hidden alpha bar ignores alpha-region input",
-          "[view][color_picker][coverage]") {
+          "[view][color_picker]") {
     ColorPicker picker;
     picker.set_bounds({0, 0, 200, 280});
     picker.set_show_alpha(false);
@@ -582,7 +582,7 @@ TEST_CASE("ColorPicker hidden alpha bar ignores alpha-region input",
 }
 
 TEST_CASE("ColorPicker mode and outside mouse input are stable",
-          "[view][color_picker][coverage][issue-652]") {
+          "[view][color_picker][issue-652]") {
     ColorPicker picker;
     picker.set_bounds({0, 0, 200, 260});
     picker.set_mode(ColorPicker::Mode::hex_only);
@@ -652,7 +652,7 @@ TEST_CASE("FileDropZone empty extensions accepts all", "[view][file_drop]") {
 }
 
 TEST_CASE("FileDropZone rejects extensionless files when extensions are required",
-          "[view][file_drop][coverage]") {
+          "[view][file_drop]") {
     FileDropZone zone;
     zone.set_accepted_extensions({".wav"});
 
@@ -663,7 +663,7 @@ TEST_CASE("FileDropZone rejects extensionless files when extensions are required
 }
 
 TEST_CASE("FileDropZone paint reflects idle valid and invalid drag states",
-          "[view][file_drop][coverage][issue-652]") {
+          "[view][file_drop][issue-652]") {
     FileDropZone zone;
     zone.set_bounds({0, 0, 180, 120});
     zone.set_label("Idle");
@@ -704,7 +704,7 @@ TEST_CASE("FileDropZone paint reflects idle valid and invalid drag states",
 }
 
 TEST_CASE("FileDropZone invalid or empty drops do not call callback",
-          "[view][file_drop][coverage][issue-652]") {
+          "[view][file_drop][issue-652]") {
     FileDropZone zone;
     zone.set_accepted_extensions({".wav"});
 
@@ -857,7 +857,7 @@ TEST_CASE("SplitView paint emits horizontal and vertical divider grips",
 }
 
 TEST_CASE("SplitView can replace panes and lays out with custom divider width",
-          "[view][split_view][coverage]") {
+          "[view][split_view]") {
     SplitView split;
     split.set_bounds({0, 0, 300, 120});
     split.set_split_fraction(0.25f);
@@ -893,7 +893,7 @@ TEST_CASE("SplitView can replace panes and lays out with custom divider width",
 }
 
 TEST_CASE("SplitView forwards rich mouse events to the base pointer hook",
-          "[view][split_view][coverage]") {
+          "[view][split_view]") {
     SplitView split;
     int forwarded = 0;
     split.on_pointer_event = [&](const MouseEvent& event) {
@@ -1034,7 +1034,7 @@ TEST_CASE("PropertyList paints categories and scalar value variants",
 }
 
 TEST_CASE("PropertyList paints color values and selected row highlight",
-          "[view][property_list][coverage]") {
+          "[view][property_list]") {
     PropertyList list;
     list.set_bounds({0, 0, 260, 100});
     list.set_row_height(24.0f);
@@ -1111,7 +1111,7 @@ TEST_CASE("Breadcrumb separator", "[view][breadcrumb]") {
 }
 
 TEST_CASE("Breadcrumb empty and out-of-range interactions are stable",
-          "[view][breadcrumb][coverage]") {
+          "[view][breadcrumb]") {
     Breadcrumb bc;
     auto empty = bc.pop();
     REQUIRE(empty.label.empty());
@@ -1128,7 +1128,7 @@ TEST_CASE("Breadcrumb empty and out-of-range interactions are stable",
 }
 
 TEST_CASE("Breadcrumb navigation targets later items and ignores separators",
-          "[view][breadcrumb][coverage]") {
+          "[view][breadcrumb]") {
     Breadcrumb bc;
     bc.set_separator(">");
     bc.set_items({{"Home", "home"}, {"Settings", "settings"}, {"Audio", "audio"}});
@@ -1152,7 +1152,7 @@ TEST_CASE("Breadcrumb navigation targets later items and ignores separators",
 }
 
 TEST_CASE("Breadcrumb paint emits background, items, and separators",
-          "[view][breadcrumb][coverage]") {
+          "[view][breadcrumb]") {
     Breadcrumb bc;
     bc.set_bounds({0, 0, 240, 32});
     bc.set_separator(">");
@@ -1184,7 +1184,7 @@ TEST_CASE("Breadcrumb paint emits background, items, and separators",
 // ── ThemeEditor ────────────────────────────────────────────────────────────
 
 TEST_CASE("ThemeEditor covers missing selection empty theme and selected paint",
-          "[view][theme-editor][coverage][issue-652]") {
+          "[view][theme-editor][issue-652]") {
     ThemeEditor editor;
     editor.set_bounds({0, 0, 360, 120});
 
@@ -1212,7 +1212,7 @@ TEST_CASE("ThemeEditor covers missing selection empty theme and selected paint",
 }
 
 TEST_CASE("ThemeEditor wraps swatches when the row is full",
-          "[view][theme-editor][coverage]") {
+          "[view][theme-editor]") {
     ThemeEditor editor;
     editor.set_bounds({0, 0, 80, 160});
 

--- a/test/test_preset_browser.cpp
+++ b/test/test_preset_browser.cpp
@@ -328,7 +328,7 @@ TEST_CASE("PresetBrowser mouse list selects and double-click activates", "[view]
 }
 
 TEST_CASE("PresetBrowser filtered list click uses filter offset and row height",
-          "[view][preset_browser][coverage][issue-655]") {
+          "[view][preset_browser][issue-655]") {
     TestPresetFixture f;
     PresetBrowser browser(*f.pm);
     browser.set_bounds({0, 0, 180, 180});
@@ -351,7 +351,7 @@ TEST_CASE("PresetBrowser filtered list click uses filter offset and row height",
 }
 
 TEST_CASE("PresetBrowser ignores filtered clicks before the list starts",
-          "[view][preset_browser][coverage][issue-655]") {
+          "[view][preset_browser][issue-655]") {
     TestPresetFixture f;
     PresetBrowser browser(*f.pm);
     browser.set_bounds({0, 0, 180, 180});

--- a/test/test_property_list.cpp
+++ b/test/test_property_list.cpp
@@ -77,7 +77,7 @@ TEST_CASE("PropertyList intrinsic height accounts for category display", "[view]
 }
 
 TEST_CASE("PropertyList empty model still paints background only",
-          "[view][property_list][coverage][large]") {
+          "[view][property_list]") {
     PropertyList list;
     list.set_bounds({0, 0, 160, 80});
     list.set_row_height(18.0f);
@@ -146,7 +146,7 @@ TEST_CASE("PropertyList set_value only mutates existing keys", "[view][property_
 }
 
 TEST_CASE("PropertyList set_value preserves variant-specific value types",
-          "[view][property_list][coverage][large]") {
+          "[view][property_list]") {
     PropertyList list;
     list.set_properties({
         {"name", "Name", std::string("Old"), false, ""},
@@ -171,7 +171,7 @@ TEST_CASE("PropertyList set_value preserves variant-specific value types",
 }
 
 TEST_CASE("PropertyList category visibility and label fallback paint paths",
-          "[view][property_list][coverage][issue-653]") {
+          "[view][property_list][issue-653]") {
     PropertyList list;
     list.set_bounds({0, 0, 220, 100});
     list.set_row_height(20.0f);
@@ -195,7 +195,7 @@ TEST_CASE("PropertyList category visibility and label fallback paint paths",
 }
 
 TEST_CASE("PropertyList selection highlight covers non-bool rows and misses",
-          "[view][property_list][coverage][issue-653]") {
+          "[view][property_list][issue-653]") {
     PropertyList list;
     list.set_bounds({0, 0, 180, 100});
     list.set_row_height(20.0f);
@@ -228,7 +228,7 @@ TEST_CASE("PropertyList selection highlight covers non-bool rows and misses",
 }
 
 TEST_CASE("PropertyList clamps color text and ignores category header clicks",
-          "[view][property_list][coverage]") {
+          "[view][property_list]") {
     PropertyList list;
     list.set_bounds({0, 0, 200, 96});
     list.set_row_height(24.0f);

--- a/test/test_psdf_atlas.cpp
+++ b/test/test_psdf_atlas.cpp
@@ -19,7 +19,7 @@ TEST_CASE("PsdfAtlas builds with the requested glyphs", "[canvas][psdf]") {
 }
 
 TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
-          "[canvas][psdf][coverage][issue-650]") {
+          "[canvas][psdf][issue-650]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'P', U'S'}, 24, 3, 256));
     REQUIRE(atlas.base_size() == 24);
@@ -33,7 +33,7 @@ TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
 }
 
 TEST_CASE("PsdfAtlas default and invalid builds leave atlas empty",
-          "[canvas][psdf][coverage]") {
+          "[canvas][psdf]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.glyph_count() == 0);
     REQUIRE(atlas.base_size() == 0);
@@ -50,7 +50,7 @@ TEST_CASE("PsdfAtlas default and invalid builds leave atlas empty",
 }
 
 TEST_CASE("PsdfAtlas packs glyph tiles and preserves metrics",
-          "[canvas][psdf][coverage]") {
+          "[canvas][psdf]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'P', U'S', U'D'}, 12, 2, 32));
     REQUIRE(atlas.width() == 32);
@@ -72,7 +72,7 @@ TEST_CASE("PsdfAtlas packs glyph tiles and preserves metrics",
 }
 
 TEST_CASE("PsdfAtlas de-duplicates and can be rebuilt",
-          "[canvas][psdf][coverage]") {
+          "[canvas][psdf]") {
     PsdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'P', U'P', U'S'}, 16, 2, 128));
     REQUIRE(atlas.glyph_count() == 2);
@@ -88,7 +88,7 @@ TEST_CASE("PsdfAtlas de-duplicates and can be rebuilt",
 }
 
 TEST_CASE("PsdfAtlas move assignment transfers the built atlas",
-          "[canvas][psdf][coverage]") {
+          "[canvas][psdf]") {
     PsdfAtlas source;
     PsdfAtlas destination;
     REQUIRE(source.build("stub", {U'A', U'B'}, 18, 2, 128));
@@ -122,7 +122,7 @@ TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
 }
 
 TEST_CASE("vector_fallback equality and negative thresholds are strict",
-          "[canvas][psdf][fallback][coverage][issue-650]") {
+          "[canvas][psdf][fallback][issue-650]") {
     REQUIRE_FALSE(should_use_vector_fallback(96.0f, 48.0f, 2.0f));
     REQUIRE(should_use_vector_fallback(96.1f, 48.0f, 2.0f));
     REQUIRE(should_use_vector_fallback(1.0f, 48.0f, -1.0f));
@@ -130,7 +130,7 @@ TEST_CASE("vector_fallback equality and negative thresholds are strict",
 }
 
 TEST_CASE("vector_fallback scales render size against the selected base",
-          "[canvas][psdf][fallback][coverage]") {
+          "[canvas][psdf][fallback]") {
     REQUIRE_FALSE(should_use_vector_fallback(63.9f, 16.0f, 4.0f));
     REQUIRE_FALSE(should_use_vector_fallback(64.0f, 16.0f, 4.0f));
     REQUIRE(should_use_vector_fallback(64.1f, 16.0f, 4.0f));

--- a/test/test_remote_view.cpp
+++ b/test/test_remote_view.cpp
@@ -163,7 +163,7 @@ TEST_CASE("RemoteViewSession - handshake sends view.hello + view.metadata", "[re
 }
 
 TEST_CASE("RemoteViewSession - metadata escapes names as valid JSON",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     EscapedMetadataProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -198,7 +198,7 @@ TEST_CASE("RemoteViewSession - metadata escapes names as valid JSON",
 }
 
 TEST_CASE("RemoteViewSession - metadata includes exact size hints and multiple params",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     MultiParamProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -264,7 +264,7 @@ TEST_CASE("RemoteViewSession - remote sets param, host StateStore reflects it", 
 }
 
 TEST_CASE("RemoteViewSession - remote param_set accepts numeric JSON variants",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -320,7 +320,7 @@ TEST_CASE("RemoteViewSession - host set_parameter notifies remote", "[remote_vie
 }
 
 TEST_CASE("RemoteViewSession - closed peer channel disables outbound operations",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -344,7 +344,7 @@ TEST_CASE("RemoteViewSession - closed peer channel disables outbound operations"
 }
 
 TEST_CASE("RemoteViewSession - send_input forwards payload to remote",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -380,7 +380,7 @@ TEST_CASE("RemoteViewSession - send_input forwards payload to remote",
 }
 
 TEST_CASE("RemoteViewSession - remote view.param_get serves state values and errors",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -454,7 +454,7 @@ TEST_CASE("RemoteViewSession - host get_parameter reads remote result", "[remote
 }
 
 TEST_CASE("RemoteViewSession - host get_parameter ignores invalid remote results",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -480,7 +480,7 @@ TEST_CASE("RemoteViewSession - host get_parameter ignores invalid remote results
 }
 
 TEST_CASE("RemoteViewSession - host get_parameter ignores remote errors",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -533,7 +533,7 @@ TEST_CASE("RemoteViewSession - malformed remote param sets are ignored", "[remot
 }
 
 TEST_CASE("ViewBridge - attach_remote_channel rejects null channel",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -547,7 +547,7 @@ TEST_CASE("ViewBridge - attach_remote_channel rejects null channel",
 }
 
 TEST_CASE("ViewBridge - attach_remote_channel reports handshake send failure",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -617,7 +617,7 @@ TEST_CASE("RemoteViewSession - close detaches and closes underlying channel", "[
 }
 
 TEST_CASE("ViewBridge - custom view lifecycle and secondary view indexing",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     LifecycleProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -677,7 +677,7 @@ TEST_CASE("ViewBridge - custom view lifecycle and secondary view indexing",
 }
 
 TEST_CASE("ViewBridge - detach_remote is false for null and stale sessions",
-          "[remote_view][coverage]") {
+          "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -168,7 +168,7 @@ TEST_CASE("RenderLoop factory selects the timer backend under force-timer",
 }
 
 TEST_CASE("RenderLoop explicit timer factory is deterministic",
-          "[render][loop][coverage][large]") {
+          "[render][loop]") {
     auto loop = RenderLoop::create_timer_loop();
     REQUIRE(loop != nullptr);
     REQUIRE_FALSE(loop->is_running());

--- a/test/test_rendering_integration.cpp
+++ b/test/test_rendering_integration.cpp
@@ -112,7 +112,7 @@ TEST_CASE("Dimension parse auto", "[view][dimension]") {
 }
 
 TEST_CASE("Dimension parse trims supported units and rejects unknown suffixes",
-          "[view][dimension][codecov]") {
+          "[view][dimension]") {
     auto px = view::Dimension::parse(" 12px \t");
     REQUIRE(px.unit == view::DimensionUnit::px);
     REQUIRE(px.value == Catch::Approx(12.0f));
@@ -192,7 +192,7 @@ TEST_CASE("RenderPassManager detects over budget", "[render][pass]") {
 }
 
 TEST_CASE("RenderPassManager resets per-frame stats and preserves frame count",
-          "[render][pass][coverage]") {
+          "[render][pass]") {
     render::RenderPassManager pm;
 
     REQUIRE(pm.frame_count() == 0);
@@ -216,7 +216,7 @@ TEST_CASE("RenderPassManager resets per-frame stats and preserves frame count",
 }
 
 TEST_CASE("RenderPassManager handles empty passes and disabled budget",
-          "[render][pass][coverage]") {
+          "[render][pass]") {
     render::RenderPassManager pm;
 
     pm.begin_frame();
@@ -286,7 +286,7 @@ TEST_CASE("FillStyle linear gradient", "[canvas][gradient]") {
 }
 
 TEST_CASE("FillStyle radial gradient exposes focal point and stops",
-          "[canvas][gradient][coverage]") {
+          "[canvas][gradient]") {
     canvas::RadialGradient rg{10.0f, 20.0f, 30.0f, 0.0f, 0.0f, {}};
     rg.focal_x = 12.0f;
     rg.focal_y = 18.0f;

--- a/test/test_resizable_shell.cpp
+++ b/test/test_resizable_shell.cpp
@@ -86,7 +86,7 @@ TEST_CASE("serialize + deserialize round-trip", "[ui][resizable-shell]") {
 }
 
 TEST_CASE("serialize stores little-endian width and height bytes",
-          "[ui][resizable-shell][coverage]") {
+          "[ui][resizable-shell]") {
     ResizableShell s({.initial_size = {0x0304u, 0x020Du}});
 
     const auto blob = s.serialize();
@@ -103,7 +103,7 @@ TEST_CASE("serialize stores little-endian width and height bytes",
 }
 
 TEST_CASE("deserialize ignores trailing bytes after the size payload",
-          "[ui][resizable-shell][coverage]") {
+          "[ui][resizable-shell]") {
     uint8_t blob[] = {
         0x2Cu, 0x01u, 0x00u, 0x00u, // 300
         0xC8u, 0x00u, 0x00u, 0x00u, // 200
@@ -160,7 +160,7 @@ TEST_CASE("constructor normalizes initial size through negotiate",
 }
 
 TEST_CASE("non-positive aspect ratio uses plain min max clamping",
-          "[ui][resizable-shell][coverage]") {
+          "[ui][resizable-shell]") {
     ResizableShell zero({.min_size = {100, 80},
                          .max_size = {500, 400},
                          .initial_size = {300, 300},

--- a/test/test_sdf_atlas.cpp
+++ b/test/test_sdf_atlas.cpp
@@ -29,7 +29,7 @@ TEST_CASE("SdfAtlas default state is empty", "[canvas][sdf][issue-641]") {
 }
 
 TEST_CASE("SdfAtlas move operations transfer atlas storage",
-          "[canvas][sdf][coverage][issue-650]") {
+          "[canvas][sdf][issue-650]") {
     SdfAtlas original;
     REQUIRE(original.build("stub", {U'A', U'B'}, 20, 2, 128));
     const auto* before = original.glyph(U'B');
@@ -89,7 +89,7 @@ TEST_CASE("SdfAtlas rejects invalid build arguments without allocation",
 }
 
 TEST_CASE("SdfAtlas invalid rebuild preserves prior atlas but overflow clears it",
-          "[canvas][sdf][coverage][issue-650]") {
+          "[canvas][sdf][issue-650]") {
     SdfAtlas atlas;
     REQUIRE(atlas.build("stub", {U'A'}, 16, 2, 128));
     REQUIRE(atlas.glyph_count() == 1);

--- a/test/test_sdf_atlas_cache.cpp
+++ b/test/test_sdf_atlas_cache.cpp
@@ -23,7 +23,7 @@ TEST_CASE("SdfAtlasCache duplicate seed glyphs produce one resident entry",
 }
 
 TEST_CASE("SdfAtlasCache can initialize an empty resident set",
-          "[canvas][cache][coverage][issue-650]") {
+          "[canvas][cache][issue-650]") {
     SdfAtlasCache cache;
     REQUIRE_FALSE(cache.initialize("", {}, 24, 4, 512));
     REQUIRE(cache.size() == 0);
@@ -62,7 +62,7 @@ TEST_CASE("SdfAtlasCache reinitialize stamps new glyphs at current frame",
 }
 
 TEST_CASE("SdfAtlasCache touching resident glyph updates recency without clearing dirty",
-          "[canvas][cache][coverage][issue-650]") {
+          "[canvas][cache][issue-650]") {
     SdfAtlasCache cache;
     REQUIRE(cache.initialize("", {U'A', U'B'}, 24, 4, 512));
 

--- a/test/test_sdf_effects.cpp
+++ b/test/test_sdf_effects.cpp
@@ -7,7 +7,7 @@
 using namespace pulp::canvas;
 
 TEST_CASE("SdfEffectParams default to inactive shader-safe values",
-          "[canvas][sdf][effects][coverage][issue-650]") {
+          "[canvas][sdf][effects][issue-650]") {
     SdfEffectParams p;
     REQUIRE(p.active == 0);
     REQUIRE_FALSE(has_effect(p.active, SdfEffect::Outline));
@@ -30,7 +30,7 @@ TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
 }
 
 TEST_CASE("SdfEffect bitmask accepts manually combined active masks",
-          "[canvas][sdf][effects][coverage][issue-650]") {
+          "[canvas][sdf][effects][issue-650]") {
     const auto mask = static_cast<std::uint8_t>(SdfEffect::Outline)
                     | static_cast<std::uint8_t>(SdfEffect::Glow)
                     | static_cast<std::uint8_t>(SdfEffect::Bevel);
@@ -57,7 +57,7 @@ TEST_CASE("preset_outline width is respected",
 }
 
 TEST_CASE("SDF effect presets preserve explicit zero dimensions",
-          "[canvas][sdf][effects][presets][coverage][issue-650]") {
+          "[canvas][sdf][effects][presets][issue-650]") {
     auto outline = preset_outline(0.0f);
     REQUIRE(has_effect(outline.active, SdfEffect::Outline));
     REQUIRE(outline.outline_width == 0.0f);

--- a/test/test_sdf_software_renderer.cpp
+++ b/test/test_sdf_software_renderer.cpp
@@ -69,7 +69,7 @@ TEST_CASE("software SDF render handles empty quad list",
 }
 
 TEST_CASE("software SDF render leaves output untouched for invalid output bounds",
-          "[canvas][sdf][render][coverage][issue-650]") {
+          "[canvas][sdf][render][issue-650]") {
     TinyAtlas atlas{1, 1, {255}};
     SdfTextQuad q;
     q.dst_w = 1.0f;
@@ -179,7 +179,7 @@ TEST_CASE("software SDF render keeps maximum alpha for overlapping quads",
 }
 
 TEST_CASE("software SDF render honors custom edge thresholds",
-          "[canvas][sdf][render][coverage][issue-650]") {
+          "[canvas][sdf][render][issue-650]") {
     TinyAtlas atlas{2, 1, {64, 255}};
     SdfTextQuad q;
     q.dst_w = 2.0f;

--- a/test/test_sdf_text.cpp
+++ b/test/test_sdf_text.cpp
@@ -42,7 +42,7 @@ struct FakeAtlas {
 }  // namespace
 
 TEST_CASE("SdfTextOptions default to shader contract values",
-          "[canvas][sdf][layout][coverage][issue-650]") {
+          "[canvas][sdf][layout][issue-650]") {
     SdfTextOptions opts;
     REQUIRE(opts.edge == Catch::Approx(0.5f));
     REQUIRE(opts.softness == 0.0f);
@@ -107,7 +107,7 @@ TEST_CASE("build_text_quads skips missing glyphs", "[canvas][sdf][layout]") {
 }
 
 TEST_CASE("build_text_quads handles empty text and zero render size",
-          "[canvas][sdf][layout][coverage][issue-650]") {
+          "[canvas][sdf][layout][issue-650]") {
     FakeAtlas atlas;
     REQUIRE(build_text_quads(atlas, std::u32string(), 10.0f, 20.0f, 12.0f).empty());
 
@@ -166,7 +166,7 @@ TEST_CASE("named SDF text wrappers forward to shared quad builder",
 }
 
 TEST_CASE("named SDF text wrappers forward options consistently",
-          "[canvas][sdf][layout][coverage][issue-650]") {
+          "[canvas][sdf][layout][issue-650]") {
     FakeAtlas atlas;
     SdfTextOptions opts;
     opts.snap = SdfPenSnap::Nearest;

--- a/test/test_splash_screen.cpp
+++ b/test/test_splash_screen.cpp
@@ -109,7 +109,7 @@ TEST_CASE("SplashScreen paint records default text and image paths",
 }
 
 TEST_CASE("SplashScreen manual dismiss waits for fade-out before callback",
-          "[view][splash][coverage]") {
+          "[view][splash]") {
     SplashScreen splash;
     splash.set_fade_in(0.1f);
     splash.set_duration(10.0f);
@@ -131,7 +131,7 @@ TEST_CASE("SplashScreen manual dismiss waits for fade-out before callback",
 }
 
 TEST_CASE("SplashScreen show restarts state after hidden dismiss",
-          "[view][splash][coverage]") {
+          "[view][splash]") {
     SplashScreen splash;
     splash.set_fade_in(0.2f);
     splash.set_duration(0.2f);
@@ -152,7 +152,7 @@ TEST_CASE("SplashScreen show restarts state after hidden dismiss",
 }
 
 TEST_CASE("SplashScreen can be shown again after completion",
-          "[view][splash][coverage]") {
+          "[view][splash]") {
     SplashScreen splash;
     splash.set_fade_in(0.01f);
     splash.set_duration(0.01f);
@@ -176,7 +176,7 @@ TEST_CASE("SplashScreen can be shown again after completion",
 }
 
 TEST_CASE("SplashScreen zero-duration phases finish deterministically",
-          "[view][splash][coverage]") {
+          "[view][splash]") {
     SplashScreen splash;
     splash.set_fade_in(0.0f);
     splash.set_duration(0.0f);

--- a/test/test_sprite_strip.cpp
+++ b/test/test_sprite_strip.cpp
@@ -60,7 +60,7 @@ TEST_CASE("SpriteStrip empty", "[view][sprite]") {
 }
 
 TEST_CASE("SpriteStrip clamps frame lookup and exposes loaded data",
-          "[view][sprite][coverage]") {
+          "[view][sprite]") {
     SpriteStrip strip;
     std::vector<uint8_t> data(4 * 20 * 4, 77);
     strip.load(data.data(), data.size(), 4, 20, 5);
@@ -83,7 +83,7 @@ TEST_CASE("SpriteStrip clamps frame lookup and exposes loaded data",
 }
 
 TEST_CASE("SpriteStrip interpolation flag is independently configurable",
-          "[view][sprite][coverage]") {
+          "[view][sprite]") {
     SpriteStrip strip;
     REQUIRE_FALSE(strip.interpolate());
 

--- a/test/test_svg_path_widget.cpp
+++ b/test/test_svg_path_widget.cpp
@@ -539,7 +539,7 @@ TEST_CASE("SvgPathWidget unparseable gradient falls back to solid fill_color",
 }
 
 TEST_CASE("SvgPathWidget malformed gradient numbers fall back without throwing",
-          "[view][svg-path][issue-932][issue-1737][codecov]") {
+          "[view][svg-path][issue-932][issue-1737]") {
     using namespace pulp::view;
     using namespace pulp::canvas;
 

--- a/test/test_token_lock.cpp
+++ b/test/test_token_lock.cpp
@@ -155,7 +155,7 @@ TEST_CASE("lock_token_in_designmd rewrites a color token in place",
 }
 
 TEST_CASE("lock_token_in_designmd preserves single-quoted scalar style",
-          "[view][token-lock][coverage]") {
+          "[view][token-lock]") {
     const std::string md =
         "---\n"
         "colors:\n"
@@ -171,7 +171,7 @@ TEST_CASE("lock_token_in_designmd preserves single-quoted scalar style",
 }
 
 TEST_CASE("lock_token_in_designmd escapes single-quoted scalar apostrophes",
-          "[view][token-lock][coverage]") {
+          "[view][token-lock]") {
     const std::string md =
         "---\n"
         "colors:\n"

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -155,7 +155,7 @@ TEST_CASE("TreeView ignores mouse up and misses", "[view][tree]") {
 }
 
 TEST_CASE("TreeView skips selection callback for non-selectable rows",
-          "[view][tree][coverage]") {
+          "[view][tree]") {
     TreeView tree;
     auto& header = tree.root().add_child("Header");
     header.selectable = false;
@@ -347,7 +347,7 @@ TEST_CASE("TreeView row_height and indent configurable", "[view][tree]") {
 }
 
 TEST_CASE("TreeView collapsed children are hidden from paint and hit testing",
-          "[view][tree][coverage][issue-654]") {
+          "[view][tree][issue-654]") {
     TreeView tree;
     auto& group = tree.root().add_child("Group");
     group.add_child("Hidden child");
@@ -369,7 +369,7 @@ TEST_CASE("TreeView collapsed children are hidden from paint and hit testing",
 }
 
 TEST_CASE("TreeView expanded child activation and selected paint paths",
-          "[view][tree][coverage][issue-654]") {
+          "[view][tree][issue-654]") {
     TreeView tree;
     tree.set_bounds({0, 0, 240, 160});
     tree.set_row_height(20.0f);
@@ -393,7 +393,7 @@ TEST_CASE("TreeView expanded child activation and selected paint paths",
 }
 
 TEST_CASE("TreeView left key on collapsed parent is handled without toggling",
-          "[view][tree][coverage][issue-654]") {
+          "[view][tree][issue-654]") {
     TreeView tree;
     auto& group = tree.root().add_child("Group");
     group.add_child("Child");

--- a/test/test_uia_mapping.cpp
+++ b/test/test_uia_mapping.cpp
@@ -21,7 +21,7 @@ TEST_CASE("role_to_control_type returns stable UIA IDs", "[a11y][uia]") {
 }
 
 TEST_CASE("UIA mapping falls back for unknown role values",
-          "[a11y][uia][coverage]") {
+          "[a11y][uia]") {
     auto unknown = static_cast<View::AccessRole>(999);
     REQUIRE(role_to_control_type(unknown) == kControlTypeCustom);
     REQUIRE(patterns_for_role(unknown).count == 0);

--- a/test/test_window_manager.cpp
+++ b/test/test_window_manager.cpp
@@ -338,7 +338,7 @@ TEST_CASE("WindowManager send and broadcast skip missing handlers",
 }
 
 TEST_CASE("WindowManager ignores handlers for unknown windows",
-          "[view][multiwindow][coverage]") {
+          "[view][multiwindow]") {
     WindowManager mgr;
     int count = 0;
 
@@ -474,7 +474,7 @@ TEST_CASE("WindowManager all window types", "[view][multiwindow]") {
 }
 
 TEST_CASE("WindowManager replacing a message handler drops the previous callback",
-          "[view][multiwindow][coverage]") {
+          "[view][multiwindow]") {
     WindowManager mgr;
     View root;
     StubWindowHost host;
@@ -496,7 +496,7 @@ TEST_CASE("WindowManager replacing a message handler drops the previous callback
 }
 
 TEST_CASE("WindowManager saved state captures visibility and restore preserves other windows",
-          "[view][multiwindow][coverage]") {
+          "[view][multiwindow]") {
     WindowManager mgr;
     View first_root;
     View second_root;
@@ -528,7 +528,7 @@ TEST_CASE("WindowManager saved state captures visibility and restore preserves o
 }
 
 TEST_CASE("WindowManager shared theme getter and later registration stay in sync",
-          "[view][multiwindow][coverage]") {
+          "[view][multiwindow]") {
     WindowManager mgr;
     Theme theme = Theme::dark();
     theme.colors["bg.primary"] = color_from_hex(0x123456);


### PR DESCRIPTION
## Summary
- remove stale Catch2 selector metadata tags (`[coverage]`, `[codecov]`, `[requested]`, `[large]`) from 48 native UI/render/widget/motion/accessibility/image/SDF test files
- preserve domain tags, issue tags, test names, fixtures, includes, assertions, and test bodies
- keep this as one coherent product-area batch rather than per-file hygiene PRs

## Validation
- `git diff --check`
- no targeted tags remain in touched files
- no empty selector strings in touched files
- selector-coupling grep over `.github`, `.shipyard`, `CMakeLists.txt`, `test/CMakeLists.txt`, `tools` found no Catch2 filters for removed tags
- extra coupling grep over `compat.json`, `compat/css.json`, `codecov.yml` found only out-of-scope `test_widget_bridge.cpp [issue-1434][coverage]`
- `python3 tools/scripts/docs_noise_lint.py`
- `python3 tools/scripts/hotspot_size_guard.py --warnings-as-errors --require-ceiling-reduction`
- `python3 tools/scripts/skill_sync_check.py` initially mapped `test_motion_swift_bridge.cpp`; tip commit includes `Skill-Update: skip skill=motion` because this is selector metadata only
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- focused Release build of all 48 affected test targets
- direct runs of all 48 affected test binaries passed; `pulp-test-sdf-atlas` reported two expected-failure assertions and exited 0

## Reviews
- RepoPrompt/rp-cli: Clean; non-blocking selector-coupling caveat checked locally
- local autoreview: clean, overall 0.97
- Claude bridge: Clean; noted compat/codecov coupling surface checked locally

Version-Bump: sdk=skip reason="test selector tag cleanup only; no API or runtime behavior change"
Skill-Sync: skip reason="skill-sync reports no mapped paths touched"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale Catch2 selector tags from 48 UI, rendering, widget, motion, accessibility, image, and SDF/text tests to reduce selector noise. Kept domain and issue tags; no code or runtime behavior changes.

- **Refactors**
  - Dropped `[coverage]`, `[codecov]`, `[requested]`, and `[large]` tags; preserved domain/issue tags and test names.
  - Verified no configs or CI filters reference the removed tags.
  - Built in Release and ran all affected test binaries; all passed.
  - Skipped version bump; no API or runtime impact.

<sup>Written for commit c5ce1ac3e23ebd49728cd04e1a27dafcfac3665c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

