### PR TITLE
docs(test): clean remaining selector tags

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -3032,7 +3032,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
-        "test/test_widget_bridge.cpp [issue-1434][coverage]"
+        "test/test_widget_bridge.cpp [issue-1434]"
       ],
       "notes": "RN supports auto/justify; we don't. pulp #1434 Triage #11: bridge accepts start/end (LTR-only aliases for left/right), auto (LTR fallback), and justify. pulp #1434 follow-up: match-parent resolves at paint time by walking the View parent chain via inheritable_text_align(); falls back to left when no ancestor set a value (CSS spec default for text-align).",
       "issue": ""

--- a/compat/css.json
+++ b/compat/css.json
@@ -2977,7 +2977,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
-        "test/test_widget_bridge.cpp [issue-1434][coverage]"
+        "test/test_widget_bridge.cpp [issue-1434]"
       ],
       "notes": "RN supports auto/justify; we don't. pulp #1434 Triage #11: bridge accepts start/end (LTR-only aliases for left/right), auto (LTR fallback), and justify. pulp #1434 follow-up: match-parent resolves at paint time by walking the View parent chain via inheritable_text_align(); falls back to left when no ancestor set a value (CSS spec default for text-align).",
       "issue": ""

--- a/test/test_cluster_step.cpp
+++ b/test/test_cluster_step.cpp
@@ -177,7 +177,7 @@ TEST_CASE("cluster_step: extended combining ranges attach to base",
 }
 
 TEST_CASE("cluster_step: regional indicator run preserves pair boundaries",
-          "[font][cluster][emoji][coverage]") {
+          "[font][cluster][emoji]") {
     // 🇺🇸🇯 — the third regional indicator starts the next flag pair.
     std::string s = "\xF0\x9F\x87\xBA\xF0\x9F\x87\xB8"
                     "\xF0\x9F\x87\xAF";
@@ -192,7 +192,7 @@ TEST_CASE("cluster_step: regional indicator run preserves pair boundaries",
 }
 
 TEST_CASE("cluster_step: ZWJ only joins pictographic targets",
-          "[font][cluster][coverage]") {
+          "[font][cluster]") {
     std::string joined = "\xE2\x98\x80\xE2\x80\x8D"
                          "\xF0\x9F\x94\xA5"; // sun + ZWJ + fire
     REQUIRE(cluster_step(joined, 0, true) == joined.size());
@@ -204,7 +204,7 @@ TEST_CASE("cluster_step: ZWJ only joins pictographic targets",
 }
 
 TEST_CASE("cluster_step: malformed multi-byte prefixes fall back to one byte",
-          "[font][cluster][utf8][coverage]") {
+          "[font][cluster][utf8]") {
     std::string bad_two = "\xC2"
                           "A";
     REQUIRE(cluster_step(bad_two, 0, true) == 1u);

--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -91,7 +91,7 @@ TEST_CASE("RectangleList subtract handles no-op and full-cover cases",
 }
 
 TEST_CASE("RectangleList subtract emits all side bands around a center cut",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -213,7 +213,7 @@ TEST_CASE("Rect enclosing union preserves non-empty side",
 }
 
 TEST_CASE("Rect right bottom and empty semantics cover zero and negative extents",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect normal{2, 3, 4, 5};
     REQUIRE(normal.right() == Catch::Approx(6.0f));
     REQUIRE(normal.bottom() == Catch::Approx(8.0f));
@@ -226,7 +226,7 @@ TEST_CASE("Rect right bottom and empty semantics cover zero and negative extents
 }
 
 TEST_CASE("Rect contains keeps right and bottom edges exclusive",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect r{-2, -3, 5, 7};
 
     REQUIRE(r.contains(-2.0f, -3.0f));
@@ -238,7 +238,7 @@ TEST_CASE("Rect contains keeps right and bottom edges exclusive",
 }
 
 TEST_CASE("Rect intersection is commutative for overlapping rectangles",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect a{-5, 2, 12, 6};
     Rect b{0, -1, 4, 10};
 
@@ -250,7 +250,7 @@ TEST_CASE("Rect intersection is commutative for overlapping rectangles",
 }
 
 TEST_CASE("Rect intersection of contained rectangle returns contained bounds",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect outer{-10, -10, 30, 30};
     Rect inner{-2, 3, 5, 6};
 
@@ -259,7 +259,7 @@ TEST_CASE("Rect intersection of contained rectangle returns contained bounds",
 }
 
 TEST_CASE("Rect intersection treats edge and corner contact as empty",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect base{0, 0, 10, 10};
 
     REQUIRE_FALSE(base.intersects({10, 2, 3, 3}));
@@ -270,7 +270,7 @@ TEST_CASE("Rect intersection treats edge and corner contact as empty",
 }
 
 TEST_CASE("Rect enclosing union handles negative coordinates",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect a{-10, 5, 4, 5};
     Rect b{3, -2, 8, 3};
 
@@ -279,7 +279,7 @@ TEST_CASE("Rect enclosing union handles negative coordinates",
 }
 
 TEST_CASE("Rect enclosing union of two empty rectangles is empty",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     Rect a{5, 6, 0, 7};
     Rect b{-1, -2, 8, 0};
 
@@ -288,7 +288,7 @@ TEST_CASE("Rect enclosing union of two empty rectangles is empty",
 }
 
 TEST_CASE("RectangleList preserves insertion order for indexing and iteration",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({3, 0, 1, 1});
     rl.add({1, 0, 1, 1});
@@ -306,7 +306,7 @@ TEST_CASE("RectangleList preserves insertion order for indexing and iteration",
 }
 
 TEST_CASE("RectangleList contains checks negative-coordinate rectangles",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({-10, -5, 4, 8});
     rl.add({5, -2, 3, 3});
@@ -318,7 +318,7 @@ TEST_CASE("RectangleList contains checks negative-coordinate rectangles",
 }
 
 TEST_CASE("RectangleList intersects ignores empty query rectangles",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -328,7 +328,7 @@ TEST_CASE("RectangleList intersects ignores empty query rectangles",
 }
 
 TEST_CASE("RectangleList bounding box for a single rectangle is that rectangle",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({-4, 8, 6, 2});
 
@@ -336,7 +336,7 @@ TEST_CASE("RectangleList bounding box for a single rectangle is that rectangle",
 }
 
 TEST_CASE("RectangleList total_area intentionally double-counts overlaps",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({5, 5, 10, 10});
@@ -345,7 +345,7 @@ TEST_CASE("RectangleList total_area intentionally double-counts overlaps",
 }
 
 TEST_CASE("RectangleList clipped preserves source order and leaves source intact",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 20, 10, 10});
@@ -360,7 +360,7 @@ TEST_CASE("RectangleList clipped preserves source order and leaves source intact
 }
 
 TEST_CASE("RectangleList clipped against disjoint bounds returns empty list",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 20, 5, 5});
@@ -369,7 +369,7 @@ TEST_CASE("RectangleList clipped against disjoint bounds returns empty list",
 }
 
 TEST_CASE("RectangleList clipped handles negative clip coordinates",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({-10, -10, 8, 8});
     rl.add({-3, -3, 8, 8});
@@ -382,7 +382,7 @@ TEST_CASE("RectangleList clipped handles negative clip coordinates",
 }
 
 TEST_CASE("RectangleList subtract top strip keeps the lower remainder",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -393,7 +393,7 @@ TEST_CASE("RectangleList subtract top strip keeps the lower remainder",
 }
 
 TEST_CASE("RectangleList subtract bottom strip keeps the upper remainder",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -404,7 +404,7 @@ TEST_CASE("RectangleList subtract bottom strip keeps the upper remainder",
 }
 
 TEST_CASE("RectangleList subtract left strip keeps the right remainder",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -415,7 +415,7 @@ TEST_CASE("RectangleList subtract left strip keeps the right remainder",
 }
 
 TEST_CASE("RectangleList subtract right strip keeps the left remainder",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -426,7 +426,7 @@ TEST_CASE("RectangleList subtract right strip keeps the left remainder",
 }
 
 TEST_CASE("RectangleList subtract vertical middle split creates left and right pieces",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -438,7 +438,7 @@ TEST_CASE("RectangleList subtract vertical middle split creates left and right p
 }
 
 TEST_CASE("RectangleList subtract horizontal middle split creates top and bottom pieces",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -450,7 +450,7 @@ TEST_CASE("RectangleList subtract horizontal middle split creates top and bottom
 }
 
 TEST_CASE("RectangleList subtract corner overlap creates two non-overlapping pieces",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -465,7 +465,7 @@ TEST_CASE("RectangleList subtract corner overlap creates two non-overlapping pie
 }
 
 TEST_CASE("RectangleList subtract overlap extending past left edge",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
 
@@ -478,7 +478,7 @@ TEST_CASE("RectangleList subtract overlap extending past left edge",
 }
 
 TEST_CASE("RectangleList subtract applies independently to multiple rectangles",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
     rl.add({20, 0, 10, 10});
@@ -491,7 +491,7 @@ TEST_CASE("RectangleList subtract applies independently to multiple rectangles",
 }
 
 TEST_CASE("RectangleList repeated subtracts work on previously split pieces",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 12, 12});
 
@@ -507,7 +507,7 @@ TEST_CASE("RectangleList repeated subtracts work on previously split pieces",
 }
 
 TEST_CASE("RectangleList clear allows reuse without stale bounds",
-          "[canvas][rect][coverage][large]") {
+          "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 100, 100});
     rl.clear();

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -1238,7 +1238,7 @@ TEST_CASE("WebCompat: class selector requires every class in classList (issue-15
 //      namespace context. The parser ignores the namespace prefix
 //      and the selector won't match.
 TEST_CASE("WebCompat: class selector is case-sensitive (CSS standards-mode spec)",
-          "[webcompat][css-selector][issue-1551][coverage]") {
+          "[webcompat][css-selector][issue-1551]") {
     TestEnvironment env;
     env.eval(R"JS(
         var __caseEl = document.createElement('div');
@@ -1880,7 +1880,7 @@ TEST_CASE("resolveCSSLength: malformed calc-family operands fall through to px",
 // isolation would pass even if the dispatcher stopped routing through
 // setLineClamp at all — this test catches that.
 TEST_CASE("WebCompat: el.style.lineClamp = 'none' routes through dispatcher to setLineClamp(id, 0)",
-          "[webcompat][issue-1552][coverage]") {
+          "[webcompat][issue-1552]") {
     TestEnvironment env;
     // Install a recording shim over setLineClamp BEFORE the dispatcher
     // runs. Captures every (id, n) pair so we can verify the routing.
@@ -1931,7 +1931,7 @@ TEST_CASE("WebCompat: el.style.lineClamp = 'none' routes through dispatcher to s
 // path: a real StyleSheet with `:focus` / `:active` rules attaches and
 // the pseudo-setup helpers run.
 TEST_CASE("WebCompat: StyleSheet with :focus rule wires _setupPseudoFocus end-to-end",
-          "[webcompat][issue-1149][coverage]") {
+          "[webcompat][issue-1149]") {
     TestEnvironment env;
     env.eval(R"JS(
         var __ffEl = document.createElement('input');
@@ -1947,7 +1947,7 @@ TEST_CASE("WebCompat: StyleSheet with :focus rule wires _setupPseudoFocus end-to
 }
 
 TEST_CASE("WebCompat: StyleSheet with :active rule wires _setupPseudoActive end-to-end",
-          "[webcompat][issue-1149][coverage]") {
+          "[webcompat][issue-1149]") {
     TestEnvironment env;
     env.eval(R"JS(
         var __aaEl = document.createElement('button');


### PR DESCRIPTION
## Summary
- Remove the remaining stale Catch2 selector metadata tags (`[coverage]`, `[codecov]`, `[requested]`, `[large]`) from rectangle, cluster, and web-compat prelude tests.
- Drop dangling `[coverage]` suffixes from the css/textAlign compat evidence strings while preserving the durable `[issue-1434]` selector.
- Preserve all domain and issue tags; no test bodies or runtime behavior changed.

## Validation
- `git diff --check`
- `rg -n '\\[(coverage|codecov|requested|large)\\]' test tools core examples packages apple android .github compat.json compat/css.json codecov.yml --glob '*.{cpp,hpp,h,mm,swift,rs,py,js,ts,tsx,json,yml,yaml,cmake,txt,md}' || true`\n- empty-selector grep over touched Catch2 files\n- `python3 -m json.tool compat.json >/dev/null`\n- `python3 -m json.tool compat/css.json >/dev/null`\n- `python3 tools/scripts/docs_noise_lint.py`\n- `python3 tools/scripts/hotspot_size_guard.py --warnings-as-errors --require-ceiling-reduction`\n- `python3 tools/scripts/skill_sync_check.py`\n- `python3 tools/scripts/compat_sync_check.py --mode=report --base origin/main`\n- `./tools/scripts/gates.sh origin/main`\n- `cmake --build build --target pulp-test-cluster-step pulp-test-rectangle-list pulp-test-web-compat-prelude -j$(sysctl -n hw.ncpu)`\n- `./build/test/pulp-test-cluster-step --reporter compact`\n- `./build/test/pulp-test-rectangle-list --reporter compact`\n- `./build/test/web-compat/pulp-test-web-compat-prelude --reporter compact`\n\n## Reviews\n- RepoPrompt Oracle review over the five-file selection; follow-up evidence resolved its cross-file/source-of-truth/coupling concerns.\n- `autoreview --mode local` clean: no accepted/actionable findings.\n- Claude bridge review clean; specifically confirmed the compat evidence edit replaces a non-existent `[issue-1434][coverage]` selector with live `[issue-1434]` evidence.\n\n## Notes\n- `compat_aggregate.py check` also fails on clean `origin/main`; running `compat_aggregate.py build` would delete unrelated imports coverage / figma-plugin data. I left that pre-existing generator drift out of this selector cleanup and will record it in planning as separate follow-up debt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale Catch2 selector tags and cleaned compat evidence strings to reduce noise and avoid brittle filtering. No runtime or test behavior changes.

- **Refactors**
  - Removed `[coverage]`, `[codecov]`, `[requested]`, `[large]` from rectangle, cluster, and web-compat prelude tests.
  - Dropped trailing `[coverage]` from `compat.json` and `compat/css.json` evidence entries; preserved `[issue-1434]`.
  - Kept all domain and issue tags; test names and logic unchanged.

<sup>Written for commit 29b7cf989bfa5e0ec3e943e53d8db440c0f4ed22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

