### PR TITLE
docs(events): clarify IAP scaffold scope

### DIFF
--- a/core/events/include/pulp/events/in_app_purchase.hpp
+++ b/core/events/include/pulp/events/in_app_purchase.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-// pulp::events::IapClient — cross-platform in-app purchase surface.
+// pulp::events::IapClient — host-overridable in-app purchase seam.
+//
+// Pulp does not ship a production billing, marketplace, or entitlement
+// layer. This API gives hosts a small testable seam they can replace with
+// product-specific StoreKit / Microsoft Store / Play Billing code while the
+// built-in backend reports `Unavailable` everywhere.
 //
 // Supported operations:
 //   * Product lookup: `request_products(skus, callback)` resolves an SKU list
@@ -13,27 +18,21 @@
 //     whenever the backend resolves a purchase asynchronously (out-of-band
 //     transactions, subscription renewals, family-sharing grants).
 //
-// Not currently implemented by the built-in backends:
+// Not currently implemented by Pulp's built-in backend:
 //   * Real StoreKit2 wiring on Apple platforms (sandbox round-trip).
-//   * Microsoft Store SDK wiring on Windows (currently a runtime-dlopen
-//     scaffold that reports `Unavailable`).
+//   * Microsoft Store SDK / StoreContext wiring on Windows.
 //   * Google Play Billing on Android.
 //   * Server-side receipt validation helpers.
 //   * Subscription-specific surfaces (auto-renew status, grace periods,
 //     promotional offers).
 //
-// Backends (runtime-detected; build never hard-fails on a missing SDK):
-//   * macOS / iOS: `StoreKit` (StoreKit 2 when available, StoreKit 1 fallback).
-//     The built-in backend currently returns `Unavailable`; production
-//     StoreKit wiring stays host-owned so the framework remains MIT-clean and
-//     doesn't pull in any non-public Apple framework headers at configure
-//     time.
-//   * Linux: no IAP surface; `is_available()` returns false.
-//   * Windows: `Windows.Services.Store.StoreContext` via WinRT activation
-//     (runtime-LoadLibrary `combase.dll`). Scaffolded only — a real
-//     purchase flow requires MSIX packaging or a transient activator.
-//   * Other platforms / build configurations: `is_available()` returns
-//     false and every call reports `Unavailable` / empty result.
+// Built-in behavior:
+//   * All platforms default to the stub backend unless a host or test installs
+//     another `IapClient` with `install_iap_backend()`.
+//   * The stub returns `is_available() == false`, `backend_id() == "none"`,
+//     and every operation reports `Unavailable` / empty result.
+//   * Production billing stays host-owned so Pulp remains MIT-clean and avoids
+//     app-store-specific policy, packaging, and receipt-validation choices.
 
 #include <cstdint>
 #include <functional>
@@ -88,7 +87,7 @@ struct Purchase {
     std::string sku;            ///< Matches the SKU passed to `purchase()`.
     PurchaseState state = PurchaseState::Unknown;
     std::string transaction_id; ///< Backend-assigned transaction identifier.
-    std::string receipt;        ///< Opaque receipt bytes (StoreKit / WinRT / etc.).
+    std::string receipt;        ///< Opaque receipt bytes from a host backend, if any.
     std::string error;          ///< Empty unless `state == Failed`.
 };
 
@@ -100,10 +99,10 @@ using PurchaseObserver = std::function<void(const Purchase&)>;
 /// Cross-platform in-app purchase surface.
 ///
 /// Use the singleton via `IapClient::instance()`. The implementation is
