### PR TITLE
docs(web): clarify WAM and WCLAP helper status

### DIFF
--- a/docs/examples/pulp-gain.md
+++ b/docs/examples/pulp-gain.md
@@ -22,10 +22,10 @@ The simplest possible Pulp plugin. A stereo gain effect with input gain, output 
 
 ## Try in Browser
 
-The same Processor code that runs as VST3/AU/CLAP is compiled to WebAssembly and
-can run in the local browser host via the Web Audio API. The repo does not yet
-publish a canonical Pages-hosted browser host, so use `tools/browser-host/`
-locally for now.
+The same Processor code that runs as VST3/AU/CLAP can be compiled to
+WebAssembly through the web-demo lane. The local `tools/browser-host/` app is
+currently a browser-host scaffold; end-to-end WAM plugin audio is not yet
+runtime-validated there.
 
 ## Supported Formats
 
@@ -37,7 +37,7 @@ locally for now.
 | CLAP | Yes |
 | AAX | Optional on macOS/Windows |
 | Standalone | Yes |
-| WAMv2 (Browser) | Yes |
+| WAMv2 (Browser) | Experimental generated-output lane; browser-host runtime not validated yet |
 | WebCLAP (WASM) | Experimental helper path; no checked-in PulpGain WCLAP target yet |
 
 ## Supported Platforms

--- a/docs/guides/web-plugins.md
+++ b/docs/guides/web-plugins.md
@@ -1,12 +1,17 @@
 # Web Plugin Formats: WAMv2 and WebCLAP
 
-Pulp plugins can run in browsers through two complementary web standards. This guide explains how they work, how to build them, and how to try the live demo.
+Pulp's web-plugin work is split across two complementary web standards. This
+guide explains the intended architecture, the checked-in build paths, and the
+current browser-host limits.
 
 ## Browser Host Availability
 
 The Pulp Browser Host is currently a local tool in `tools/browser-host/`. The
 repo does not yet publish a canonical repo-owned Pages deployment for it, so
-browser-host examples should be treated as local-run instructions for now.
+browser-host examples should be treated as local-run instructions for now. The
+host is also not yet an end-to-end validated WAM/WebCLAP runtime; use it as a
+browser-host scaffold until the AudioWorklet and WebCLAP host-library paths are
+wired and tested.
 
 ## Two Paths to the Browser
 
@@ -29,7 +34,7 @@ Pulp Processor (C++ → WASM via Emscripten)
 **Key files:**
 - `core/format/include/pulp/format/web/wam_adapter.hpp` — C++ bridge
 - `core/format/src/wasm/wam_adapter.cpp` — implementation
