### PR TITLE
docs(harness): repair stale compat evidence refs

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -425,8 +425,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -444,8 +444,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -467,8 +467,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
@@ -486,8 +486,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -509,8 +509,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
@@ -528,8 +528,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -547,8 +547,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -584,8 +584,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -752,7 +752,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
+        "test/test_widget_bridge_css_misc.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
@@ -1703,8 +1703,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1722,8 +1722,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1741,8 +1741,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1760,8 +1760,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1779,8 +1779,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1798,8 +1798,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1817,8 +1817,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1836,8 +1836,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1855,8 +1855,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -2151,7 +2151,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2222,7 +2222,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2238,7 +2238,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2254,7 +2254,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2673,7 +2673,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2746,7 +2746,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2761,7 +2761,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2776,7 +2776,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -3265,8 +3265,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3287,8 +3287,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3309,8 +3309,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3331,8 +3331,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3353,8 +3353,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -5876,7 +5876,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp \u2014 `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
@@ -5892,8 +5892,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -5909,8 +5909,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -5926,8 +5926,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -5943,8 +5943,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -6021,7 +6021,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "semantic:yoga/box-sizing",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
@@ -6037,7 +6037,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -6052,7 +6052,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -6067,7 +6067,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -6082,7 +6082,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -6299,7 +6299,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]",
-        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
       "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default \u2014 \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
@@ -6315,7 +6315,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]",
-        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
       "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
@@ -6399,7 +6399,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setOverflow accepts scroll keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setOverflow accepts scroll keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "DIVERGE\u2192PASS sweep \u2014 `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
@@ -6434,7 +6434,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/web-compat/test_popover_row_template_1147.cpp",
-        "test/test_widget_bridge.cpp::\"flex shorthand keyword forms\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"flex shorthand keyword forms\""
       ],
       "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE\u2192PASS sweep \u2014 keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
       "issue": ""

--- a/compat/css.json
+++ b/compat/css.json
@@ -370,8 +370,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -389,8 +389,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -412,8 +412,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
@@ -431,8 +431,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -454,8 +454,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
@@ -473,8 +473,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -492,8 +492,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -529,8 +529,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
-        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
@@ -697,7 +697,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
+        "test/test_widget_bridge_css_misc.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
@@ -1648,8 +1648,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1667,8 +1667,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1686,8 +1686,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1705,8 +1705,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1724,8 +1724,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1743,8 +1743,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1762,8 +1762,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1781,8 +1781,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -1800,8 +1800,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
-        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge_css_grid.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge_css_grid.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
@@ -2096,7 +2096,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2167,7 +2167,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2183,7 +2183,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2199,7 +2199,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
@@ -2618,7 +2618,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2691,7 +2691,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2706,7 +2706,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -2721,7 +2721,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
@@ -3210,8 +3210,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3232,8 +3232,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3254,8 +3254,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3276,8 +3276,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
@@ -3298,8 +3298,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
-        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge_css_animations.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge_css_animations.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",

--- a/compat/yoga.json
+++ b/compat/yoga.json
@@ -283,7 +283,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp \u2014 `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
@@ -299,8 +299,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -316,8 +316,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -333,8 +333,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -350,8 +350,8 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
-        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
@@ -428,7 +428,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "semantic:yoga/box-sizing",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
@@ -444,7 +444,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -459,7 +459,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -474,7 +474,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -489,7 +489,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
@@ -706,7 +706,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]",
-        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
       "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default \u2014 \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
@@ -722,7 +722,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]",
-        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
       "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
@@ -806,7 +806,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp::\"setOverflow accepts scroll keyword\"",
+        "test/test_widget_bridge_css_per_edge.cpp::\"setOverflow accepts scroll keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
       "notes": "DIVERGE\u2192PASS sweep \u2014 `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
@@ -841,7 +841,7 @@
       "unsupportedValues": [],
       "tests": [
         "test/web-compat/test_popover_row_template_1147.cpp",
-        "test/test_widget_bridge.cpp::\"flex shorthand keyword forms\""
+        "test/test_widget_bridge_css_per_edge.cpp::\"flex shorthand keyword forms\""
       ],
       "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE\u2192PASS sweep \u2014 keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
       "issue": ""


### PR DESCRIPTION
## Summary

- Rewire stale exact compatibility evidence refs from the old `test/test_widget_bridge.cpp` umbrella file to the focused CSS/Yoga widget-bridge test files.
- Update only `compat.json`, `compat/css.json`, and `compat/yoga.json`.
- Leave runtime code, tests, generated reports, broad `[issue-1711][evidence-backfill]` placeholders, support values, and catalog statuses unchanged.

## Why

After the widget bridge tests were split, exact `path::TEST_CASE` refs in the compat catalogs still pointed at the old umbrella test file. The harness verifier treated those otherwise-valid evidence refs as dangling. This repair moves exactly 43 rows from `SUPPORTED-NO-EVIDENCE` to `PASS` without changing claimed support.

## Validation

- `git diff --check origin/main`
- `python3 -m unittest tools.harness.tests.test_verifier`
- `python3 tools/harness/verifier.py --all --json --no-docs` -> `518 total / 203 PASS / 283 SUPPORTED-NO-EVIDENCE / 32 OOS`
- JSON-aware ref guard: 142 scalar changes, all under `tests` arrays; 14 unique moved exact refs; all 14 resolve to real `TEST_CASE`s
- `tools/scripts/gates.sh origin/main`

## Review Notes

Local adversarial review found no must-fix before PR: this is a data-only exact-ref repair with no runtime/importer/rendering/layout/platform boundary change, no new abstraction, no branching complexity, and no file-size growth.

`python3 tools/scripts/compat_aggregate.py check` still fails because of the pre-existing split/aggregate unicode normalization drift around `listStyleType`; this PR intentionally keeps that separate from the exact-ref repair.

Claude no-tools second opinion session `4c6c3c26-2d05-4e80-ac79-3ab0176266b2` also found no must-fix before PR. It classified the pre-existing red `compat_aggregate.py` check as a should-fix-soon hygiene item for a separate PR, because fixing it here would pull unrelated imports/object-coverage drift into this exact-ref change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repaired stale evidence refs in the compat harness by moving them from the umbrella test to the split widget-bridge test files. Promotes 43 rows from SUPPORTED-NO-EVIDENCE to PASS with no runtime or test changes.

- **Bug Fixes**
  - Updated only compat catalogs: compat.json, compat/css.json, compat/yoga.json.
  - Rewired tests[] paths from `test/test_widget_bridge.cpp` to: `test/test_widget_bridge_css_animations.cpp`, `test/test_widget_bridge_css_grid.cpp`, `test/test_widget_bridge_css_per_edge.cpp`, `test/test_widget_bridge_css_misc.cpp`.
  - All moved refs resolve to existing TEST_CASEs; the verifier no longer flags them as dangling.

<sup>Written for commit 86e73d691e11b6b0e43bae065651a40de164146d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

