### PR TITLE
docs(import): align import-design source status

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1271,7 +1271,7 @@ file error.
 
 ### import-design
 
-**Status**: experimental
+**Status**: partial
 
 Import designs from Figma/Figma plugin, Stitch, v0, Pencil, Claude Design,
 React JSX, or Google DESIGN.md source files into generated Pulp UI code.

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -854,15 +854,15 @@ commands:
   - name: import-design
     status: partial
     summary: >
-      Import designs from Figma, Stitch, v0, Pencil, Claude Design, React JSX,
-      or Google DESIGN.md into Pulp JS, DesignIR, or baked C++ artifacts. The
-      designmd source is tokens-only (no ui.js); other sources can emit a full
-      ui.js + tokens.json.
+      Import designs from Figma/Figma plugin, Stitch, v0, Pencil,
+      Claude Design, React JSX, or Google DESIGN.md into Pulp JS, DesignIR,
+      or baked C++ artifacts. The designmd source is tokens-only (no ui.js);
+      other sources can emit a full ui.js + tokens.json.
     args:
       - name: --from
         kind: option
         required: true
-        description: "Design source: figma, stitch, v0, pencil, claude, designmd, jsx"
+        description: "Design source: figma, figma-plugin, stitch, v0, pencil, claude, designmd, jsx"
       - name: --file
         kind: option
         description: Input file path (required if --url not given)


### PR DESCRIPTION
## Summary

- Marks `pulp import-design` as `partial` in the CLI reference to match `docs/status/cli-commands.yaml`.
- Adds the implemented `figma-plugin` source to the status manifest summary and `--from` source list.
- Leaves runtime/importer behavior unchanged; implementation/help/tests already accept and exercise `--from figma-plugin`.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/reference/cli.md docs/status/cli-commands.yaml`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `bash tools/check-docs.sh` (passed with existing `109` warnings)
- `python3 tools/scripts/cli_sync_check.py --strict --json` (0 issues; existing warnings)
- `python3 tools/scripts/docs_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=false`)
- `tools/scripts/gates.sh origin/main`
- `git merge-tree --write-tree origin/main HEAD`
- Push pre-push fast gates passed with `PULP_SKIP_DIFF_COVER=1`; hook ran the fast gates plus its 29-test helper suite.

## Review

Strict local architecture/code-health review found no must-fix or should-fix-soon item: docs/status-only, no runtime/importer/rendering/layout/platform boundary change, no new abstraction, and no new file-size or ownership risk. The skill-sync skip trailers are scoped to wording-only edits in broad CLI/status docs and avoid unrelated skill churn.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns docs for `pulp import-design`: mark status as partial and add `figma-plugin` to the `--from` sources to match `docs/status/cli-commands.yaml`. No runtime changes; docs-only sync.

<sup>Written for commit 860dfe4bd3ef9cf1005c6326d283c643e537fb64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

