### PR TITLE
docs(cli): clean docs command source comment

### DIFF
--- a/tools/cli/cmd_docs.cpp
+++ b/tools/cli/cmd_docs.cpp
@@ -604,15 +604,13 @@ int cmd_docs(const std::vector<std::string>& args) {
     std::string sub = args[0];
 
     if (sub == "build-site") {
-        // #577 PR 4 retired tools/build-docs.py in favour of MkDocs Material.
-        // Delegate to `mkdocs build`. Extra args are forwarded so callers can
-        // pass `--site-dir`, `--strict`, etc.
+        // Static docs are built through MkDocs Material. Extra args are
+        // forwarded so callers can pass `--site-dir`, `--strict`, etc.
         //
         // Resolve `mkdocs.yml` from the project root so `pulp docs
         // build-site` works regardless of the caller's current
         // directory — the previous `tools/build-docs.py` path behaved
-        // this way because it resolved paths from the script location
-        // (#591).
+        // this way because it resolved paths from the script location.
         auto mkdocs_yml = root / "mkdocs.yml";
         std::string cmd = "mkdocs build -f " + shell_quote(mkdocs_yml);
         for (size_t i = 1; i < args.size(); ++i) {


### PR DESCRIPTION
## Summary
- Removes stale issue-number breadcrumbs from the long-lived `pulp docs build-site` source comment.
- Keeps the stable rationale: MkDocs Material is the static-docs path, extra args are forwarded, and `mkdocs.yml` is resolved from the project root.
- No behavior change.

## Validation
- `python3 tools/scripts/docs_noise_lint.py tools/cli/cmd_docs.cpp`
- `git diff --check`
- `tools/scripts/gates.sh origin/main`

## Review Notes
- Focused `pulp docs` trace found the command complete/functioning across CLI implementation, public docs/status, unit tests, shellout tests, and MCP docs wrappers.
- Strict local code-health review found no must-fix: this is comment-only, adds no branching or abstraction, and touches no runtime/importer/rendering/layout/platform boundary.
- Shipyard passed skill-sync/version-bump, then failed because target `mac` cloud is unreachable via `gh auth status`; branch push + this PR are the supervised fallback path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the `pulp docs build-site` source comment by removing stale issue references and simplifying wording on MkDocs Material, arg forwarding, and root `mkdocs.yml` resolution. No code or behavior changes.

<sup>Written for commit 4d6dbcdb0d15b17575d8b9c751035da39d1c76aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

