### PR TITLE
docs(web): clarify browser host validation status

### DIFF
--- a/docs/guides/web-plugins.md
+++ b/docs/guides/web-plugins.md
@@ -1,12 +1,16 @@
 # Web Plugin Formats: WAMv2 and WebCLAP
 
-Pulp plugins can run in browsers through two complementary web standards. This guide explains how they work, how to build them, and how to try the live demo.
+Pulp has experimental browser-format scaffolding through two complementary web
+standards. This guide explains the current build outputs, adapter pieces, and
+local browser-host scaffold.
 
 ## Browser Host Availability
 
 The Pulp Browser Host is currently a local tool in `tools/browser-host/`. The
 repo does not yet publish a canonical repo-owned Pages deployment for it, so
 browser-host examples should be treated as local-run instructions for now.
+The host is not yet a runtime-validated WAMv2/WebCLAP demo for the checked-in
+generated plug-in outputs.
 
 ## Two Paths to the Browser
 
@@ -96,7 +100,9 @@ emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```
 
-The output is a `.js` + `.wasm` pair for the checked-in demo plugins. The root
+The output is a `.js` + `.wasm` pair for the checked-in demo plugins. These
+outputs are useful for browser-integration work, but the repo does not yet
+claim end-to-end browser-host audio validation for them. The root
 `tools/cmake/PulpWasm.cmake` helper is available for projects that include it
 explicitly, but the root Pulp build does not currently create WAM targets from
 `-DPULP_WASM=ON` alone.
@@ -146,10 +152,13 @@ The `PULP_WCLAP_PLUGIN()` macro handles all of this automatically.
 
 ## Pulp Browser Host
 
-The Pulp Browser Host (`tools/browser-host/`) is a self-contained HTML app that can:
+The Pulp Browser Host (`tools/browser-host/`) is a self-contained HTML scaffold
+for browser integration work. It currently provides:
 
-- Load WAMv2 modules via ES module import
-- Route audio through the plugin (file playback or microphone)
+- Local file/URL controls and basic file-playback or microphone routing UI
+- A WAMv2 ES module import path for modules exposing `default.createInstance(audioCtx)`
+- A raw `.wasm` fetch/compile path that still needs the AudioWorklet bridge file
+  and generated-output wiring
 - Display auto-generated parameter controls
 - Provide an on-screen MIDI keyboard for instruments
 - Show a real-time oscilloscope
@@ -157,6 +166,9 @@ The Pulp Browser Host (`tools/browser-host/`) is a self-contained HTML app that 
 
 The host currently recognizes WCLAP URLs and files, but the `.wclap.tar.gz`
 unpack/instantiate path is still a placeholder until `wclap-host-js` is wired.
+The checked-in WAM demo outputs are Emscripten module factories with `wam_*`
+exports, so they should be treated as generated-output fixtures until the host
+bridge is wired and browser-validated against them.
 
 ### Publishing Status
 
@@ -181,7 +193,7 @@ python3 -m http.server 8080
 |--------|-----------|---------|-------------|----------|-----|
 | CLAP | CMake | Native | ✅ Direct | ❌ | clap.gui (NSView/HWND) |
 | WebCLAP | WASI SDK | WASM | Experimental via wclap-bridge | Experimental via external wclap-host-js; Pulp browser-host loading not wired yet | clap.webview |
-| WAMv2 | Emscripten | WASM | ❌ | ✅ AudioWorklet | HTML/CSS/JS |
+| WAMv2 | Emscripten | WASM | ❌ | Experimental generated-output lane; Pulp browser-host runtime validation pending | HTML/CSS/JS |
 
 ## What Runs Where
 

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -247,7 +247,7 @@ docs:
   - slug: web-plugins
     path: guides/web-plugins.md
     kind: guide
-    summary: WAMv2 and WebCLAP web plugin formats — build, deploy, and browser demo
+    summary: WAMv2 and WebCLAP web plugin formats — build scaffolds and browser-host status
 
   - slug: from-react-css
     path: guides/from-react-css.md

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -17,7 +17,7 @@ platforms:
     notes: Foundation in place. AVAudioSession, AUv3, UIKit views, Metal surface.
   web:
     status: experimental
-    notes: WAMv2, WebCLAP adapters, Emscripten build pipeline, browser test host. Not yet runtime-validated in browser.
+    notes: WAMv2/WebCLAP adapter scaffolding, Emscripten generated-output lane, and local browser-host scaffold. Not yet runtime-validated end-to-end in browser.
 
 formats:
   vst3:
@@ -47,8 +47,10 @@ formats:
     linux: experimental
   wam_v2:
     web: experimental
+    notes: Emscripten demo outputs and adapter bridge exist; Pulp browser-host runtime validation is pending.
   webclap:
     web: experimental
+    notes: WASI helper path exists for project-defined targets; browser-host unpack/instantiate wiring is not yet implemented.
   aax:
     macos: experimental
     windows: experimental

--- a/examples/web-demos/README.md
+++ b/examples/web-demos/README.md
@@ -1,8 +1,13 @@
 # Pulp Web Demos
 
-Pulp audio plugins compiled to WebAssembly and running in the browser.
+Pulp audio plugins compiled to WebAssembly for the experimental browser-host
+integration lane.
 
 ## Quick Start
+
+The commands below build the checked-in Emscripten outputs and open the local
+browser-host scaffold. The repo does not yet claim end-to-end browser audio
+validation for these generated outputs.
 
 ```bash
 # 1. Build the WASM plugins (requires Emscripten)
