### PR TITLE
docs(test): clean audit follow-up breadcrumbs

### DIFF
--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -6,9 +6,8 @@
 # but gracefully handles the case where either isn't buildable on this
 # branch / OS:
 #
-#   - `experimental/pulp-rs/` only exists after Phase 8 prep lands. When
-#     the dir is absent, skip the Rust build and let the harness
-#     auto-skip any Rust-dependent test.
+#   - If `experimental/pulp-rs/` is absent, skip the Rust build and let the
+#     harness auto-skip any Rust-dependent test.
 #   - Linux needs apt deps for the C++ build (ALSA / X11 / Wayland via
 #     SDL3). We install the minimum set; if the build still fails, that
 #     regression is worth catching and not a sandbox-harness problem.

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -5,13 +5,12 @@ name: Workflow lint
 # tooling (yamllint, actionlint, `python3 -c yaml.safe_load`) so any
 # contributor or agent can run the same checks locally.
 #
-# Motivating incident: #501 shipped an auto-release.yml with Python
-# code at column 1 nested inside a YAML `run: |` block whose indent
-# indicator was 10 spaces. YAML terminated the block scalar at the
-# first less-indented line, producing a workflow file GitHub refused
-# to execute. Every auto-release run since #501 failed silently with
-# "workflow file issue" and 0 jobs — v0.23.1 never auto-tagged. Fixed
-# in #510; this lint workflow prevents the re-occurrence class.
+# Motivating incident: an auto-release workflow shipped with Python code at
+# column 1 nested inside a YAML `run: |` block whose indent indicator was 10
+# spaces. YAML terminated the block scalar at the first less-indented line,
+# producing a workflow file GitHub refused to execute. Auto-release runs then
+# failed silently with "workflow file issue" and 0 jobs; this lint workflow
+# prevents the recurrence class.
 #
 # Scope: runs only on PRs that touch `.github/workflows/**` or this
 # file itself. Keeps the check fast on the 99% of PRs that don't
@@ -64,9 +63,9 @@ jobs:
           set -euo pipefail
           python3 -m pip install --quiet 'pyyaml>=6'
           # Dumb-but-decisive: every workflow file must round-trip
-          # through `yaml.safe_load` without raising. Catches the #501
-          # class (block-scalar terminated by less-indented content)
-          # even if yamllint's rules don't flag it.
+          # through `yaml.safe_load` without raising. Catches block scalars
+          # terminated by less-indented content even if yamllint's rules don't
+          # flag them.
           python3 - <<'PY'
           import sys, pathlib, yaml
           failures = []
@@ -129,11 +128,10 @@ jobs:
         # ~30 pre-existing shellcheck findings across auto-release.yml,
         # release-cli.yml, android.yml, freshness-check.yml, etc. that
         # pre-date this watchdog and aren't in scope here. Core actionlint
-        # still catches the #501 class (YAML block-scalar issues), bad
+        # still catches YAML block-scalar issues, bad
         # `uses:` refs, missing required keys, and deprecated action
         # versions — which are the failure modes Layer 1 exists to catch.
-        # A follow-up sweep to clean up shellcheck findings can re-enable
-        # it later.
+        # Re-enable shellcheck after those existing findings are retired.
         uses: raven-actions/actionlint@v2
         with:
           matcher: true

--- a/examples/PulpSampler/CMakeLists.txt
+++ b/examples/PulpSampler/CMakeLists.txt
@@ -1,5 +1,5 @@
 # PulpSampler — sample-buffer sampler with MIDI triggering and ADSR
-# CLAP only for now (like PulpSynth/PulpDrums)
+# CLAP is the validated example format; enable others only after validation.
 
 if(PULP_HAS_CLAP)
     # CLAP plugin

--- a/examples/PulpSynth/CMakeLists.txt
+++ b/examples/PulpSynth/CMakeLists.txt
@@ -10,7 +10,7 @@ if(PULP_BUILD_TESTS)
     catch_discover_tests(pulp-synth-test)
 endif()
 
