### PR TITLE
docs(events): clarify Windows notification scaffold

### DIFF
--- a/core/events/include/pulp/events/push_notifications.hpp
+++ b/core/events/include/pulp/events/push_notifications.hpp
@@ -20,8 +20,9 @@
 // Backends (runtime-detected; build never hard-fails on a missing SDK):
 //   * macOS / iOS: `UNUserNotificationCenter` from `UserNotifications.framework`.
 //   * Linux: `libnotify.so.4` via runtime-dlopen.
-//   * Windows: `Windows.UI.Notifications.ToastNotificationManager` via WinRT
-//     activation (runtime-LoadLibrary `combase.dll`).
+//   * Windows: scaffold-only `winrt-toast-scaffold` backend that probes WinRT
+//     availability via runtime-LoadLibrary `combase.dll`, but reports
+//     unavailable until full toast activator / AUMID integration ships.
 //   * Other platforms / build configurations: `is_available()` returns false
 //     and `post_local_notification` reports a posted notification id of 0.
 
@@ -77,7 +78,7 @@ public:
     virtual bool is_available() const = 0;
 
     /// Short identifier of the active backend ("user-notifications", "libnotify",
-    /// "winrt-toast", or "none"). Useful for diagnostics and host reports.
+    /// "winrt-toast-scaffold", or "none"). Useful for diagnostics and host reports.
     virtual std::string backend_id() const = 0;
 
     /// Ask the OS for permission to post notifications. The callback fires once


### PR DESCRIPTION
## Summary

- Corrects the public `PushNotifications` header so Windows is described as the current scaffold-only `winrt-toast-scaffold` backend.
- Aligns the documented diagnostic backend id with the implementation and tests.
- Leaves runtime behavior unchanged; this is a public-header documentation/truthfulness fix only.

## Evidence

- `core/events/platform/win/winrt_toast_backend.cpp` reports `backend_id() == "winrt-toast-scaffold"`, keeps `is_available() == false`, and returns `0` from `post_local_notification()` until full toast activator / AUMID integration exists.
- `test/test_push_notifications.cpp` already includes `winrt-toast-scaffold` in the allowed backend ids.
- The public header previously described Windows as a real `ToastNotificationManager` / WinRT activation backend and listed `"winrt-toast"` as the diagnostic id.

## Validation

Refreshed exact head: `35bbce81f1f8b893af62a05a0ef00bad37a833c6` on base `4b9f412f81b32ddabcb7d98193fb6b4f9a942f9b`.

- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/classify_changes.py --base origin/main --json` (`native_build_required=true`)
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD --pr-title "docs(events): clarify Windows notification scaffold"`
- `bash tools/scripts/gates.sh origin/main`
- `git merge-tree --write-tree origin/main HEAD` -> `94594e0dc8956806d58298ccf63a2f2b674514ae`
- Release configure: `cmake -S . -B build-ra-events -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON`
- Release build: `cmake --build build-ra-events --target pulp-test-push-notifications --parallel $(sysctl -n hw.ncpu)`
- Release flag proof: `CMAKE_BUILD_TYPE=Release`, `CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG`
- Direct test: `./build-ra-events/test/pulp-test-push-notifications --reporter compact` (`35` assertions / `4` cases)
- Focused CTest: `ctest --test-dir build-ra-events -R "push-notifications|PushNotifications" --output-on-failure` (`4/4`)

## Review

Strict local architecture/code-health review found no must-fix or should-fix-soon item: the diff changes only comments in one 114-line public header, matches existing backend/test behavior, changes no runtime/importer/rendering/layout/platform boundary, adds no abstraction, and introduces no file-size or ownership risk.

Claude second-opinion on the refreshed exact diff also found no must-fix or should-fix (`session_id=5bd7623e-6aa6-4664-a727-fa630cc67746`). Claude noted one optional non-blocking wording observation about the general header preamble, but explicitly said it was not worth a revision on its own.

## Notes

Local QEMU Windows ARM64 was considered but not used: this is a header-comment-only truthfulness fix, and QEMU ARM64 is additive smoke only, not replacement evidence for hosted Windows x64.
