### PR TITLE
test(harness): sync compat aggregate parts

### DIFF
--- a/compat/css.json
+++ b/compat/css.json
@@ -1996,7 +1996,7 @@
     },
     "css/listStyleType": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal / decimal-leading-zero / lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian). Marker glyph paint is deferred — `decimal` additionally needs sibling-index resolution from the parent's children, and the counter-style keywords need glyph rendering before they become visually distinct from disc.",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal / decimal-leading-zero / lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian). Marker glyph paint is deferred \u2014 `decimal` additionally needs sibling-index resolution from the parent's children, and the counter-style keywords need glyph rendering before they become visually distinct from disc.",
       "supportedValues": [
         "none",
         "disc",
@@ -2015,7 +2015,7 @@
         "georgian"
       ],
       "unsupportedValues": [
-        "cjk-decimal / hebrew / hiragana / katakana / etc. (other CSS Counter Styles Level 3 keywords — storage-only follow-up)"
+        "cjk-decimal / hebrew / hiragana / katakana / etc. (other CSS Counter Styles Level 3 keywords \u2014 storage-only follow-up)"
       ],
       "tests": [
         "test/test_widget_bridge.cpp::\"setListStyleType maps each keyword to the right enum (issue-1514)\"",
@@ -2024,7 +2024,7 @@
         "packages/pulp-react/test/prop-applier-list-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1514 — Bridge stores the type keyword on a View::ListStyleType enum slot; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup — decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene. Counter-style extension (lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian / decimal-leading-zero) is storage-only today; paint-side glyph rendering remains the follow-up.",
+      "notes": "pulp #1514 \u2014 Bridge stores the type keyword on a View::ListStyleType enum slot; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup \u2014 decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene. Counter-style extension (lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian / decimal-leading-zero) is storage-only today; paint-side glyph rendering remains the follow-up.",
       "issue": "1514"
     },
     "css/margin": {

--- a/compat/imports.json
+++ b/compat/imports.json
@@ -1,6 +1,38 @@
 {
   "imports": {
     "_note": "The 'imports' prefix tracks design-import format detection (see core/dsl/import-design / tools/cli/src/import_design.cpp / docs/reference/imports/*). Each top-level key is a recognized import source (claude, figma, pencil, stitch, v0); each entry carries 'parser-version' (the Pulp-side detector version) and 'detected-formats' (a list of {format-version, introduced, deprecated, fingerprint, notes} objects). The `fingerprint` field is the heuristic the parser uses to recognize the source format from a directory or file payload. When a new import source lands or an existing source's export format changes, add a detected-formats entry rather than mutating an existing one (so historical exports keep parsing). Tracked via PR #1047 (pulp #1031) for versioned import-design detection.",
+    "object-coverage": {
+      "_note": "IR-level, source-agnostic coverage of normalized DesignIR object types across the import pipeline. For each type, the support level at three stages: 'detected' (an adapter recognizes the source object), 'parsed' (it is lowered into the normalized IR), 'codegen' (generate_pulp_js emits a real renderable primitive for it). Source-agnostic by construction: the importer and codegen operate on the normalized IR, so a 'handled' type renders identically for figma/figma-plugin/pencil/stitch/v0/claude. Levels: handled | partial | missing. The 'types' rows are DRIFT-CHECKED by test/test_import_object_coverage.cpp (binary pulp-test-import-object-coverage, Catch2 tag [object-coverage]): it builds a synthetic IRNode per type, runs generate_pulp_js, and FAILS if a 'codegen: handled' type drops to an empty frame, or a 'codegen: missing' vector-kind does not trip the dropped-vector invariant (#3275) — keeping this matrix honest against the code. The 'features' rows track cross-cutting paint/layout capabilities owned by separate hardening slices; they are documented here but not type-drift-checked. Seeded from planning/2026-05-31-import-coverage-hardening-plan.md section 3.",
+      "levels": ["handled", "partial", "missing"],
+      "types": {
+        "frame":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "group/section/slice normalize to frame; emits createRow/createCol"},
+        "text":      {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "first-char dominant style; emits createLabel. Per-range runs tracked in features.text-per-range-styles"},
+        "label":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "alias of text; emits createLabel"},
+        "image":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "solid/linear-gradient/image fills; emits createImage; no-skew + gross-size invariants guard sizing"},
+        "vector":    {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "a node carrying path_data (d/pathData) lowers to a native SvgPathWidget via createSvgPath+setSvgPath; a bare vector with no path_data and no rasterized asset still drops and is flagged by the dropped-vector invariant. Rasterize-at-export remains the faithful path for the figma lane"},
+        "path":      {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "see vector"},
+        "svg_path":  {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "see vector"},
+        "rect":      {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "synthesize_primitive_paths derives an SVG rect `d` (rounded via border-radius) from geometry when the node carries no path_data/fill/children, so codegen lowers it to a native SvgPath (svg_fill forced to none; border -> svg_stroke). A filled rect still renders via the generic-frame branch unchanged"},
+        "svg_rect":  {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "see rect"},
+        "rectangle": {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "see rect"},
+        "line":      {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "synthesized as the bounding-box diagonal (M0 0 L w h); border -> svg_stroke. Hairlines (area < 256px^2) remain below the dropped-vector area gate but still lower to a real SvgPath"},
+        "svg_line":  {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "see line"},
+        "ellipse":   {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "synthesized as two half-arcs inside the (w,h) box; ellipse children consumed into a parent widget's native paint are still not flagged"},
+        "circle":    {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "see ellipse"},
+        "polygon":   {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "synthesized as a regular polygon inscribed in (w,h); corner count from the pointCount attribute (default 3) when the source provides it. Rasterize-to-PNG at export remains an alternative faithful path"},
+        "polyline":  {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "an open run of explicit points; not synthesizable from geometry alone, so the bare form still drops (carry path_data or rasterize at export)"},
+        "star":      {"detected": "handled", "parsed": "partial", "codegen": "handled", "note": "synthesized with alternating outer/inner radii; pointCount (default 5) and innerRadius ratio (default 0.5) read from attributes when present"}
+      },
+      "features": {
+        "text-per-range-styles":            {"detected": "handled", "parsed": "handled", "codegen": "partial", "note": "mixed-style text parses into IRNode.text_runs (from a `runs`/`textRuns` array; the Figma exporter builds them from characterStyleOverrides + styleOverrideTable) and the web-compat codegen emits nested per-run <span style=...> children (font-weight/size/style/color/letter-spacing/decoration) with the gaps inheriting the dominant style. Native (bridge) codegen now emits setTextRuns -> the bridge builds a canvas::AttributedString and Label::paint_attributed_ draws each span (single-line); multi-line mixed text still degrades to the dominant style, hence codegen partial. Char offsets are UTF-8 byte offsets (Figma exporter converts; codegen snaps to codepoint starts)"},
+        "interactive-promotion":            {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "button/input promotion from onclick/aria/cursor signals; native-arm disposition is promotion-dependent"},
+        "grid-container":                   {"detected": "partial", "parsed": "handled", "codegen": "partial", "note": "display:grid / gridTemplateColumns|Rows / gridAutoFlow / per-item gridColumn|Row parse into IRLayout grid fields and lower to the native grid engine (createGrid + setGrid template_columns/rows/gap/auto_flow + per-item column/row start/end) — NOT Yoga grid (Pulp's own LayoutMode::grid). Explicit line placement (\"1 / 3\") handled; span / named-lines / minmax deferred to auto-flow, hence codegen partial"},
+        "radial-angular-diamond-gradient":  {"detected": "handled", "parsed": "handled", "codegen": "partial", "note": "radial-gradient()/conic-gradient() parse in the setBackgroundGradient bridge and paint via the canvas radial/sweep (SkGradientShader MakeRadial/MakeSweep; CoreGraphics native radial + software conic) through View::paint dispatch (bg_gradient_type 2/3). Figma GRADIENT_RADIAL/ANGULAR/DIAMOND export to the CSS forms (diamond approximated by radial). Center defaults to 50% 50%; radial extent keywords (closest-side/closest-corner/farthest-side/farthest-corner) map to an approximate radius fraction of max(w,h) — exact per-keyword geometry needs w/h+center which the bridge layer lacks, and explicit px radii are not converted, hence codegen partial"},
+        "mix-blend-mode":                   {"detected": "handled", "parsed": "handled", "codegen": "partial", "note": "IRStyle.mix_blend_mode is parsed (style.mixBlendMode + figma.blend_mode, normalized to the CSS keyword; normal/pass-through dropped) and emitted on container/image/text/svg_path nodes (web style.mixBlendMode; native setMixBlendMode → View::set_mix_blend_mode + save_layer_with_blend). Not yet emitted on audio-widget nodes (knob/fader/meter), hence partial"},
+        "masks-clip-paths":                 {"detected": "partial", "parsed": "partial", "codegen": "partial", "note": "IRStyle.clip_path/mask/mask_image/mask_size parsed (clipPath/mask/maskImage/maskSize) and emitted web (style.*) + native (setClipPath/setMask/setMaskImage/setMaskSize → View::set_clip_path/set_mask/... pulp #1515) on container/image/text/svg_path nodes. CSS sources carry these directly; Figma mask-layer → clip-path extraction is a separate adapter concern, hence detected/parsed partial"},
+        "constraints":                      {"detected": "partial", "parsed": "handled", "codegen": "partial", "note": "Figma resize constraints (constraints.horizontal/vertical, also under a figma{} or layout{} block; MIN/MAX/CENTER/STRETCH/SCALE normalized to left/right/center/stretch/scale) parse into IRLayout.h/v_constraint and lower to flex at codegen: center -> auto margins both sides, right/bottom -> leading auto margin, scale -> flex-grow:1, stretch -> align-self:stretch, left/top -> flex default. Best-effort within Flexbox (no new layout primitive); axis-exact scale/stretch depends on parent direction, hence codegen partial"}
+      }
+    },
     "claude": {
       "parser-version": "2.1",
       "detected-formats": [
@@ -42,7 +74,13 @@
             },
             {
               "kind": "frontmatter-key",
-              "any-of": ["colors", "typography", "rounded", "spacing", "components"]
+              "any-of": [
+                "colors",
+                "typography",
+                "rounded",
+                "spacing",
+                "components"
+              ]
             }
           ],
           "notes": "Google's DESIGN.md (Apache-2.0, https://github.com/google-labs-code/design.md). Upstream pin: tag 0.1.1. YAML frontmatter + Markdown body. Strict detection: filename + frontmatter fence + name: key + at least one canonical token-group key. The all-of match plus 95% confidence floor avoids false positives on generic Jekyll/Hugo Markdown frontmatter."
