### PR TITLE
[codex] Fix scan worker install rpath

### DIFF
--- a/tools/scan-worker/CMakeLists.txt
+++ b/tools/scan-worker/CMakeLists.txt
@@ -12,7 +12,21 @@ endif()
 
 add_executable(pulp-scan-worker scan_worker_main.cpp)
 target_link_libraries(pulp-scan-worker PRIVATE pulp::host pulp::runtime)
-set_target_properties(pulp-scan-worker PROPERTIES OUTPUT_NAME "pulp-scan-worker")
+set_target_properties(pulp-scan-worker PROPERTIES
+    OUTPUT_NAME "pulp-scan-worker")
+
+# Match the CLI install layout so installed scan workers can resolve shared
+# dependencies such as libwgpu_native from the SDK prefix.
+if(APPLE)
+    set_target_properties(pulp-scan-worker PROPERTIES
+        INSTALL_RPATH "@executable_path/../lib"
+        BUILD_WITH_INSTALL_RPATH FALSE
+        MACOSX_RPATH TRUE)
+elseif(UNIX)
+    set_target_properties(pulp-scan-worker PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib"
+        BUILD_WITH_INSTALL_RPATH FALSE)
+endif()
 
 if(PULP_BUILD_TESTS)
     add_executable(pulp-test-scan-worker test_scan_worker.cpp)


### PR DESCRIPTION
## Summary

Adds explicit install RPATH handling for `pulp-scan-worker`, matching the existing `pulp-cli` SDK install layout.

## Why

A temp SDK install can emit an `install_name_tool` warning for `pulp-scan-worker` when CMake tries to rewrite a build-tree rpath that is not present in the binary. The worker can also depend on `@rpath/libwgpu_native.dylib`, so the correct fix is not to suppress build rpaths; the installed binary should get the SDK-local rpath and the build-tree binary should remain runnable for tests.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-scan-worker pulp-test-scan-worker -j$(sysctl -n hw.ncpu)`
- `./build/tools/scan-worker/pulp-test-scan-worker`
- `cmake --install build --prefix /tmp/pulp-sdk-install-scan-worker.HLtN7Z`
- Verified installed `bin/pulp-scan-worker` has `LC_RPATH @executable_path/../lib`
- `autoreview --mode branch --base origin/main` clean: no accepted/actionable findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes install RPATH for `pulp-scan-worker` to match the `pulp-cli` SDK layout. Removes the macOS `install_name_tool` warning and ensures shared libs resolve at runtime.

- **Bug Fixes**
  - macOS: set `INSTALL_RPATH` to `@executable_path/../lib`; Linux: set to `$ORIGIN/../lib`.
  - Keep `BUILD_WITH_INSTALL_RPATH` disabled (and `MACOSX_RPATH` enabled on macOS) so build-tree binaries still run in tests.
  - Installed worker can find `@rpath/libwgpu_native.dylib`; build layout stays unchanged.

<sup>Written for commit 9a33559c8827e8af12b6f6171a6c952ffa16a56c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