-- `core/format/src/wasm/wam-plugin.js` — WAMv2 JS runtime
+- `core/format/src/wasm/wam-plugin.js` — experimental WAMv2 JS runtime scaffold
 
 **Upstream references:**
 - [WAMv2 API](https://github.com/webaudiomodules/api) — interface definitions
@@ -96,10 +101,12 @@ emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```
 
-The output is a `.js` + `.wasm` pair for the checked-in demo plugins. The root
-`tools/cmake/PulpWasm.cmake` helper is available for projects that include it
-explicitly, but the root Pulp build does not currently create WAM targets from
-`-DPULP_WASM=ON` alone.
+The output is a `.js` + `.wasm` pair for the checked-in demo plugins. Those
+files expose the C entry points used by `WamProcessorBridge`; wrapping them as a
+host-compatible WAM ES module and running them through the browser host is still
+experimental and not runtime-validated. The root `tools/cmake/PulpWasm.cmake`
+helper is available for projects that include it explicitly, but the root Pulp
+build does not currently create WAM targets from `-DPULP_WASM=ON` alone.
 
 ### Option 2: WebCLAP (WASI SDK)
 
@@ -109,10 +116,9 @@ export WASI_SDK_PREFIX=/opt/wasi-sdk
 
 # Configure a project that includes tools/cmake/PulpWclap.cmake and calls
 # pulp_add_wclap(...). The root Pulp tree does not currently define a checked-in
-# PulpGain_WCLAP target.
+# PulpGain_WCLAP target, and there is no root PULP_BUILD_WCLAP toggle.
 cmake -S . -B build-wclap \
   -DCMAKE_TOOLCHAIN_FILE=tools/cmake/wasi-toolchain.cmake \
-  -DPULP_BUILD_WCLAP=ON \
   -DCMAKE_BUILD_TYPE=Release
 
 # Build the project-defined WCLAP target
@@ -146,17 +152,17 @@ The `PULP_WCLAP_PLUGIN()` macro handles all of this automatically.
 
 ## Pulp Browser Host
 
-The Pulp Browser Host (`tools/browser-host/`) is a self-contained HTML app that can:
+The Pulp Browser Host (`tools/browser-host/`) is a self-contained HTML shell for
+the web-plugin runtime work. Today it can:
 
-- Load WAMv2 modules via ES module import
-- Route audio through the plugin (file playback or microphone)
-- Display auto-generated parameter controls
-- Provide an on-screen MIDI keyboard for instruments
-- Show a real-time oscilloscope
-- Share plugin state via URL (base64-encoded)
+- Accept WAM/WASM/WCLAP URLs or files and classify them by extension
+- Serve as the local static host for checked-in Emscripten outputs
+- Play audio files through the Web Audio analyser path
+- Show the shell UI, MIDI keyboard, and oscilloscope
 
-The host currently recognizes WCLAP URLs and files, but the `.wclap.tar.gz`
-unpack/instantiate path is still a placeholder until `wclap-host-js` is wired.
+The host does not yet instantiate the checked-in WAM demo outputs into plugin
+`AudioWorkletNode`s, build parameter controls from those outputs, or unpack
+WCLAP bundles with `wclap-host-js`.
 
 ### Publishing Status
 
@@ -181,7 +187,7 @@ python3 -m http.server 8080
 |--------|-----------|---------|-------------|----------|-----|
 | CLAP | CMake | Native | ✅ Direct | ❌ | clap.gui (NSView/HWND) |
 | WebCLAP | WASI SDK | WASM | Experimental via wclap-bridge | Experimental via external wclap-host-js; Pulp browser-host loading not wired yet | clap.webview |
-| WAMv2 | Emscripten | WASM | ❌ | ✅ AudioWorklet | HTML/CSS/JS |
+| WAMv2 | Emscripten | WASM | ❌ | Experimental generated-output lane; Pulp browser-host runtime wiring not validated | HTML/CSS/JS |
 
 ## What Runs Where
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ MIT-licensed. No royalties. No copyleft.
 
 - [Building](guides/build.md) — requirements, options, platform notes
 - [Testing](guides/testing.md) — running tests, validation, writing tests
-- [Web Plugins](guides/web-plugins.md) — WAMv2, WebCLAP, browser demos
+- [Web Plugins](guides/web-plugins.md) — WAMv2, WebCLAP, browser-host status
 - [Design from Figma](guides/figma-plugin.md) — the "Design for Pulp" plugin, export, and import ([model](reference/design-import-model.md))
 - [Docs Maintenance](guides/docs-maintenance.md) — how docs stay consistent with code
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -93,7 +93,8 @@ adapter compiles and loads — not that every host-facing feature is wired.
 - **AUv3** — iOS jetsam pressure not modeled; heavy V8 / WebView workloads in
   the AUv3 process risk termination at ~50 MB. Tracked: workstream 05.
 - **WAM v2 / WebCLAP** — Browser origin sandbox only; no Pulp-side capability
-  manifest yet. Tracked: `planning/security/container-and-sandbox-strategy-v4.md`.
+  manifest yet, and the Pulp browser-host runtime wiring is still scaffolded.
+  Tracked: `planning/security/container-and-sandbox-strategy-v4.md`.
 
 If you hit a limitation not listed, check
 `planning/production-readiness/01-format-adapters.md` and file an issue.
@@ -108,7 +109,7 @@ If you hit a limitation not listed, check
 | Windows | experimental | [platform](modules.md#platform) | WASAPI, Win32 MIDI, NSIS installer, CI |
 | Linux | experimental | [platform](modules.md#platform) | ALSA, JACK, LV2, CI |
 | iOS | experimental | [platform](modules.md#platform) | AVAudioSession, AUv3, UIKit, Metal |
-| Web / WASM | experimental | [platform](modules.md#platform) | WAMv2, WebCLAP, Emscripten pipeline |
+| Web / WASM | experimental | [platform](modules.md#platform) | WAMv2/WebCLAP scaffolding, Emscripten pipeline; browser-host runtime not validated |
 
 Key headers: `pulp/platform/detect.hpp`, `pulp/platform/native_handle.hpp`
 

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -247,7 +247,7 @@ docs:
   - slug: web-plugins
     path: guides/web-plugins.md
     kind: guide
-    summary: WAMv2 and WebCLAP web plugin formats — build, deploy, and browser demo
+    summary: WAMv2 and WebCLAP web plugin formats — build scaffolds and browser-host status
 
   - slug: from-react-css
     path: guides/from-react-css.md

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -17,7 +17,7 @@ platforms:
     notes: Foundation in place. AVAudioSession, AUv3, UIKit views, Metal surface.
   web:
     status: experimental
-    notes: WAMv2, WebCLAP adapters, Emscripten build pipeline, browser test host. Not yet runtime-validated in browser.
+    notes: WAMv2/WebCLAP adapter scaffolding, Emscripten demo build pipeline, and browser-host shell. C++ bridge tests exist; browser-host plugin audio is not yet fully wired or runtime-validated.
 
 formats:
   vst3:
@@ -47,8 +47,10 @@ formats:
     linux: experimental
   wam_v2:
     web: experimental
+    notes: C++ WamProcessorBridge and checked-in Emscripten demo outputs exist; host-compatible WAM ES-module / browser AudioWorklet loading remains scaffolded.
   webclap:
     web: experimental
+    notes: Adapter macro and CMake helper exist; no checked-in PulpGain_WCLAP target or Pulp browser-host wclap-host-js integration yet.
   aax:
     macos: experimental
     windows: experimental
@@ -115,8 +117,10 @@ format_limitations:
     - "iOS jetsam pressure not modeled — heavy V8 / WebView workloads in the AUv3 process risk termination at ~50 MB (workstream 05)."
   wam_v2:
     - "Browser origin sandbox only; no Pulp-side capability manifest yet (security plan v4 §4.5)."
+    - "Pulp Browser Host WAM loading is scaffolded; checked-in demo outputs are not runtime-validated in browser and are not loaded into a plugin AudioWorkletNode yet."
   webclap:
     - "Same browser-sandbox-only constraint as wam_v2."
+    - "Pulp Browser Host recognizes WCLAP URLs/files, but .wclap.tar.gz unpack/instantiate via wclap-host-js is still placeholder work."
 
 scripted_ui:
   ui_script_target_wiring:

--- a/examples/web-demos/README.md
+++ b/examples/web-demos/README.md
@@ -1,6 +1,6 @@
 # Pulp Web Demos
 
-Pulp audio plugins compiled to WebAssembly and running in the browser.
+Pulp audio plugin experiments compiled to WebAssembly for browser-host work.
 
 ## Quick Start
 
@@ -10,7 +10,7 @@ cd examples/web-demos/wasm-build
 emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 
-# 2. Copy outputs to browser host
+# 2. Copy outputs for browser-host inspection
 cp build/Pulp*.{js,wasm} ../../tools/browser-host/plugins/
 
 # 3. Serve and open
@@ -18,6 +18,9 @@ cd ../../tools/browser-host
 python3 -m http.server 8080
 # Open http://localhost:8080
 ```
+
+This serves the generated assets through the local browser-host scaffold. It
+does not yet prove end-to-end plugin audio execution in the browser.
 
 ## What's Here
 
@@ -47,17 +50,19 @@ source emsdk_env.sh
 # Download from https://github.com/WebAssembly/wasi-sdk/releases
 export WASI_SDK_PREFIX=/opt/wasi-sdk
 
-# Build a project that includes tools/cmake/PulpWclap.cmake and calls
-# pulp_add_wclap(...). The checked-in web demos currently ship WAMv2
-# Emscripten targets, not a ready-made WebCLAP target.
-cmake -S ../.. -B build-wclap \
-  -DCMAKE_TOOLCHAIN_FILE=../../tools/cmake/wasi-toolchain.cmake \
-  -DPULP_BUILD_WCLAP=ON
+# Build your plugin project after it includes tools/cmake/PulpWclap.cmake
+# and calls pulp_add_wclap(...). The checked-in web demos currently ship
+# WAMv2 Emscripten targets, not a ready-made WebCLAP target, and there is
+# no root PULP_BUILD_WCLAP toggle.
+cmake -S <your-plugin-project> -B build-wclap \
+  -DCMAKE_TOOLCHAIN_FILE=<pulp-root>/tools/cmake/wasi-toolchain.cmake
 ```
 
 ## How It Works
 
-Each plugin is compiled to WebAssembly using Emscripten. The WASM module exports C functions that the browser host calls from an `AudioWorkletProcessor`:
+Each plugin is compiled to WebAssembly using Emscripten. The WASM module exports
+C functions intended for an `AudioWorkletProcessor`; the checked-in browser host
+does not yet complete this end-to-end AudioWorklet wiring.
 
 ```
 Browser (JS)                    WASM Module (C++)
@@ -109,7 +114,7 @@ The same Pulp Processor runs as:
 | VST3 | macOS, Windows, Linux | CMake (native) |
 | AU v2 | macOS | CMake (native) |
 | CLAP | macOS, Windows, Linux | CMake (native) |
-| **WAMv2** | **Browser** | **Emscripten** |
+| **WAMv2** | **Browser** | **Emscripten; browser-host runtime scaffold** |
 | **WebCLAP** | **Native + Browser** | **WASI SDK helper; no checked-in demo target yet** |
 
 ## Acknowledgments

--- a/tools/cmake/PulpWclap.cmake
+++ b/tools/cmake/PulpWclap.cmake
@@ -11,10 +11,9 @@
 #
 # Usage:
 #   cmake -S . -B build-wclap \
-#     -DCMAKE_TOOLCHAIN_FILE=tools/cmake/wasi-toolchain.cmake \
-#     -DPULP_BUILD_WCLAP=ON
+#     -DCMAKE_TOOLCHAIN_FILE=tools/cmake/wasi-toolchain.cmake
 #
-# Or use the helper function in your CMakeLists.txt:
+# Use this helper from your CMakeLists.txt before configuring the project:
 #   pulp_add_wclap(MyPlugin
 #       PLUGIN_ID "com.mycompany.myplugin"
 #       PLUGIN_NAME "My Plugin"

--- a/tools/cmake/wasi-toolchain.cmake
+++ b/tools/cmake/wasi-toolchain.cmake
@@ -3,8 +3,7 @@
 #
 # Usage:
 #   cmake -S . -B build-wclap \
-#     -DCMAKE_TOOLCHAIN_FILE=tools/cmake/wasi-toolchain.cmake \
-#     -DPULP_BUILD_WCLAP=ON
+#     -DCMAKE_TOOLCHAIN_FILE=tools/cmake/wasi-toolchain.cmake
 #
 # Prerequisites:
 #   - wasi-sdk installed (default: /opt/wasi-sdk)


### PR DESCRIPTION
## Summary
- remove stale root `PULP_BUILD_WCLAP` guidance and point WCLAP users at explicit project-local `PulpWclap.cmake` inclusion
- clarify that checked-in WAM/Emscripten demo outputs and C++ bridge tests exist, but browser-host WAM plugin audio is still scaffolded/not runtime-validated
- update support matrix, capabilities, docs index, PulpGain, and web-demo docs so placeholder browser-host behavior is not presented as a working WAM/WebCLAP host

## Validation
Initial branch validation before the docs-index-only amend:
- `git diff --check origin/main...HEAD`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/scripts/docs_noise_lint.py docs/guides/web-plugins.md examples/web-demos/README.md docs/status/support-matrix.yaml docs/examples/pulp-gain.md docs/reference/capabilities.md tools/cmake/PulpWclap.cmake tools/cmake/wasi-toolchain.cmake`
- `tools/check-docs.sh` (passes with existing 109 warnings)
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON`
- `cmake --build build --target pulp-test-wam-wclap pulp-test-web-demos --parallel 8`
- `ctest --test-dir build -R 'Wam|WCLAP|web-demos|WebCLAP|web demos' --output-on-failure`
- `./build/test/pulp-test-web-demos`
- `./build/test/pulp-test-wam-wclap`

Post-amend validation for the folded docs-index summary:
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/status/docs-index.yaml docs/guides/web-plugins.md examples/web-demos/README.md docs/status/support-matrix.yaml docs/examples/pulp-gain.md docs/reference/capabilities.md tools/cmake/PulpWclap.cmake tools/cmake/wasi-toolchain.cmake`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `tools/scripts/gates.sh origin/main`
- pre-push fast gates passed