-# ── Plugin (CLAP only for now — add VST3/AU when validated) ──────────────
+# ── Plugin (CLAP is validated; enable other formats after validation) ─────
 pulp_add_plugin(PulpSynth
     FORMATS         CLAP
     PLUGIN_NAME     "PulpSynth"

--- a/test/integration/real_plugins.toml
+++ b/test/integration/real_plugins.toml
@@ -41,7 +41,9 @@
 
 # ── Free plugin set (canonical) ────────────────────────────────────────────
 #
-# Fixture-pinning status, as of the 2026-05-26 4.2 follow-up:
+# Runnable pinned fixtures use archives the scaffold can unpack without
+# running vendor installers; installer-only pinned rows skip cleanly, and
+# rows still marked TBD are not yet pinned.
 #
 # - Surge XT 1.3.4 (GitHub release) — pinned. The "pluginsonly" variants
 #   for Linux/Windows are intentionally chosen over the full installers

--- a/test/support/audio_contracts.cpp
+++ b/test/support/audio_contracts.cpp
@@ -1,4 +1,4 @@
-// audio_contracts.cpp — named audio contracts (harness PR 3).
+// audio_contracts.cpp — named audio contracts.
 // See audio_contracts.hpp for the vocabulary and message policy.
 
 #include "audio_contracts.hpp"

--- a/test/support/audio_contracts.hpp
+++ b/test/support/audio_contracts.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file audio_contracts.hpp
-/// Named audio contracts over RenderScenario (harness PR 3).
+/// Named audio contracts over RenderScenario.
 ///
 /// A contract is a named, human-readable claim ("PulpGain bypass is
 /// transparent") bound to one rendered scenario plus a list of

--- a/test/support/audio_signal_generators.cpp
+++ b/test/support/audio_signal_generators.cpp
@@ -1,6 +1,6 @@
-// audio_signal_generators.cpp — deterministic stimulus generators
-// (harness PR 2). Each generator's determinism contract is documented in
-// the header; keep expressions here in lock-step with those docs.
+// audio_signal_generators.cpp — deterministic stimulus generators.
+// Each generator's determinism contract is documented in the header; keep
+// expressions here in lock-step with those docs.
 
 #include "audio_signal_generators.hpp"
 

--- a/test/support/audio_signal_generators.hpp
+++ b/test/support/audio_signal_generators.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file audio_signal_generators.hpp
-/// Deterministic stimulus generators and event scripts (harness PR 2).
+/// Deterministic stimulus generators and event scripts.
 ///
 /// Test/tool layer only. Every generator here is deterministic by
 /// construction: identical arguments produce bit-identical buffers on a

--- a/test/support/audio_test_signals.hpp
+++ b/test/support/audio_test_signals.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file audio_test_signals.hpp
-/// Shared deterministic test-signal generators (harness PR 1B).
+/// Shared deterministic test-signal generators.
 ///
 /// Replaces the per-TU `make_sine` / `make_sine_vec` helpers that were
 /// duplicated across the golden and determinism-matrix suites. The exact

--- a/test/support/render_scenario.cpp
+++ b/test/support/render_scenario.cpp
@@ -1,4 +1,4 @@
-// render_scenario.cpp — typed offline render scenarios (harness PR 2).
+// render_scenario.cpp — typed offline render scenarios.
 // Event-application semantics are documented in render_scenario.hpp; keep
 // the block loop here in lock-step with those docs.
 

--- a/test/support/render_scenario.hpp
+++ b/test/support/render_scenario.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file render_scenario.hpp
-/// Typed offline render scenarios over HeadlessHost (harness PR 2).
+/// Typed offline render scenarios over HeadlessHost.
 ///
 /// A RenderScenario describes one deterministic render — processor
 /// factory, sample rate, block size, channel layout, duration, input

--- a/test/test_audio_contracts.cpp
+++ b/test/test_audio_contracts.cpp
@@ -1,9 +1,9 @@
-// test_audio_contracts.cpp — harness PR 3: named contracts for the
-// example plugins (PulpGain effect + PulpTone instrument here; PulpEffect
-// lives in test_audio_contracts_effect.cpp because pulp_gain.hpp and
-// pulp_effect.hpp define colliding unscoped enumerators — same reason the
-// golden suites are split). Acceptance: a new effect copies one of
-// these fixtures; failures name the contract that broke.
+// test_audio_contracts.cpp — named contracts for the example plugins
+// (PulpGain effect + PulpTone instrument here; PulpEffect lives in
+// test_audio_contracts_effect.cpp because pulp_gain.hpp and pulp_effect.hpp
+// define colliding unscoped enumerators — same reason the golden suites are
+// split). Acceptance: a new effect copies one of these fixtures; failures
+// name the contract that broke.
 //
 // Analyzer Determinism Contract (uniform for every contract in this TU):
 // - stimulus: documented deterministic generators (sine / silence / MIDI
@@ -44,7 +44,7 @@ double window_rms_dbfs(const ScenarioResult& result, std::size_t start,
 } // namespace
 
 TEST_CASE("AudioContract verdict mechanics",
-          "[audio][contract][harness-3]") {
+          "[audio][contract]") {
     auto scenario = RenderScenario(pulp::examples::create_pulp_gain)
         .name("contract-meta")
         .sample_rate(48000.0)
@@ -83,7 +83,7 @@ TEST_CASE("AudioContract verdict mechanics",
 }
 
 TEST_CASE("Contract: PulpGain unity settings are transparent",
-          "[audio][contract][pulpgain][harness-3]") {
+          "[audio][contract][pulpgain]") {
     // Default gains (0 dB in / 0 dB out) multiply by exactly 1.0f, so the
     // output must be bit-identical to the stimulus (tolerance: exact).
     const auto input = make_sine(2, 9600, 440.0f, 48000.0, 0.5f);
@@ -102,7 +102,7 @@ TEST_CASE("Contract: PulpGain unity settings are transparent",
 }
 
 TEST_CASE("Contract: PulpGain scales level by the configured gain",
-          "[audio][contract][pulpgain][harness-3]") {
+          "[audio][contract][pulpgain]") {
     // -12 dBFS-peak sine has RMS -15.05 dBFS; -6 dB input gain and -6 dB
     // output gain compose to -12 dB → RMS -27.05 dBFS (numeric ±0.5 dB).
     // Gain is stateless per sample, so partitioning is exact.
@@ -126,7 +126,7 @@ TEST_CASE("Contract: PulpGain scales level by the configured gain",
 }
 
 TEST_CASE("Contract: PulpGain bypass is transparent",
-          "[audio][contract][pulpgain][harness-3]") {
+          "[audio][contract][pulpgain]") {
     // Bypass copies samples and must win over extreme gain settings
     // (tolerance: exact).
     const auto input = make_sine(2, 9600, 220.0f, 48000.0, 0.5f);
@@ -148,7 +148,7 @@ TEST_CASE("Contract: PulpGain bypass is transparent",
 }
 
 TEST_CASE("Contract: PulpGain keeps silence silent",
-          "[audio][contract][pulpgain][harness-3]") {
+          "[audio][contract][pulpgain]") {
     // Silence in → silence out: a gain stage adds no self-noise even at
     // +24 dB (threshold −90 dBFS, the metrics silence floor).
     AudioContract contract(
@@ -166,7 +166,7 @@ TEST_CASE("Contract: PulpGain keeps silence silent",
 }
 
 TEST_CASE("Contract: PulpTone note-on produces the claimed tone",
-          "[audio][contract][pulptone][harness-3]") {
+          "[audio][contract][pulptone]") {
     // A4 (note 69, velocity 100) at default −6 dB volume: amplitude
     // 0.5012 · (100/127) ≈ 0.395 → held RMS ≈ −11.2 dBFS including the
     // 10 ms attack (numeric ±1.3 dB window); pitch 440 Hz ±5 cents.
@@ -195,7 +195,7 @@ TEST_CASE("Contract: PulpTone note-on produces the claimed tone",
 }
 
 TEST_CASE("Contract: PulpTone is silent without MIDI",
-          "[audio][contract][pulptone][harness-3]") {
+          "[audio][contract][pulptone]") {
     // An instrument given no events must not self-oscillate or leak
     // voice state (threshold −90 dBFS).
     AudioContract contract(
@@ -213,7 +213,7 @@ TEST_CASE("Contract: PulpTone is silent without MIDI",
 }
 
 TEST_CASE("Contract: PulpTone release tail decays",
-          "[audio][contract][pulptone][harness-3]") {
+          "[audio][contract][pulptone]") {
     // Note-off at 200 ms with the default 200 ms release: the final 50 ms
     // of a 400 ms render must sit ≥ 20 dB below the held level (numeric;
     // a hand-built CheckResult — the vocabulary is open to custom claims).

--- a/test/test_audio_contracts_effect.cpp
+++ b/test/test_audio_contracts_effect.cpp
@@ -1,4 +1,4 @@
-// test_audio_contracts_effect.cpp — harness PR 3: PulpEffect contracts.
+// test_audio_contracts_effect.cpp — PulpEffect contracts.
 // Separate TU within pulp-test-audio-contracts because pulp_effect.hpp and
 // pulp_gain.hpp define colliding unscoped enumerators (kBypass).
 //
@@ -46,7 +46,7 @@ RenderScenario lowpass_scenario(const char* name, float cutoff_hz,
 } // namespace
 
 TEST_CASE("Contract: PulpEffect lowpass attenuates high frequencies",
-          "[audio][contract][pulpeffect][harness-3]") {
+          "[audio][contract][pulpeffect]") {
     // Golden semantics: a 200 Hz lowpass must drop an 8 kHz, 0.5-amp sine
     // (RMS −9.05 dBFS) by ≥ 20 dB in steady state — measured after the
     // stated 100 ms warm-up (numeric). The biquad is per-sample state with
@@ -65,7 +65,7 @@ TEST_CASE("Contract: PulpEffect lowpass attenuates high frequencies",
 }
 
 TEST_CASE("Contract: PulpEffect lowpass preserves low frequencies",
-          "[audio][contract][pulpeffect][harness-3]") {
+          "[audio][contract][pulpeffect]") {
     // A 5 kHz lowpass passes a 100 Hz, 0.5-amp sine (RMS −9.05 dBFS)
     // within 1 dB in steady state (numeric; matches the golden suite's
     // "within ~2 dB" claim with margin).
@@ -82,7 +82,7 @@ TEST_CASE("Contract: PulpEffect lowpass preserves low frequencies",
 }
 
 TEST_CASE("Contract: PulpEffect bypass is transparent",
-          "[audio][contract][pulpeffect][harness-3]") {
+          "[audio][contract][pulpeffect]") {
     // Bypass copies samples and must win over an aggressive filter setup
     // (tolerance: exact).
     const auto input = make_sine(2, 9600, 1000.0f, kSampleRate, 0.5f);
@@ -104,7 +104,7 @@ TEST_CASE("Contract: PulpEffect bypass is transparent",
 }
 
 TEST_CASE("Contract: PulpEffect keeps silence silent",
-          "[audio][contract][pulpeffect][harness-3]") {
+          "[audio][contract][pulpeffect]") {
     // Zero input through a zero-state biquad stays exactly zero — no
     // self-noise, no denormal rumble (threshold −90 dBFS).
     AudioContract contract(

--- a/test/test_audio_support.cpp
+++ b/test/test_audio_support.cpp
@@ -1,13 +1,13 @@
-// test_audio_support.cpp — tests for the PR 1A audio harness helpers
-// (test/support/audio_metrics + audio_assertions). These test the helpers
+// test_audio_support.cpp — tests for the audio harness helpers
+// (audio_metrics + audio_assertions). These test the helpers
 // THEMSELVES against synthetic buffers with known ground truth; existing
-// golden/matrix tests are converted in PR 1B.
+// golden/matrix tests use the shared helpers.
 //
 // Analyzer Determinism Contract (declared once for the whole file, per
 // planning/2026-06-09-audio-observability-and-validation-harness-plan.md):
 //   stimulus:        synthetic sine/DC/silence buffers generated inline with
 //                    std::sin — coherence with any FFT length is irrelevant
-//                    because no FFT is used in PR 1A
+//                    because no FFT is used
 //   analysis window: none (pure time-domain arithmetic over all samples)
 //   warm-up trim:    none (stimuli are steady-state from sample 0)
 //   estimator:       positive-going zero-crossing with linear interpolation
@@ -37,7 +37,7 @@ using Catch::Matchers::WithinRel;
 // ── metrics: levels ─────────────────────────────────────────────────────
 
 TEST_CASE("audio_metrics: full-scale sine has known peak/RMS/DC",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     // 440 Hz @ 48 kHz, 4800 frames = exactly 44 cycles, so RMS is the ideal
     // 1/sqrt(2) and DC is ~0 without partial-cycle bias.
     auto buf = make_sine_f(2, 4800, 440.0f, 48000.0);
@@ -58,7 +58,7 @@ TEST_CASE("audio_metrics: full-scale sine has known peak/RMS/DC",
 }
 
 TEST_CASE("audio_metrics: dBFS conversion round-trips",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     REQUIRE_THAT(to_dbfs(1.0), WithinAbs(0.0, 1e-12));
     REQUIRE_THAT(to_dbfs(0.5), WithinAbs(-6.0206, 1e-3));
     REQUIRE_THAT(from_dbfs(to_dbfs(0.25)), WithinAbs(0.25, 1e-9));
@@ -67,7 +67,7 @@ TEST_CASE("audio_metrics: dBFS conversion round-trips",
 }
 
 TEST_CASE("audio_metrics: DC offset is reported",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     pulp::audio::Buffer<float> buf(1, 1000);
     for (auto& s : buf.channel(0)) s = 0.25f;
     auto m = analyze(buf, 48000.0);
@@ -78,7 +78,7 @@ TEST_CASE("audio_metrics: DC offset is reported",
 // ── metrics: defects ────────────────────────────────────────────────────
 
 TEST_CASE("audio_metrics: NaN and Inf samples are counted, not propagated",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     auto buf = make_sine_f(1, 1024, 440.0f, 48000.0, 0.5f);
     buf.channel(0)[10] = std::numeric_limits<float>::quiet_NaN();
     buf.channel(0)[20] = std::numeric_limits<float>::infinity();
@@ -99,7 +99,7 @@ TEST_CASE("audio_metrics: NaN and Inf samples are counted, not propagated",
 }
 
 TEST_CASE("audio_metrics: clipped samples are counted at the threshold",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     pulp::audio::Buffer<float> buf(1, 100);
     for (auto& s : buf.channel(0)) s = 0.9f;
     buf.channel(0)[5] = 1.0f;   // exactly at threshold — counts
@@ -115,7 +115,7 @@ TEST_CASE("audio_metrics: clipped samples are counted at the threshold",
 }
 
 TEST_CASE("audio_metrics: silence runs are measured",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     auto buf = make_sine_f(1, 1000, 440.0f, 48000.0, 0.5f);
     // Insert a 200-sample dropout (the plan's "standalone boundary went
     // silent for N consecutive blocks" signature, in miniature).
@@ -130,7 +130,7 @@ TEST_CASE("audio_metrics: silence runs are measured",
 // ── assertions: silence / level ─────────────────────────────────────────
 
 TEST_CASE("audio_assertions: silence and non-silence",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     pulp::audio::Buffer<float> silent(2, 512);
     silent.clear();
     auto silent_m = analyze(silent, 48000.0);
@@ -147,7 +147,7 @@ TEST_CASE("audio_assertions: silence and non-silence",
 }
 
 TEST_CASE("audio_assertions: peak and RMS ranges",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     // -6 dBFS sine: peak ≈ -6 dBFS, RMS ≈ -9 dBFS.
     auto buf = make_sine_f(1, 4800, 440.0f, 48000.0, 0.501187f);
     auto m = analyze(buf, 48000.0);
@@ -161,7 +161,7 @@ TEST_CASE("audio_assertions: peak and RMS ranges",
 // ── assertions: frequency ───────────────────────────────────────────────
 
 TEST_CASE("audio_assertions: frequency estimate within cents tolerance",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     // Tolerance class: numeric. The zero-crossing estimator on a clean
     // 440 Hz sine over 9600 frames (88 cycles) should land well inside
     // ±5 cents.
@@ -178,7 +178,7 @@ TEST_CASE("audio_assertions: frequency estimate within cents tolerance",
 }
 
 TEST_CASE("audio_assertions: frequency estimator reports no-estimate "
-          "honestly", "[audio-support][harness-1a]") {
+          "honestly", "[audio-support]") {
     pulp::audio::Buffer<float> dc(1, 1024);
     for (auto& s : dc.channel(0)) s = 0.5f; // no zero crossings
     auto check = assert_frequency_near(dc.channel(0), 48000.0, 440.0, 5.0);
@@ -191,7 +191,7 @@ TEST_CASE("audio_assertions: frequency estimator reports no-estimate "
 }
 
 TEST_CASE("audio_assertions: sample-rate mismatch shows as pitch shift",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     // The plan's "chipmunk" regression: a 440 Hz tone rendered at 48 kHz but
     // played/analyzed as 96 kHz reads as 880 Hz. The helpers must make that
     // visible rather than vaguely "different".
@@ -203,7 +203,7 @@ TEST_CASE("audio_assertions: sample-rate mismatch shows as pitch shift",
 // ── assertions: null + channel routing ──────────────────────────────────
 
 TEST_CASE("audio_assertions: null test detects exact and near matches",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     auto a = make_sine_f(2, 1024, 440.0f, 48000.0, 0.5f);
     auto b = make_sine_f(2, 1024, 440.0f, 48000.0, 0.5f);
 
@@ -220,7 +220,7 @@ TEST_CASE("audio_assertions: null test detects exact and near matches",
 }
 
 TEST_CASE("audio_assertions: null test rejects shape mismatch",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     auto a = make_sine_f(2, 512, 440.0f, 48000.0);
     auto b = make_sine_f(1, 512, 440.0f, 48000.0);
     auto check = assert_null_near(a, b, -120.0);
@@ -229,7 +229,7 @@ TEST_CASE("audio_assertions: null test rejects shape mismatch",
 }
 
 TEST_CASE("audio_assertions: duplicated channels are flagged",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     pulp::audio::Buffer<float> buf(2, 512);
     for (std::size_t i = 0; i < 512; ++i) {
         const float v = std::sin(2.0f * std::numbers::pi_v<float> * 440.0f *
@@ -246,7 +246,7 @@ TEST_CASE("audio_assertions: duplicated channels are flagged",
 }
 
 TEST_CASE("audio_assertions: two silent channels are not flagged as duplicated",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     // Two channels that are both silent are trivially sample-identical, but
     // there is no signal to duplicate — that is not a routing bug.
     pulp::audio::Buffer<float> silent(2, 512); // zero-initialized.
@@ -274,7 +274,7 @@ TEST_CASE("audio_assertions: two silent channels are not flagged as duplicated",
 // ── signal summary ──────────────────────────────────────────────────────
 
 TEST_CASE("audio_metrics: summarize renders the agent-readable report",
-          "[audio-support][harness-1a]") {
+          "[audio-support]") {
     auto buf = make_sine_f(2, 9600, 220.0f, 48000.0, 0.5f);
     auto m = analyze(buf, 48000.0);
     auto est = estimate_frequency(buf.channel(0), 48000.0);
@@ -288,13 +288,12 @@ TEST_CASE("audio_metrics: summarize renders the agent-readable report",
     REQUIRE(text.find("dBFS") != std::string::npos);
 }
 
-// ── end-to-end through HeadlessHost (the PR 1B conversion pattern) ──────
+// ── end-to-end through HeadlessHost ─────────────────────────────────────
 
 TEST_CASE("audio_support: HeadlessHost render analyzed by the helpers",
-          "[audio-support][harness-1a]") {
-    // Proves the helpers compose with the offline host exactly the way the
-    // PR 1B golden-test conversion will use them: render PulpGain at unity
-    // and assert signal facts instead of raw sample loops.
+          "[audio-support]") {
+    // Proves the helpers compose with the offline host: render PulpGain at
+    // unity and assert signal facts instead of raw sample loops.
     pulp::format::HeadlessHost host(pulp::examples::create_pulp_gain);
     host.prepare(48000.0, 1024);
 

--- a/test/test_audio_tone_regression.cpp
+++ b/test/test_audio_tone_regression.cpp
@@ -1,4 +1,4 @@
-// test_audio_tone_regression.cpp — harness PR 1B regression scenario.
+// test_audio_tone_regression.cpp — PulpTone regression scenario.
 //
 // Renders PulpTone through HeadlessHost at 48 kHz across small host block
 // sizes (64/128/256) and asserts the signal facts the standalone-silence
@@ -86,7 +86,7 @@ pulp::audio::Buffer<float> render_tone(double sample_rate, int block,
 } // namespace
 
 TEST_CASE("Tone regression: PulpTone 48 kHz render across host block sizes",
-          "[audio][regression][pulptone][harness-1b]") {
+          "[audio][regression][pulptone]") {
     constexpr double sr = 48000.0;
     constexpr int total = 9600; // 200 ms; exact multiple of 64/128/256
 
@@ -124,10 +124,9 @@ TEST_CASE("Tone regression: PulpTone 48 kHz render across host block sizes",
 }
 
 TEST_CASE("Tone regression: metrics artifact JSON carries schema and facts",
-          "[audio][regression][harness-1b][artifact]") {
-    // The artifact writer is new in this PR, so it gets its own coverage:
-    // round-trip the JSON through choc::json::parse and verify the schema
-    // version, provenance, shape, and per-channel facts survive.
+          "[audio][regression][artifact]") {
+    // Round-trip the artifact JSON through choc::json::parse and verify the
+    // schema version, provenance, shape, and per-channel facts survive.
     auto out = render_tone(48000.0, 256, 1024);
     const auto m = analyze(out, 48000.0);
 

--- a/test/test_design_import_anchors.cpp
+++ b/test/test_design_import_anchors.cpp
@@ -1,4 +1,4 @@
-// Phase 0a: tests for stable_anchor_id assignment on IRNode trees.
+// Tests for stable_anchor_id assignment on IRNode trees.
 // Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
 // Mirrors the TS-side tests in packages/pulp-import-ir/tests/anchors.test.ts.
 
@@ -176,10 +176,9 @@ TEST_CASE("adapter anchors use source_node_id when present",
 
 TEST_CASE("adapter strategy falls back to content-hash for nodes without IDs",
           "[view][import][anchors]") {
-    // Phase 0a soft-fail: missing source_node_id shouldn't crash the
-    // pipeline. The fallback uses the content-hash branch so the node
-    // still gets SOME anchor — better for downstream inspector use than
-    // an empty anchor.
+    // Missing source_node_id shouldn't crash the pipeline. The fallback uses
+    // the content-hash branch so the node still gets SOME anchor — better for
+    // downstream inspector use than an empty anchor.
     IRNode root = make_node("frame", {}, {}, "0:1");
     root.children.push_back(make_node("button", "OK"));  // no source_node_id
 
@@ -196,8 +195,8 @@ TEST_CASE("adapter strategy falls back to content-hash for nodes without IDs",
 TEST_CASE("assign_anchors preserves pre-existing stable_anchor_id values",
           "[view][import][anchors]") {
     // If an authored override has already set stable_anchor_id, the
-    // walker must leave it alone. This is how Phase 1 will honor
-    // user-pinned anchors for elements they want to track precisely.
+    // walker must leave it alone. This preserves user-pinned anchors for
+    // elements they want to track precisely.
     IRNode root = make_node("frame");
     root.stable_anchor_id = "pinned-by-user";
     root.children.push_back(make_node("text", "Hello"));
@@ -211,9 +210,8 @@ TEST_CASE("assign_anchors preserves pre-existing stable_anchor_id values",
 
 // ── parser entry-point integration ──────────────────────────────────────
 //
-// These verify the parsers we wired in Phase 0a actually call
-// assign_anchors with the right strategy and produce stable output
-// across re-imports of the same source.
+// These verify the parsers call assign_anchors with the right strategy and
+// produce stable output across re-imports of the same source.
 
 TEST_CASE("parse_figma_json populates anchors via the adapter strategy",
           "[view][import][anchors]") {
@@ -292,8 +290,8 @@ TEST_CASE("parse_claude_html re-tags provenance after delegating to stitch",
 TEST_CASE("parse_stitch_html regex-fallback path also assigns anchors",
           "[view][import][anchors]") {
     // Non-JSON input forces the regex fallback at the end of
-    // parse_stitch_html. The Phase 0a additions stamp provenance +
-    // confidence=DIVERGE and call assign_anchors on the regex-built tree.
+    // parse_stitch_html. The regex fallback stamps provenance +
+    // confidence=DIVERGE and calls assign_anchors on the regex-built tree.
     const std::string html = "<div><span>hello</span><span>world</span></div>";
     auto ir = parse_stitch_html(html);
 
@@ -326,8 +324,8 @@ TEST_CASE("parse_v0_tsx JSON path populates content-hash anchors",
 TEST_CASE("parse_v0_tsx structural TSX path assigns anchors",
           "[view][import][anchors]") {
     // Non-JSON TSX input takes the host-JSX structural extraction path.
-    // Phase 0a stamps DIVERGE confidence + anchors because dynamic React
-    // expressions still require runtime import.
+    // Structural extraction stamps DIVERGE confidence + anchors because
+    // dynamic React expressions still require runtime import.
     const std::string tsx =
         "<div className=\"flex-row gap-2\">"
         "<div className=\"flex-col p-2\">child</div>"
@@ -400,7 +398,7 @@ TEST_CASE("generate_pulp_js bridge_native_js mode emits @pulp-anchor comments",
     REQUIRE(js.find("// @pulp-anchor figma:0:1") != std::string::npos);
 }
 
-// ── Phase 0b: setAnchor() codegen — binds anchor to the live widget ─────
+// ── setAnchor() codegen — binds anchor to the live widget ───────────────
 
 TEST_CASE("web-compat codegen emits setAnchor calls per node",
           "[view][import][anchors][setAnchor]") {

--- a/test/test_design_system.cpp
+++ b/test/test_design_system.cpp
@@ -1,4 +1,4 @@
-// Phase 8a — pulp::design module + component catalog + metadata.
+// pulp::design module + component catalog + metadata.
 // Verifies the catalog is well-formed (every entry maps a Figma component to a
 // real native class + header + tokens), the theme helper produces the token-true
 // Ink & Signal theme, and apply_ink_signal restyles a view tree.

--- a/test/test_design_system_interaction.cpp
+++ b/test/test_design_system_interaction.cpp
@@ -1,7 +1,7 @@
-// Phase 8 fidelity follow-up — verify the design-system widgets are actually
-// WIRED (not just painted): driving each via its input handlers must change
-// its value/state and fire its callback. Catches a widget that looks right but
-// doesn't respond (the "knobs don't move" failure mode).
+// Verify the design-system widgets are actually wired, not just painted:
+// driving each via its input handlers must change its value/state and fire its
+// callback. Catches a widget that looks right but doesn't respond (the "knobs
+// don't move" failure mode).
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/test_golden_audio.cpp
+++ b/test/test_golden_audio.cpp
@@ -12,7 +12,7 @@
 // for known inputs and parameter settings.
 //
 // Signal generation and RMS/peak measurement use the shared harness
-// helpers (test/support/) — harness PR 1B conversion.
+// helpers (test/support/).
 
 #include <pulp/audio/analysis/audio_metrics.hpp>
 #include "support/audio_test_signals.hpp"

--- a/test/test_golden_effect.cpp
+++ b/test/test_golden_effect.cpp
@@ -3,7 +3,7 @@
 #include <pulp/format/headless.hpp>
 
 // Signal generation and RMS measurement use the shared harness helpers
-// (test/support/) — harness PR 1B conversion.
+// (test/support/).
 #include <pulp/audio/analysis/audio_metrics.hpp>
 #include "support/audio_test_signals.hpp"
 

--- a/test/test_render_scenario.cpp
+++ b/test/test_render_scenario.cpp
@@ -1,8 +1,8 @@
-// test_render_scenario.cpp — harness PR 2 coverage.
+// test_render_scenario.cpp — render-scenario harness coverage.
 //
-// Covers, per the Slice 2 acceptance of
+// Covers the render-scenario harness acceptance for
 // planning/2026-06-09-audio-observability-and-validation-harness-plan.md:
-//   - Buffer<float>::view() const (the core API fix shipped in this PR)
+//   - Buffer<float>::view() const
 //   - deterministic signal generators (seeded noise, impulse, step, DC,
 //     multi-sine, swept sine, automation + MIDI scripts)
 //   - RenderScenario typed scenarios for one effect (PulpGain) and one
@@ -44,7 +44,7 @@ double window_rms_dbfs(const pulp::audio::Buffer<float>& buffer,
 } // namespace
 
 TEST_CASE("Buffer const view exposes identical read-only data",
-          "[audio][buffer][harness-2]") {
+          "[audio][buffer]") {
     auto buf = make_sine(2, 256, 440.0f, 48000.0, 0.5f);
     const auto& const_buf = buf;
 
@@ -64,7 +64,7 @@ TEST_CASE("Buffer const view exposes identical read-only data",
 }
 
 TEST_CASE("Signal generators are deterministic and shaped as documented",
-          "[audio][generators][harness-2]") {
+          "[audio][generators]") {
     SECTION("silence, DC, impulse, impulse train, step") {
         const auto silence = make_silence(2, 128);
         CHECK(analyze(silence, 48000.0).max_peak() == 0.0);
@@ -163,7 +163,7 @@ TEST_CASE("Signal generators are deterministic and shaped as documented",
 }
 
 TEST_CASE("RenderScenario: PulpGain effect scenario",
-          "[audio][scenario][pulpgain][harness-2]") {
+          "[audio][scenario][pulpgain]") {
     // -12 dBFS sine peak → RMS -15.05 dBFS; -6 dB output gain → -21.05.
     auto scenario = RenderScenario(pulp::examples::create_pulp_gain)
         .name("pulpgain.minus6")
@@ -189,7 +189,7 @@ TEST_CASE("RenderScenario: PulpGain effect scenario",
 }
 
 TEST_CASE("RenderScenario: PulpGain bypass nulls against unity gain",
-          "[audio][scenario][pulpgain][harness-2]") {
+          "[audio][scenario][pulpgain]") {
     // Bypass copies input; unity gain multiplies by exactly 1.0f. Both must
     // be bit-identical to the stimulus, hence to each other (tolerance
     // class: exact).
@@ -210,7 +210,7 @@ TEST_CASE("RenderScenario: PulpGain bypass nulls against unity gain",
 }
 
 TEST_CASE("RenderScenario: PulpGain block-quantized automation",
-          "[audio][scenario][pulpgain][automation][harness-2]") {
+          "[audio][scenario][pulpgain][automation]") {
     // Output gain drops 0 → -20 dB exactly at the half-way block boundary;
     // the two halves must differ by 20 dB (numeric ±0.2 dB).
     constexpr std::int64_t half = 12000;
@@ -230,7 +230,7 @@ TEST_CASE("RenderScenario: PulpGain block-quantized automation",
 }
 
 TEST_CASE("RenderScenario: PulpTone instrument scenario with MIDI script",
-          "[audio][scenario][pulptone][harness-2]") {
+          "[audio][scenario][pulptone]") {
     // A4 note-on at frame 0, note-off at 200 ms, render 400 ms: pitch must
     // be 440 Hz (numeric ±5 cents over the held half) and the release tail
     // must decay (default release is 200 ms).
@@ -259,7 +259,7 @@ TEST_CASE("RenderScenario: PulpTone instrument scenario with MIDI script",
 }
 
 TEST_CASE("RenderScenario: 64/128/256 block partition invariance",
-          "[audio][scenario][partition][harness-2]") {
+          "[audio][scenario][partition]") {
     constexpr int kBlocks[] = {64, 128, 256};
 
     SECTION("PulpGain (effect) is exactly partition-invariant") {
@@ -296,7 +296,7 @@ TEST_CASE("RenderScenario: 64/128/256 block partition invariance",
 }
 
 TEST_CASE("RenderScenario matrix runner sweeps sample rate × block size",
-          "[audio][scenario][matrix][harness-2]") {
+          "[audio][scenario][matrix]") {
     // Generator input so the 100 ms stimulus tracks each cell's rate.
     auto scenario = RenderScenario(pulp::examples::create_pulp_gain)
         .name("pulpgain.matrix")

--- a/test/test_sampler_starter.cpp
+++ b/test/test_sampler_starter.cpp
@@ -12,9 +12,9 @@
 using namespace pulp::design;
 using namespace pulp::view;
 
-// Phase 8d — the sampler starter. Structure assertions run everywhere; the
-// render assertion only where a screenshot provider exists. This is the
-// end-to-end proof that the ingested design system composes into a real UI.
+// Sampler starter structure assertions run everywhere; the render assertion
+// only where a screenshot provider exists. This is the end-to-end proof that
+// the ingested design system composes into a real UI.
 
 namespace {
 // Count direct children of `root` whose dynamic type is T.

--- a/test/test_widget_gallery.cpp
+++ b/test/test_widget_gallery.cpp
@@ -13,8 +13,8 @@ Theme ink_signal(bool dark) {
 }
 }  // namespace
 
-// Phase 5 — the component gallery. The structure assertions run everywhere; the
-// render assertions only where a screenshot provider exists (macOS in CI).
+// Component gallery structure assertions run everywhere; the render assertions
+// only where a screenshot provider exists (macOS in CI).
 // This is the "gallery stays current, enforced" mechanism: if the gallery stops
 // building or rendering, CI fails.
 


### PR DESCRIPTION
## Summary
- remove stale phase/PR/harness breadcrumbs from workflow, example, audio-harness, and design/import comments
- remove numbered Catch2 session tags (`[harness-1a]`, `[harness-1b]`, `[harness-2]`, `[harness-3]`) while preserving feature selectors
- reword fixture/workflow/example notes as durable present-tense rationale

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report $(git diff --name-only origin/main...HEAD)`
- workflow YAML parse for `.github/workflows/workflow-lint.yml` and `.github/workflows/sandbox-e2e.yml`
- targeted stale-breadcrumb grep
- removed harness-tag consumer grep
- `./tools/scripts/gates.sh origin/main`
- `cmake --build build --target pulp-test-audio-support pulp-test-render-scenario pulp-test-audio-contracts pulp-test-audio-tone-regression pulp-test-golden pulp-test-golden-effect pulp-test-design-import-anchors pulp-test-design-system pulp-test-design-system-interaction pulp-test-sampler-starter pulp-test-widget-gallery -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-audio-support`
- `./build/test/pulp-test-render-scenario`
- `./build/test/pulp-test-audio-contracts`
- `./build/test/pulp-test-audio-tone-regression`
- `./build/test/pulp-test-golden`
- `./build/test/pulp-test-golden-effect`
- `./build/test/pulp-test-design-import-anchors`
- `./build/test/pulp-test-design-system`
- `./build/test/pulp-test-design-system-interaction`
- `./build/test/pulp-test-sampler-starter`
- `./build/test/pulp-test-widget-gallery`
- pre-push gates clean

## Reviews
- RepoPrompt final re-review: Clean
- `autoreview` final rerun: clean; patch correct (0.88)
- Claude final rerun: Clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale audit breadcrumbs in tests and workflows and removed numbered harness tags to use stable, feature-based test selectors. Improves readability and filtering with no code, API, or CI behavior changes.

- **Refactors**
  - Removed phase/PR/harness breadcrumbs from workflow, example, and test comments.
  - Replaced `[harness-*]` Catch2 tags with stable selectors (e.g., `[audio][contract]`, `[pulpgain]`, `[pulptone]`).
  - Tightened wording in workflow comments while keeping lint behavior the same.
  - Minor note updates in example CMake files and `test/integration/real_plugins.toml`.

<sup>Written for commit 994335567ef8fc93b988ae868c01829bfcee08cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

