### PR TITLE
test(examples): cover audio inspector render proof helper

### DIFF
--- a/examples/audio-inspector-demo/CMakeLists.txt
+++ b/examples/audio-inspector-demo/CMakeLists.txt
@@ -5,3 +5,16 @@ target_link_libraries(pulp-audio-inspector-demo PRIVATE pulp::standalone)
 
 add_executable(pulp-audio-inspector-demo-render render_proof_wav.cpp)
 target_link_libraries(pulp-audio-inspector-demo-render PRIVATE pulp::format)
+
+if(PULP_BUILD_TESTS)
+    add_test(
+        NAME audio-inspector-demo-render-proof
+        COMMAND ${CMAKE_COMMAND}
+            -DRENDER_EXE=$<TARGET_FILE:pulp-audio-inspector-demo-render>
+            -DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/render-proof-test
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/render_proof_test.cmake
+    )
+    set_tests_properties(audio-inspector-demo-render-proof PROPERTIES
+        LABELS "examples;audio-inspector"
+        TIMEOUT 15)
+endif()

--- a/examples/audio-inspector-demo/render_proof_test.cmake
+++ b/examples/audio-inspector-demo/render_proof_test.cmake
@@ -1,0 +1,84 @@
+if(NOT DEFINED RENDER_EXE)
+    message(FATAL_ERROR "render_proof_test.cmake: RENDER_EXE not set")
+endif()
+if(NOT DEFINED OUTPUT_DIR)
+    message(FATAL_ERROR "render_proof_test.cmake: OUTPUT_DIR not set")
+endif()
+
+set(output_wav "${OUTPUT_DIR}/audio-inspector-proof.wav")
+set(metadata_json "${OUTPUT_DIR}/audio-inspector-proof.json")
+
+file(REMOVE_RECURSE "${OUTPUT_DIR}")
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+execute_process(
+    COMMAND "${RENDER_EXE}"
+        --output "${output_wav}"
+        --metadata-json "${metadata_json}"
+        --duration 0.05
+        --sample-rate 8000
+        --block-size 64
+        --frequency 330
+        --level-db -18
+    RESULT_VARIABLE render_result
+    OUTPUT_VARIABLE render_stdout
+    ERROR_VARIABLE render_stderr
+)
+
+message(STATUS "audio-inspector render stdout:\n${render_stdout}")
+if(render_stderr)
+    message(STATUS "audio-inspector render stderr:\n${render_stderr}")
+endif()
+
+if(NOT render_result EQUAL 0)
+    message(FATAL_ERROR
+        "pulp-audio-inspector-demo-render failed with ${render_result}: ${render_stderr}")
+endif()
+
+if(NOT render_stdout MATCHES "frames=400")
+    message(FATAL_ERROR "render stdout did not report the expected frame count")
+endif()
+
+if(NOT EXISTS "${output_wav}")
+    message(FATAL_ERROR "render did not write WAV: ${output_wav}")
+endif()
+file(SIZE "${output_wav}" output_wav_size)
+if(output_wav_size LESS 512)
+    message(FATAL_ERROR "rendered WAV is too small (${output_wav_size} bytes)")
+endif()
+
+if(NOT EXISTS "${metadata_json}")
+    message(FATAL_ERROR "render did not write metadata JSON: ${metadata_json}")
+endif()
+file(READ "${metadata_json}" metadata)
+foreach(expected
+        "\"schema\": \"pulp.video-proof.audio-render.v1\""
+        "\"sample_rate\": 8000"
+        "\"frames\": 400"
+        "\"channels\": 2"
+        "\"block_size\": 64"
+        "\"frequency_hz\": 330"
+        "\"level_db\": -18")
+    if(NOT metadata MATCHES "${expected}")
+        message(FATAL_ERROR "metadata JSON missing expected field: ${expected}")
+    endif()
+endforeach()
+
+execute_process(
+    COMMAND "${RENDER_EXE}" --duration 0.05
+    RESULT_VARIABLE missing_output_result
+    OUTPUT_VARIABLE missing_output_stdout
+    ERROR_VARIABLE missing_output_stderr
+)
+
+if(missing_output_result EQUAL 0)
+    message(FATAL_ERROR "render helper accepted an invocation without --output")
+endif()
+if(NOT missing_output_stderr MATCHES "--output is required")
+    message(FATAL_ERROR "missing-output error did not mention the required output flag")
+endif()
+if(NOT missing_output_stderr MATCHES "Usage: pulp-audio-inspector-demo-render")
+    message(FATAL_ERROR "missing-output error did not print usage")
+endif()
+
+message(STATUS "audio-inspector-demo-render-proof: OK (${output_wav_size} bytes)")


### PR DESCRIPTION
## Summary

- Adds a CMake-script CTest for `pulp-audio-inspector-demo-render`.
- Verifies the helper writes a deterministic WAV plus metadata JSON.
- Pins the missing-`--output` failure path so the documented render-proof helper has direct CLI coverage.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=ON -DPULP_BUILD_TESTS=ON`
- `cmake --build build --target pulp-audio-inspector-demo-render --parallel 8`
- `ctest --test-dir build -R '^audio-inspector-demo-render-proof$' --output-on-failure`
- `cmake --build build --target pulp-test-audio-inspector-demo-processor --parallel 8`
- `./build/test/pulp-test-audio-inspector-demo-processor --reporter compact` (`779` assertions / `3` cases)
- Release proof: `CMAKE_BUILD_TYPE=Release`, `-O3 -DNDEBUG` for the render helper and `pulp-format`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=true`)
- `tools/scripts/gates.sh origin/main`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- Push pre-push fast gates passed with `PULP_SKIP_DIFF_COVER=1` after the focused Release proof above

## Review

Strict local architecture/code-health review found no must-fix or should-fix-soon item: test-only CMake/script addition, touched files stay small, no runtime/importer/rendering/platform boundary change, no new abstraction, and the script follows the existing example-local CMake test pattern.

Claude second opinion was attempted but remains unavailable locally: `Not logged in · Please run /login`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CTest for `pulp-audio-inspector-demo-render` that renders a short WAV, validates the metadata JSON for expected fields, and asserts the CLI errors when `--output` is missing.

<sup>Written for commit c7b967e24f92f2ab6822173772a6e61fe526ab89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

