### PR TITLE
fix(cli): validate PULP_AUDIO_CAPTURE_ROLLING_FORMAT env value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.514.0
+    VERSION 0.515.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_environment.hpp
+++ b/core/format/include/pulp/format/detail/standalone_environment.hpp
@@ -2,6 +2,7 @@
 
 #include <pulp/format/detail/editor_environment.hpp>
 #include <pulp/format/standalone.hpp>
+#include <pulp/runtime/log.hpp>
 #include <pulp/runtime/system.hpp>
 
 #include <charconv>
@@ -113,8 +114,21 @@ inline StandaloneConfig standalone_config_from_environment(StandaloneConfig conf
         if (parse_positive_frame_delay(*frames, parsed))
             config.audio_capture_rolling_frames = parsed;
     }
-    if (auto fmt = runtime::get_env("PULP_AUDIO_CAPTURE_ROLLING_FORMAT"))
-        config.audio_capture_rolling_int24 = (*fmt == "int24");
+    if (auto fmt = runtime::get_env("PULP_AUDIO_CAPTURE_ROLLING_FORMAT")) {
+        if (*fmt == "int24") {
+            config.audio_capture_rolling_int24 = true;
+        } else if (*fmt == "float") {
+            config.audio_capture_rolling_int24 = false;
+        } else {
+            // Match the CLI flag's strictness: an unrecognized value is a
+            // mistake, not a silent fall-through to float.
+            runtime::log_warn(
+                "Standalone: PULP_AUDIO_CAPTURE_ROLLING_FORMAT='{}' unrecognized "
+                "(expected 'float' or 'int24'); using float",
+                *fmt);
+            config.audio_capture_rolling_int24 = false;
+        }
+    }
     if (!config.audio_capture_rolling_path.empty())
         config.headless = true;
 

--- a/test/test_standalone_audio_capture_rolling_wav.cpp
+++ b/test/test_standalone_audio_capture_rolling_wav.cpp
@@ -16,6 +16,7 @@
 
 #include <cmath>
 #include <filesystem>
+#include <cstdlib>
 #include <functional>
 #include <vector>
 
@@ -173,6 +174,24 @@ TEST_CASE("rolling capture WAV with an empty path or unprepared buffer is a no-o
     CHECK_FALSE(pulp::format::detail::write_audio_capture_rolling_wav_file("", rolling, cfg));
     CHECK_FALSE(pulp::format::detail::write_audio_capture_rolling_wav_file(
         (fs::temp_directory_path() / "pulp_rolling_empty.wav").string(), rolling, cfg));
+}
+
+TEST_CASE("PULP_AUDIO_CAPTURE_ROLLING_FORMAT env parses int24/float and ignores junk",
+          "[standalone][audio-capture-rolling]") {
+    auto parse = [](const char* value) {
+        if (value) ::setenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT", value, 1);
+        else ::unsetenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT");
+        pulp::format::StandaloneConfig cfg;
+        cfg = pulp::format::detail::standalone_config_from_environment(cfg);
+        return cfg.audio_capture_rolling_int24;
+    };
+    CHECK(parse("int24") == true);
+    CHECK(parse("float") == false);
+    // Unrecognized values fall back to float (and log a warning — see the env parser).
+    CHECK(parse("int32") == false);
+    CHECK(parse("INT24") == false);
+    CHECK(parse(nullptr) == false);  // unset → default float
+    ::unsetenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT");
 }
 
 #if PULP_ENABLE_AUDIO_PROBES


### PR DESCRIPTION
## What

The `PULP_AUDIO_CAPTURE_ROLLING_FORMAT` env override silently fell back to float on any value other than `int24` — so `=int32` or a typo'd `=INT24` produced float with **no diagnostic**, inconsistent with the `--audio-capture-rolling-format` CLI flag which hard-rejects bad values. Now accepts only `int24`/`float` and logs a warning on anything else (still defaulting to float).

Adds an env-parse test covering `int24`, `float`, an unrecognized value, a wrong-case value, and unset.

## Provenance

Found by the **final adversarial review** of the audio-harness Phase-7 work (no MUST-FIX; this was the one SHOULD-FIX consistency wart). The review otherwise confirmed sample-accurate `--param` and the int24 path correct — frame-0 params still reach the plugin via the forwarded queue, no double-apply, no domain mismatch, exhaustive `WavBitDepth` mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the `PULP_AUDIO_CAPTURE_ROLLING_FORMAT` env var so only `int24` and `float` are accepted; any other value now logs a warning and falls back to float, matching the `--audio-capture-rolling-format` flag. Adds env-parse tests for valid/invalid/wrong-case/unset values and bumps the project version.

<sup>Written for commit 49d8321d6249ada01c97a7f6cbe416c29a8eff34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