@@ -92,6 +130,31 @@
     "v0": {
       "parser-version": "0.1",
       "detected-formats": []
+    },
+    "figma-plugin": {
+      "parser-version": "0.1.0",
+      "detected-formats": [
+        {
+          "format-version": "2026.05-figma-plugin-v1",
+          "introduced": "2026-05-28",
+          "deprecated": null,
+          "match": "all-of",
+          "fingerprint": [
+            {
+              "kind": "json-key-equals",
+              "path": "provenance.adapter",
+              "value": "figma-plugin"
+            },
+            {
+              "kind": "json-key-equals",
+              "path": "format_version",
+              "value": "2026.05-figma-plugin-v1"
+            }
+          ],
+          "min-confidence-pct": 95,
+          "notes": "Pulp Figma plugin v1 export. Generated by the 'Design for Pulp' plugin."
+        }
+      ]
     }
   }
 }

--- a/tools/scripts/compat_aggregate.py
+++ b/tools/scripts/compat_aggregate.py
@@ -20,7 +20,8 @@ setting reproduces that mix, so re-serialization would NOT be
 byte-stable. Instead this tool slices the raw text at the top-level
 key boundaries: every part holds the exact bytes of its key block,
 and the aggregate is rebuilt by concatenating those bytes with the
-original ``{\\n`` prefix, ``,\\n`` separators, and ``\\n}`` suffix.
+original ``{\\n`` prefix, ``,\\n`` separators, and final wrapper
+(``\\n}`` or ``\\n}\\n``).
 
 Layout produced::
 