-/// thread-safe: any thread may invoke any method, but callbacks are
-/// dispatched on a platform-defined thread (typically a StoreKit /
-/// WinRT delegate queue) — callers must hop back to their own UI
-/// thread if the callback touches view state.
+/// thread-safe: any thread may invoke any method. The built-in stub invokes
+/// callbacks synchronously; host backends may dispatch on their own platform
+/// queue, so callers must hop back to their UI thread before touching view
+/// state.
 class IapClient {
 public:
     static IapClient& instance();
@@ -114,8 +113,9 @@ public:
     /// On `false`, every method reports `Unavailable` and never charges.
     virtual bool is_available() const = 0;
 
-    /// Short identifier of the active backend ("storekit2", "winrt-store",
-    /// "test-mock", or "none"). Useful for diagnostics and host reports.
+    /// Short identifier of the active backend. Pulp's built-in backend reports
+    /// "none"; tests use "test-mock"; host backends should choose a stable
+    /// diagnostic id such as "storekit2", "winrt-store", or "play-billing".
     virtual std::string backend_id() const = 0;
 
     /// Ask the backend for metadata + localized pricing of the given SKUs.

--- a/core/events/src/in_app_purchase.cpp
+++ b/core/events/src/in_app_purchase.cpp
@@ -2,13 +2,12 @@
 //
 // This translation unit owns:
 //   * The shared `IapClient::instance()` accessor.
-//   * A `StubBackend` used when no platform backend is wired into the build
+//   * A `StubBackend` used when no host backend is installed
 //     so callers never crash on `instance().purchase(...)`.
 //
-// Platform backends register themselves through `install_iap_backend()`
-// from their own translation units (mac/ios/win/linux). They are linked
-// conditionally by the events CMakeLists.txt so a build on an OS without
-// a backend simply falls through to the stub.
+// Host or test backends register themselves through `install_iap_backend()`.
+// Pulp intentionally does not link a production StoreKit / Microsoft Store /
+// Play Billing backend, so the built-in path falls through to the stub.
 //
 // The stub deliberately keeps state machinery minimal — it doesn't
 // queue products or pretend to grant entitlements. Callers see
@@ -75,8 +74,7 @@ std::unique_ptr<IapClient>& instance_slot() {
 
 // Backends register themselves by calling this from a translation-unit
 // initializer (or a test installs a mock). Last writer wins so a host
-// application can override the default platform backend with a test
-// double.
+// application can override the default stub with a test double.
 void install_iap_backend(std::unique_ptr<IapClient> backend) {
     std::lock_guard lock(instance_mutex());
     instance_slot() = std::move(backend);

--- a/docs/policies/non-goals.md
+++ b/docs/policies/non-goals.md
@@ -26,9 +26,12 @@ live-stream ingest, and frame-level video effects are not in scope.
 
 ### In-app purchases, marketplace, product unlocking
 
-Pulp does not provide a built-in IAP / product-key / marketplace
-layer. Plugin developers who sell commercial products handle license
-validation through their own stack.
+Pulp does not provide a production IAP / product-key / marketplace
+layer. The `pulp::events::IapClient` API is only a host-overridable
+stub and mock seam: Pulp's built-in backend reports `Unavailable`
+everywhere and never performs a purchase. Plugin developers who sell
+commercial products handle billing and license validation through their
+own stack.
 
 - **Why:** App-store IAP and license-server integration are
   business-domain decisions (receipt format, fraud detection, refund

--- a/test/test_in_app_purchase.cpp
+++ b/test/test_in_app_purchase.cpp
@@ -5,10 +5,10 @@
 //   * Singleton returns a usable backend whose `backend_id()` matches
 //     one of the documented identifiers.
 //   * The default stub returns false from `is_available()` on builds
-//     without a real backend, and every operation reports `Unavailable`
+//     without a host backend, and every operation reports `Unavailable`
 //     synchronously without charging.
 //   * A test-double backend installed through the same registration
-//     hook real backends use can intercept product lookups, purchases,
+//     hook host backends use can intercept product lookups, purchases,
 //     restore, observer notification, and finish_transaction end-to-end.
 
 #include <pulp/events/in_app_purchase.hpp>
@@ -25,7 +25,7 @@
 
 namespace pulp::events {
 // Defined in src/in_app_purchase.cpp — exposed here so tests can install
-// a mock backend in place of the stub / real platform backend.
+// a mock backend in place of the built-in stub.
 void install_iap_backend(std::unique_ptr<IapClient>);
 } // namespace pulp::events
 
@@ -157,12 +157,11 @@ TEST_CASE("IapClient singleton is always available", "[in-app-purchase]") {
     auto& iap = IapClient::instance();
     REQUIRE_FALSE(iap.backend_id().empty());
 
-    // Documented backend identifiers — keep this list synced with the
-    // header comment in in_app_purchase.hpp.
+    // Built-in/test backend identifiers — keep this list synced with the
+    // current repo-provided backends. Host-specific billing backends should
+    // update this smoke test when they become part of Pulp.
     const std::vector<std::string> known = {
         "none",
-        "storekit2",
-        "winrt-store",
         "test-mock",
     };
     bool matched = false;
@@ -181,10 +180,10 @@ TEST_CASE("IapClient stub backend reports unavailable", "[in-app-purchase]") {
 
     auto& iap = IapClient::instance();
     if (iap.backend_id() != "none") {
-        // Real platform backend got installed via static initializer —
-        // skip the stub-specific assertions. The mock-backend case below
-        // still covers the API contract end-to-end.
-        SUCCEED("Platform backend installed; stub path not exercised here.");
+        // A host/test backend got installed via static initializer — skip the
+        // stub-specific assertions. The mock-backend case below still covers
+        // the API contract end-to-end.
+        SUCCEED("Non-stub backend installed; stub path not exercised here.");
         return;
     }
 


### PR DESCRIPTION
## Summary

- Clarifies `IapClient` as a host-overridable stub/mock seam, not a production billing or entitlement layer shipped by Pulp.
- Aligns the non-goals policy with the shipped `IapClient` scaffold: built-in behavior returns `Unavailable` everywhere and never performs a purchase.
- Narrows the smoke test's built-in backend-id list to current repo-provided ids (`none`, `test-mock`) so tests do not imply missing StoreKit / Microsoft Store / Play Billing backends are present.

## Evidence

- `docs/policies/non-goals.md` said Pulp does not provide a built-in IAP / product-key / marketplace layer.
- `core/events/include/pulp/events/in_app_purchase.hpp`, `core/events/src/in_app_purchase.cpp`, and `test/test_in_app_purchase.cpp` shipped a stubbed `IapClient` seam but still used wording that could read as a cross-platform production billing/backend surface.
- `core/events/CMakeLists.txt` wires only the shared stub source for IAP; there are no built-in StoreKit, Microsoft Store, or Play Billing backend sources in `core/events/platform/`.

## Validation

- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py docs/policies/non-goals.md`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `bash tools/check-docs.sh` (passed with existing `109` warnings)
- `tools/scripts/gates.sh origin/main`
- Release configure: `cmake -S . -B build-ra-iap -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON`
- Release build: `cmake --build build-ra-iap --target pulp-test-in-app-purchase --parallel $(sysctl -n hw.ncpu)`
- Release flag proof: `CMAKE_BUILD_TYPE=Release`, `-O3 -DNDEBUG` for `pulp-test-in-app-purchase` and `pulp-events`
- Direct test: `./build-ra-iap/test/pulp-test-in-app-purchase --reporter compact` (`43` assertions / `4` cases)
- Focused CTest: `ctest --test-dir build-ra-iap -R 'in-app-purchase|IapClient' --output-on-failure` (`4/4`)
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=true`)
- `git merge-tree --write-tree origin/main HEAD`
- Push pre-push fast gates passed with `PULP_SKIP_DIFF_COVER=1`; hook ran the fast gates plus its 29-test helper suite.

## Review

Strict local architecture/code-health review found no must-fix or should-fix-soon item: four-file docs/comment/test-expectation cleanup, no runtime/importer/rendering/layout/platform behavior change, no new abstraction, no file-size or ownership risk, and real billing remains explicitly deferred/host-owned.

Claude second-opinion bridge was attempted with a bounded wrapper but local Claude is not logged in (`Not logged in · Please run /login`), so no substantive Claude finding is claimed.

## Notes

- The commit includes an explicit `Version-Bump: sdk=skip` trailer because this touches a public header but changes comments only; no API or behavior changes.
- Local QEMU Windows ARM64 was considered but not used: this slice does not implement Windows billing behavior, and QEMU ARM64 is additive smoke only, not replacement evidence for hosted Windows x64.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `pulp::events::IapClient` is a host-overridable stub, not a production billing/entitlement layer. Updates policy docs, header comments, and tests to reflect that the built-in backend always reports Unavailable (`is_available() == false`, `backend_id() == "none"`), and narrows the smoke test to repo-provided backends (`none`, `test-mock`).

<sup>Written for commit 57291b1ded8d851b279b0793f59c381fc6e4da2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