@@ -57,7 +62,8 @@ cmake -S ../.. -B build-wclap \
 
 ## How It Works
 
-Each plugin is compiled to WebAssembly using Emscripten. The WASM module exports C functions that the browser host calls from an `AudioWorkletProcessor`:
+Each plugin is compiled to WebAssembly using Emscripten. The WASM module exports
+C functions intended for the browser AudioWorklet bridge:
 
 ```
 Browser (JS)                    WASM Module (C++)
@@ -69,7 +75,11 @@ AudioWorkletProcessor  ──────►  wam_init(sampleRate, blockSize)
   getDescriptor        ──────►  wam_descriptor() → JSON
 ```
 
-The C++ side uses `WamProcessorBridge` which wraps a standard Pulp `Processor`. PulpPluck reuses the native example processor source that runs as VST3, AU v2, or CLAP on the desktop; PulpGain and PulpChorus use the same adapter shape for their web-demo processors.
+The C++ side uses `WamProcessorBridge` which wraps a standard Pulp `Processor`.
+PulpPluck reuses the native example processor source that runs as VST3, AU v2,
+or CLAP on the desktop; PulpGain and PulpChorus use the same adapter shape for
+their web-demo processors. The current browser host still needs runtime bridge
+wiring before these generated outputs are treated as a validated in-browser demo.
 
 ## File Structure
 
@@ -109,7 +119,7 @@ The same Pulp Processor runs as:
 | VST3 | macOS, Windows, Linux | CMake (native) |
 | AU v2 | macOS | CMake (native) |
 | CLAP | macOS, Windows, Linux | CMake (native) |
-| **WAMv2** | **Browser** | **Emscripten** |
+| **WAMv2** | **Browser scaffold** | **Emscripten output; runtime validation pending** |
 | **WebCLAP** | **Native + Browser** | **WASI SDK helper; no checked-in demo target yet** |
 
 ## Acknowledgments


### PR DESCRIPTION
## Summary
- clarify that the Pulp browser host is an experimental scaffold, not yet a runtime-validated WAMv2/WebCLAP demo for the checked-in generated outputs
- update the web-demos README and support matrix to describe the Emscripten generated-output lane and pending browser runtime validation
- update the docs index summary for the web plugin guide

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/guides/web-plugins.md examples/web-demos/README.md docs/status/support-matrix.yaml docs/status/docs-index.yaml`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `tools/scripts/gates.sh origin/main`
- `tools/check-docs.sh` (existing warnings only)
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` -> `native_build_required=false`
- `cmake -S . -B build-web-audit -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=ON -DPULP_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-web-audit --target pulp-test-web-demos --parallel 8`
- `./build-web-audit/test/pulp-test-web-demos` (8 cases / 269 assertions)
- pre-push fast gates passed

## Adversarial review
- Must-fix before PR: none found.
- Should-fix soon: coordinate with #5104, which owns the separate stale `PULP_BUILD_WCLAP` example cleanup in the same guide/README; do not duplicate that patch here.
- Acceptable for now: docs/status-only correction; no runtime/importer/rendering/layout/platform code changed, no new abstraction/API/helper surface added, and the larger AudioWorklet / WCLAP host runtime wiring remains explicitly deferred.

Claude second-opinion review was attempted locally but the CLI is still unauthenticated (`Not logged in`).

Audit ledger: planning main records this as RA-WEB-017.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that the browser host is an experimental scaffold and that WAMv2/WebCLAP outputs are not yet runtime-validated in the browser. Updates the web plugin guide, support matrix, docs index, and `examples/web-demos` README to reflect the Emscripten generated-output lane and pending AudioWorklet/host wiring.

<sup>Written for commit f7814edea0bb72195a60ac2138780537dd8e899f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