@@ -106,14 +107,19 @@ def slice_aggregate(raw: str) -> dict[str, str]:
           "kN": <vN>\\n
         }
 
-    so block_i is the substring ``  "ki": <vi>`` with no surrounding
-    separators. Returns ``{key: block_text}``.
+    optionally followed by one final newline. Each block_i is the
+    substring ``  "ki": <vi>`` with no surrounding separators.
+    Returns ``{key: block_text}``.
     """
     if not raw.startswith("{\n"):
         raise ValueError("compat.json does not start with '{\\n' — "
                           "structure assumption broken, refusing to slice")
-    if not raw.endswith("\n}"):
-        raise ValueError("compat.json does not end with '\\n}' — "
+    if raw.endswith("\n}\n"):
+        final_block_end = -3
+    elif raw.endswith("\n}"):
+        final_block_end = -2
+    else:
+        raise ValueError("compat.json does not end with '\\n}' or '\\n}\\n' — "
                           "structure assumption broken, refusing to slice")
 
     # Find the byte offset where each top-level key block begins.
@@ -153,18 +159,21 @@ def slice_aggregate(raw: str) -> dict[str, str]:
                 )
             blocks[key] = raw[start:nxt - 2]
         else:
-            blocks[key] = raw[start:-2]  # trim trailing '\n}'
+            blocks[key] = raw[start:final_block_end]  # trim trailing wrapper
     return blocks
 
 
-def assemble_aggregate(blocks: dict[str, str]) -> str:
+def assemble_aggregate(
+    blocks: dict[str, str], *, trailing_newline: bool = False,
+) -> str:
     """Inverse of :func:`slice_aggregate` — concatenate verbatim blocks
     back into the byte-identical aggregate text."""
     missing = [k for k in ALL_KEYS_ORDER if k not in blocks]
     if missing:
         raise ValueError(f"missing key block(s): {missing}")
     body = ",\n".join(blocks[k] for k in ALL_KEYS_ORDER)
-    return "{\n" + body + "\n}"
+    suffix = "\n}\n" if trailing_newline else "\n}"
+    return "{\n" + body + suffix
 
 
 def part_text_for(keys: list[str], blocks: dict[str, str]) -> str:
@@ -231,7 +240,9 @@ def cmd_split(root: Path) -> int:
     )
 
     # Verify the round-trip immediately.
-    rebuilt = _aggregate_from_parts(parts_dir)
+    rebuilt = _aggregate_from_parts(
+        parts_dir, trailing_newline=raw.endswith("\n}\n"),
+    )
     if rebuilt != raw:
         print("compat_aggregate: split produced a non-byte-identical "
               "round-trip — aborting (compat/ left in place for "
@@ -242,7 +253,9 @@ def cmd_split(root: Path) -> int:
     return 0
 
 
-def _aggregate_from_parts(parts_dir: Path) -> str:
+def _aggregate_from_parts(
+    parts_dir: Path, *, trailing_newline: bool = False,
+) -> str:
     """Read compat/ parts and reassemble the aggregate text."""
     blocks: dict[str, str] = {}
     for key in SURFACE_KEYS:
@@ -258,7 +271,7 @@ def _aggregate_from_parts(parts_dir: Path) -> str:
     blocks.update(blocks_from_part(
         meta.read_text(encoding="utf-8"), META_KEYS,
     ))
-    return assemble_aggregate(blocks)
+    return assemble_aggregate(blocks, trailing_newline=trailing_newline)
 
 
 def cmd_build(root: Path) -> int:
@@ -268,8 +281,16 @@ def cmd_build(root: Path) -> int:
         print(f"compat_aggregate: no parts dir at {parts_dir} — run "
               "`split` first.", file=sys.stderr)
         return 1
-    rebuilt = _aggregate_from_parts(parts_dir)
-    (root / "compat.json").write_text(rebuilt, encoding="utf-8")
+    aggregate = root / "compat.json"
+    # When creating a fresh aggregate, follow the repo's current style and
+    # write a final newline. Existing aggregates keep their current suffix.
+    trailing_newline = True
+    if aggregate.exists():
+        trailing_newline = aggregate.read_text(encoding="utf-8").endswith("\n}\n")
+    rebuilt = _aggregate_from_parts(
+        parts_dir, trailing_newline=trailing_newline,
+    )
+    aggregate.write_text(rebuilt, encoding="utf-8")
     print(f"compat_aggregate: regenerated compat.json from {parts_dir}.")
     return 0
 
@@ -292,7 +313,9 @@ def cmd_check(root: Path) -> int:
 
     current = aggregate.read_text(encoding="utf-8")
     try:
-        rebuilt = _aggregate_from_parts(parts_dir)
+        rebuilt = _aggregate_from_parts(
+            parts_dir, trailing_newline=current.endswith("\n}\n"),
+        )
     except (ValueError, FileNotFoundError) as exc:
         print(f"compat_aggregate: cannot rebuild from parts: {exc}",
               file=sys.stderr)

--- a/tools/scripts/test_compat_aggregate.py
+++ b/tools/scripts/test_compat_aggregate.py
@@ -76,6 +76,14 @@ class SliceAssembleTests(unittest.TestCase):
         blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
         self.assertEqual(ca.assemble_aggregate(blocks), SAMPLE_AGGREGATE)
 
+    def test_round_trip_preserves_trailing_newline_when_requested(self) -> None:
+        raw = SAMPLE_AGGREGATE + "\n"
+        blocks = ca.slice_aggregate(raw)
+        self.assertEqual(
+            ca.assemble_aggregate(blocks, trailing_newline=True),
+            raw,
+        )
+
     def test_all_top_level_keys_present(self) -> None:
         blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
         self.assertEqual(set(blocks), set(ca.ALL_KEYS_ORDER))
@@ -202,6 +210,31 @@ class CliRoundTripTests(unittest.TestCase):
                 agg.read_text(encoding="utf-8"), original,
                 "build must regenerate a byte-identical compat.json",
             )
+            self.assertEqual(self._run("check", root).returncode, 0)
+
+    def test_split_build_check_preserves_trailing_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            agg = root / "compat.json"
+            agg.write_text(SAMPLE_AGGREGATE + "\n", encoding="utf-8")
+            original = agg.read_text(encoding="utf-8")
+
+            self.assertEqual(self._run("split", root).returncode, 0)
+            self.assertEqual(self._run("build", root).returncode, 0)
+            self.assertEqual(agg.read_text(encoding="utf-8"), original)
+            self.assertEqual(self._run("check", root).returncode, 0)
+
+    def test_build_creates_new_aggregate_with_trailing_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            agg = root / "compat.json"
+            agg.write_text(SAMPLE_AGGREGATE, encoding="utf-8")
+            self.assertEqual(self._run("split", root).returncode, 0)
+
+            agg.unlink()
+
+            self.assertEqual(self._run("build", root).returncode, 0)
+            self.assertEqual(agg.read_text(encoding="utf-8"), SAMPLE_AGGREGATE + "\n")
             self.assertEqual(self._run("check", root).returncode, 0)
 
     def test_check_detects_drift(self) -> None:


### PR DESCRIPTION
## Summary
- preserve `compat.json` final-newline style in `tools/scripts/compat_aggregate.py` split/build/check flows
- document and test the fresh-aggregate final-newline policy
- regenerate `compat/css.json` and `compat/imports.json` from the aggregate so split parts are byte-identical again

## Validation
- `git diff --check origin/main...HEAD`
- `tools/scripts/compat_aggregate.py check`
- `python3 tools/scripts/test_compat_aggregate.py` (23 tests)
- `python3 -m unittest tools.harness.tests.test_verifier` (13 tests)
- `tools/harness/verifier.py --all --json --no-docs` (518 total / 203 PASS / 283 SUPPORTED-NO-EVIDENCE / 32 OOS; exits 0)
- `tools/scripts/gates.sh origin/main`
- `tools/scripts/compat_aggregate.py build && tools/scripts/compat_aggregate.py check && git diff --exit-code`
- `git merge-tree --write-tree origin/main HEAD`

## Review Notes
- Strict local architecture/code-health review found no must-fix before PR: no runtime/importer/rendering/layout/platform code changed, no new abstraction was added, and touched Python files remain below 1k LOC.
- The large `compat/imports.json` addition is regenerated data already present in `compat.json` on `origin/main`, not new catalog content.
- The remaining `283` SUPPORTED-NO-EVIDENCE rows are inherited evidence-anchor backlog, not introduced by this PR.
- Claude bridge review was attempted but unavailable locally (`Not logged in`). Shipyard submission was unavailable because configured targets are unreachable, so this PR used the supervised fallback after local/pre-push gates passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the final-newline style of `compat.json` across split/build/check so round-trips stay byte-identical. Fresh builds now default to a final newline; existing aggregates keep their current suffix.

- **Bug Fixes**
  - Aggregate slice/assemble now support both `\n}` and `\n}\n`; `build`/`check` pass the wrapper through.
  - Added tests for trailing-newline preservation and the fresh-build policy.
  - Resynced parts for `compat/css.json` and `compat/imports.json`; includes `imports.object-coverage` and `imports.figma-plugin` already present in the aggregate without changing catalog content.

<sup>Written for commit 520676dd83b83ead2f05b3b06190596a3fff42a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

