### PR TITLE
chore(cmake): clarify plugin MIDI option contract

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -47,6 +47,12 @@ The resulting mapping (`_pulp_add_au` / `_pulp_add_auv3` in `tools/cmake/PulpUti
 
 When you add a new example or change an existing one's descriptor to declare `accepts_midi = true`, you **must** also add `ACCEPTS_MIDI` to its `pulp_add_plugin()` call. There is no runtime fallback — the two surfaces are independent and the CMake flag is what ends up in the Info.plist.
 
+Do **not** pass `PRODUCES_MIDI` to `pulp_add_plugin()`. MIDI output is
+declared by `PluginDescriptor::produces_midi` in processor code and consumed
+by the format/runtime layer where supported; it is not a CMake packaging flag.
+If a caller passes `PRODUCES_MIDI` anyway, CMake warns and ignores it so stale
+docs/tests cannot imply a fake packaging effect.
+
 ## MIDI Input Wiring
 
 ### The entry FACTORY must dispatch MusicDevice selectors — not just the base class
@@ -145,7 +151,7 @@ the audio callback path. Tests live in
 
 ## Current Gaps
 
-- **MIDI output from AU v2 effects** is not wired yet; `#626` tracks the missing render-notify / `MIDIOutput` path. `Processor::process()` can write to `midi_out`, but `PulpAUEffect` has no render-notify callback / `MIDIOutput` mixin that emits those events back to the host. Effects that declare `produces_midi = true` work in CLAP / VST3 but stay silent on AU v2. `descriptor.produces_midi` is *not* wired to a CMake flag yet — the AU type selection is driven entirely by `accepts_midi`.
+- **MIDI output from AU v2 effects** is not wired yet; `#626` tracks the missing render-notify / `MIDIOutput` path. `Processor::process()` can write to `midi_out`, but `PulpAUEffect` has no render-notify callback / `MIDIOutput` mixin that emits those events back to the host. Effects that declare `produces_midi = true` work in CLAP / VST3 but stay silent on AU v2. `descriptor.produces_midi` is descriptor/runtime metadata, not a CMake flag; AU type selection is driven entirely by `accepts_midi` / `ACCEPTS_MIDI`, and passing `PRODUCES_MIDI` to `pulp_add_plugin()` warns without changing package metadata.
 
 - **AU v3 parity** for MIDI on effects is not re-audited in this pass. If you touch `core/format/src/au_adapter.mm`, confirm the AUv3 `componentType` logic in `_pulp_add_auv3` still matches the fix in `_pulp_add_au`.
 

--- a/docs/reference/cmake.md
+++ b/docs/reference/cmake.md
@@ -16,6 +16,7 @@ pulp_add_plugin(<target>
     MANUFACTURER    <string>
     VERSION         <string>
     CATEGORY        <Effect|Instrument|MidiEffect>
+    ACCEPTS_MIDI
     PLUGIN_CODE     <4-char>
     MANUFACTURER_CODE <4-char>
     AAX_PRODUCT_CODE <4-char>
@@ -40,6 +41,7 @@ pulp_add_plugin(<target>
 | `MANUFACTURER` | No | `"Unknown"` | Manufacturer name |
 | `VERSION` | No | `"1.0.0"` | Plugin version string |
 | `CATEGORY` | No | `"Effect"` | Plugin category: `Effect`, `Instrument`, or `MidiEffect` |
+| `ACCEPTS_MIDI` | No | Off | Mirrors `PluginDescriptor::accepts_midi` for package metadata. AU v2/AUv3 effects that accept MIDI need this so Pulp emits a MIDI-routable component type (`aumf`) instead of an audio-only effect (`aufx`). MIDI output is controlled by `PluginDescriptor::produces_midi`; there is no `pulp_add_plugin(PRODUCES_MIDI)` flag. |
 | `PLUGIN_CODE` | AU/AUv3 only | -- | 4-character AU plugin code |
 | `MANUFACTURER_CODE` | AU/AUv3/AAX only | -- | 4-character manufacturer code used by AU, AUv3, and AAX |
 | `AAX_PRODUCT_CODE` | AAX only | -- | 4-character stable AAX product identifier |

--- a/docs/status/cmake-functions.yaml
+++ b/docs/status/cmake-functions.yaml
@@ -13,6 +13,7 @@ functions:
       - MANUFACTURER
       - VERSION
       - CATEGORY
+      - ACCEPTS_MIDI
       - PLUGIN_CODE
       - MANUFACTURER_CODE
       - AAX_PRODUCT_CODE

--- a/test/cmake/test_au_v2_type_selection.cmake
+++ b/test/cmake/test_au_v2_type_selection.cmake
@@ -14,6 +14,10 @@ Expected mapping:
   (MidiEffect,  *)     -> aumi
   (Effect,      true)  -> aumf   <-- the fix
   (Effect,      false) -> aufx
+
+Also pins the public CMake-option contract: `ACCEPTS_MIDI` is the only
+pulp_add_plugin MIDI packaging option. MIDI output remains
+PluginDescriptor/format metadata, not a parallel `PRODUCES_MIDI` CMake flag.
 ]]
 
 function(_select_au_type out_var category accepts_midi)
@@ -69,6 +73,50 @@ endif()
 
 if(_fail)
     message(FATAL_ERROR "AU v2 component-type selection smoke failed.")
-else()
-    message(STATUS "AU v2 component-type selection: all cases pass.")
 endif()
+
+get_filename_component(_repo_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(_utils "${_repo_root}/tools/cmake/PulpUtils.cmake")
+set(_reference "${_repo_root}/docs/reference/cmake.md")
+set(_status "${_repo_root}/docs/status/cmake-functions.yaml")
+
+foreach(_path IN LISTS _utils _reference _status)
+    if(NOT EXISTS "${_path}")
+        message(FATAL_ERROR "Required file missing: ${_path}")
+    endif()
+endforeach()
+
+file(READ "${_utils}" _utils_text)
+string(REGEX MATCH "cmake_parse_arguments\\(PLUGIN[ \t\r\n]+\"([^\"]*)\"" _parse_match "${_utils_text}")
+if(NOT _parse_match)
+    message(FATAL_ERROR "Could not find pulp_add_plugin cmake_parse_arguments option list")
+endif()
+
+set(_plugin_options "${CMAKE_MATCH_1}")
+if(NOT _plugin_options MATCHES "(^|;)ACCEPTS_MIDI($|;)")
+    message(FATAL_ERROR "pulp_add_plugin must parse ACCEPTS_MIDI")
+endif()
+if(_plugin_options MATCHES "(^|;)PRODUCES_MIDI($|;)")
+    message(FATAL_ERROR "pulp_add_plugin must not parse inert PRODUCES_MIDI")
+endif()
+if(NOT _utils_text MATCHES "PRODUCES_MIDI is ignored")
+    message(FATAL_ERROR "pulp_add_plugin must warn when callers pass inert PRODUCES_MIDI")
+endif()
+
+file(READ "${_reference}" _reference_text)
+if(NOT _reference_text MATCHES "`ACCEPTS_MIDI`")
+    message(FATAL_ERROR "docs/reference/cmake.md must document ACCEPTS_MIDI")
+endif()
+if(_reference_text MATCHES "\\|[ \t]*`PRODUCES_MIDI`")
+    message(FATAL_ERROR "docs/reference/cmake.md must not document PRODUCES_MIDI as a CMake option")
+endif()
+
+file(READ "${_status}" _status_text)
+if(NOT _status_text MATCHES "[ \t-]ACCEPTS_MIDI")
+    message(FATAL_ERROR "docs/status/cmake-functions.yaml must list ACCEPTS_MIDI")
+endif()
+if(_status_text MATCHES "[ \t-]PRODUCES_MIDI")
+    message(FATAL_ERROR "docs/status/cmake-functions.yaml must not list PRODUCES_MIDI")
+endif()
+
+message(STATUS "AU v2 type selection and pulp_add_plugin MIDI-option contract: OK")

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -490,11 +490,17 @@ endfunction()
 #
 function(pulp_add_plugin target)
     cmake_parse_arguments(PLUGIN
-        "ACCEPTS_MIDI;PRODUCES_MIDI"
+        "ACCEPTS_MIDI"
         "PLUGIN_NAME;BUNDLE_ID;VERSION;MANUFACTURER;CATEGORY;PLUGIN_CODE;MANUFACTURER_CODE;AAX_PRODUCT_CODE;AAX_NATIVE_CODE;PROCESSOR_FACTORY;UI_SCRIPT;DESIGN_WIDTH;DESIGN_HEIGHT;DESIGN_MIN_WIDTH;DESIGN_MIN_HEIGHT;DESIGN_MAX_WIDTH;DESIGN_MAX_HEIGHT"
         "FORMATS;SOURCES;CONTENT_CAPABILITIES;CONTENT_KINDS;CONTENT_HOT_RELOAD_KINDS;CONTENT_MANUAL_RESCAN_KINDS"
         ${ARGN}
     )
+    if("PRODUCES_MIDI" IN_LIST PLUGIN_UNPARSED_ARGUMENTS)
+        message(WARNING
+            "pulp_add_plugin(${target}): PRODUCES_MIDI is ignored. "
+            "Set PluginDescriptor::produces_midi = true in the processor; "
+            "MIDI output is format/runtime metadata, not a CMake packaging flag.")
+    endif()
 
     # Defaults
     if(NOT PLUGIN_PLUGIN_NAME)


### PR DESCRIPTION
## Summary

- remove inert `pulp_add_plugin(PRODUCES_MIDI)` option parsing and warn when callers pass it
- document `ACCEPTS_MIDI` as the CMake packaging flag for MIDI-routable AU v2/AUv3 effects
- pin the CMake MIDI-option contract in the existing AU v2 type-selection test and update the AUv2 skill guidance

## Validation

- `git diff --check origin/main...HEAD`
- `cmake -P test/cmake/test_au_v2_type_selection.cmake`
- `ctest --test-dir build -R cmake-au-v2-type-selection --output-on-failure`
- `python3 tools/docs_generate.py check`
- `python3 tools/scripts/docs_noise_lint.py docs/reference/cmake.md docs/status/cmake-functions.yaml .agents/skills/auv2/SKILL.md test/cmake/test_au_v2_type_selection.cmake tools/cmake/PulpUtils.cmake`
- `tools/scripts/gates.sh origin/main`
- `cmake --build build --parallel 8`

## Adversarial Review

Must-fix before PR: none found.

Should-fix soon: none newly introduced. AU v2 MIDI output remains explicitly unwired and documented as a current gap.

Acceptable for now: the CMake contract test reads the helper option list textually, which is appropriate here because this patch pins a public CMake option contract. No runtime/importer/rendering/layout/platform boundary changes, no new abstraction, and no touched file crosses 1k LOC.

Claude bridge note: attempted twice. The first attempt entered a tool-use path and returned no review; the second no-tools retry hit the budget cap before returning a review. No Claude finding is available for this PR.
