### PR TITLE
docs(view): align ImageView decode status

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -257,7 +257,7 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | ScrollView (smooth scroll, fade bars) | usable | [view](modules.md#view) | |
 | Meter (RMS + peak hold), ProgressBar | usable | [view](modules.md#view) | |
 | XYPad, WaveformView, SpectrumView | usable | [view](modules.md#view) | |
-| ImageView | usable | [view](modules.md#view) | Placeholder rendering |
+| ImageView | usable | [view](modules.md#view) | File-backed decode with placeholder fallback |
 | TreeView, Tooltip, Panel, Icon | usable | [view](modules.md#view) | |
 | SpectrogramView (scrolling STFT) | usable | [view](modules.md#view) | |
 | MultiMeter, CorrelationMeter | usable | [view](modules.md#view) | |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -960,8 +960,8 @@ widgets:
   checkbox:         { status: usable, header: widgets.hpp }
   toggle_button:    { status: usable, header: widgets.hpp }
   icon:             { status: usable, header: widgets.hpp }
-  image_view:       { status: partial, header: widgets.hpp,
-                      notes: "Placeholder rendering; Skia decode planned." }
+  image_view:       { status: usable, header: widgets.hpp,
+                      notes: "File-backed decode through Canvas::draw_image_from_file / draw_image_from_file_rect on supported backends; placeholder fallback when decode/backend support is missing." }
   meter:            { status: usable, header: widgets.hpp }
   multi_meter:      { status: usable, header: widgets.hpp }
   correlation_meter: { status: usable, header: widgets.hpp }


### PR DESCRIPTION
## Summary
- Aligns the stale schema-v2 ImageView status row with the already-correct widget status row.
- Records current behavior: file-backed ImageView sources render through `Canvas::draw_image_from_file` / `draw_image_from_file_rect` on supported backends, with placeholder fallback when source/decode/backend support is missing.
- Updates the manual capabilities inventory row from placeholder-only wording to bounded file-backed decode wording.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/scripts/docs_noise_lint.py --base origin/main --head HEAD --mode=report -- docs/status/support-matrix.yaml docs/reference/capabilities.md`
- `python3 tools/check_status_ladder.py --mode=report`
- `bash tools/check-docs.sh` (passes with existing 109 warnings)
- `python3 tools/scripts/classify_changes.py --base origin/main --json` (`native_build_required=false`)
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD --pr-title "docs(view): align ImageView decode status"`
- `bash tools/scripts/gates.sh origin/main`
- `git merge-tree --write-tree origin/main HEAD` -> `a64309f100a79461c7e119d9a64c075c2d2e5153`
- Pre-push fast gates passed with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`.

## Review Notes
Strict local adversarial/code-health review found no must-fix. This is a docs/status-only refresh of two rows; it does not touch runtime/importer/rendering/layout/platform boundaries, add abstraction, or create duplicated logic. Acceptable for now: `docs/status/support-matrix.yaml` is already over 1k LOC as a status source of truth, but this patch does not make that structure meaningfully worse.

Claude second-opinion was attempted and did not produce a usable review: `claude -p` ran silently until interrupted and returned `error_during_execution` / `aborted_streaming`.

This refresh replaces the old conflicting #5119 head (`a897a5b4e`) with current-main head `7da5e5554`.