### PR TITLE
fix(mcp): pulp_audio_render temp-dir leak + opaque-error hardening

### DIFF
--- a/core/format/include/pulp/format/detail/standalone_environment.hpp
+++ b/core/format/include/pulp/format/detail/standalone_environment.hpp
@@ -120,8 +120,9 @@ inline StandaloneConfig standalone_config_from_environment(StandaloneConfig conf
         } else if (*fmt == "float") {
             config.audio_capture_rolling_int24 = false;
         } else {
-            // Match the CLI flag's strictness: an unrecognized value is a
-            // mistake, not a silent fall-through to float.
+            // Unlike the CLI flag (which hard-rejects), an env var can't fail the
+            // launch — so warn loudly and default to float rather than silently
+            // swallowing what is almost certainly a typo.
             runtime::log_warn(
                 "Standalone: PULP_AUDIO_CAPTURE_ROLLING_FORMAT='{}' unrecognized "
                 "(expected 'float' or 'int24'); using float",

--- a/tools/mcp/mcp_tools.cpp
+++ b/tools/mcp/mcp_tools.cpp
@@ -973,49 +973,42 @@ std::string handle_audio_render(const std::string& params_json) {
         return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: plugin must be a bundle path, not an option\"}]}";
     }
 
+    auto out = extract_string(params_json, "out");
+    if (!out.empty() && out.front() == '-') {
+        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: out must be a file path, not an option\"}]}";
+    }
+
     auto has = [&](const char* key) {
         auto raw = extract_raw(params_json, key);
         return !raw.empty() && raw != "null";
     };
+    auto arg_error = [](const std::string& msg) {
+        return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(msg) + "}]}";
+    };
+
+    // ── Validate every argument BEFORE creating any temp dir, so an early
+    //    rejection can't leak one. The command flags are accumulated here. ──
+    std::string flags;
 
     // Exactly one duration source (mirrors the CLI's mutually-exclusive contract).
     const bool has_ms = has("duration_ms");
     const bool has_frames = has("duration_frames");
     if (has_ms == has_frames) {
-        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: pass exactly one of duration_ms / duration_frames\"}]}";
+        return arg_error("Error: pass exactly one of duration_ms / duration_frames");
     }
-
-    std::string cmd = shell_quote(source_build_cli_path(root).string()) + " audio render";
-    cmd += " --plugin " + shell_quote(plugin);
-
-    // Output WAV: honor an explicit `out` (kept); otherwise render into a private
-    // temp dir we clean up — the metrics JSON is the return value either way.
-    std::string temp_error;
-    fs::path temp_dir;
-    auto out = extract_string(params_json, "out");
-    if (out.empty()) {
-        auto temp = make_private_probe_json_temp(temp_error);
-        if (temp.json_path.empty()) {
-            return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string("Error: " + temp_error) + "}]}";
-        }
-        temp_dir = temp.directory;
-        out = (temp.directory / "render.wav").string();
-    }
-    cmd += " --out " + shell_quote(out);
-
     if (has_ms) {
         int ms = extract_int(params_json, "duration_ms", -1);
-        if (ms <= 0) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: duration_ms must be a positive integer\"}]}";
-        cmd += " --duration-ms " + std::to_string(ms);
+        if (ms <= 0) return arg_error("Error: duration_ms must be a positive integer");
+        flags += " --duration-ms " + std::to_string(ms);
     } else {
         int fr = extract_int(params_json, "duration_frames", -1);
-        if (fr <= 0) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: duration_frames must be a positive integer\"}]}";
-        cmd += " --duration-frames " + std::to_string(fr);
+        if (fr <= 0) return arg_error("Error: duration_frames must be a positive integer");
+        flags += " --duration-frames " + std::to_string(fr);
     }
 
     auto add_str = [&](const char* key, const char* flag) {
         auto v = extract_string(params_json, key);
-        if (!v.empty()) cmd += std::string(" ") + flag + " " + shell_quote(v);
+        if (!v.empty()) flags += std::string(" ") + flag + " " + shell_quote(v);
     };
     add_str("format", "--format");
     add_str("id", "--id");
@@ -1028,44 +1021,60 @@ std::string handle_audio_render(const std::string& params_json) {
         if (has(key)) {
             int v = extract_int(params_json, key, min_value - 1);
             if (v < min_value)
-                return std::string("Error: ") + key + " must be >= " + std::to_string(min_value);
-            cmd += std::string(" ") + flag + " " + std::to_string(v);
+                return std::string("Error: ") + key + " must be an integer >= " + std::to_string(min_value);
+            flags += std::string(" ") + flag + " " + std::to_string(v);
         }
         return {};
     };
     for (auto err : {add_int("block", "--block", 1),
                      add_int("in_channels", "--in-channels", 0),
                      add_int("out_channels", "--out-channels", 1)}) {
-        if (!err.empty()) {
-            if (!temp_dir.empty()) { std::error_code ec; fs::remove_all(temp_dir, ec); }
-            return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(err) + "}]}";
-        }
+        if (!err.empty()) return arg_error(err);
     }
     if (has("sample_rate")) {
         double sr = extract_double(params_json, "sample_rate", -1.0);
-        if (sr <= 0.0) {
-            if (!temp_dir.empty()) { std::error_code ec; fs::remove_all(temp_dir, ec); }
-            return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: sample_rate must be positive\"}]}";
-        }
-        cmd += " --sample-rate " + std::to_string(sr);
+        if (sr <= 0.0) return arg_error("Error: sample_rate must be positive");
+        flags += " --sample-rate " + std::to_string(sr);
     }
 
-    // --json prints the metrics manifest to stdout; stderr (plugin logs, objc
-    // warnings) is dropped so stdout is clean JSON.
-    cmd += " --json 2>/dev/null";
+    // ── All args valid. Now make a private temp dir (for the metrics manifest,
+    //    and the WAV when `out` is omitted); it is cleaned on every exit below. ──
+    std::string temp_error;
+    auto temp = make_private_probe_json_temp(temp_error);
+    if (temp.json_path.empty()) {
+        return arg_error("Error: " + temp_error);
+    }
+    const fs::path temp_dir = temp.directory;
+    if (out.empty()) out = (temp_dir / "render.wav").string();
+    const auto manifest_path = (temp_dir / "metrics.json").string();
+
+    std::string cmd = shell_quote(source_build_cli_path(root).string()) + " audio render";
+    cmd += " --plugin " + shell_quote(plugin);
+    cmd += " --out " + shell_quote(out);
+    cmd += " --manifest " + shell_quote(manifest_path);
+    cmd += flags;
+    // Read the manifest from a FILE (like audio scope) so stderr — plugin load /
+    // prepare / write failures, objc warnings — can be captured via 2>&1 and
+    // surfaced on failure instead of corrupting the JSON or vanishing.
+    cmd += " 2>&1";
     auto output = exec(cmd);
 
-    if (!temp_dir.empty()) {
-        std::error_code ec;
-        fs::remove_all(temp_dir, ec);
+    auto manifest_json = read_text_file(manifest_path);
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+
+    if (manifest_json.empty()) {
+        std::string message = "Error: pulp audio render did not write a metrics manifest";
+        if (!output.empty()) message += "\n" + output;
+        return arg_error(message);
     }
 
     std::string normalized_json;
     std::string parse_error;
-    if (!normalize_structured_json(output, normalized_json, parse_error)) {
-        std::string message = "Error: pulp audio render did not return metrics JSON: "
-                            + parse_error + "\n" + output;
-        return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(message) + "}]}";
+    if (!normalize_structured_json(manifest_json, normalized_json, parse_error)) {
+        std::string message = "Error: " + parse_error + "\n" + manifest_json;
+        if (!output.empty()) message += "\n" + output;
+        return arg_error(message);
     }
     return json_tool_payload(normalized_json);
 }


### PR DESCRIPTION
Final-adversarial-review fixes for the `pulp_audio_render` MCP handler (added in #5122).

## MUST-FIX — temp-dir leak
A non-positive / non-integer `duration_ms`/`duration_frames` returned **after** the temp dir was created, leaking a temp directory on every bad call (reachable from untrusted MCP args). Restructured so **all** argument validation runs before any temp dir exists — flags are accumulated into a string first, then a single temp dir is created and unconditionally cleaned on every exit.

## SHOULD-FIX — opaque errors
The handler read the manifest from stdout with `2>/dev/null`, so a plugin load / prepare / write failure produced an opaque "did not return metrics JSON". It now writes the manifest to a file via `--manifest` and runs with `2>&1` (mirroring `handle_audio_scope`), so the **real** error surfaces.

**Before:** `Error: pulp audio render did not return metrics JSON`
**After:** `Error: ... CLAP load: dlopen failed for '/nonexistent/foo.clap': ...`

## SHOULD-FIX — `out` guard
`out` now gets the same leading-`-` guard as `plugin` (defensive parity; it was already shell-quoted, so not an injection).

## Comment fix
The `PULP_AUDIO_CAPTURE_ROLLING_FORMAT` env note no longer claims it "matches the CLI flag's strictness" — it warns-and-defaults (an env var can't fail the launch), which the comment now states accurately.

## Verification
End-to-end via JSON-RPC: normal render returns metrics (−6 dBFS sine → −6 peak) through the manifest path; a missing bundle surfaces the real `dlopen failed` error. MCP suite green (55 cases). Shell-quoting confirmed complete by the review (no injection). `Version-Bump: skip` — internal MCP tooling, no released SDK/plugin surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a temp-dir leak and improves error reporting in the MCP audio render handler. Adds a small safety check for the `out` path and clarifies an environment variable comment.

- **Bug Fixes**
  - Validate all args before creating any temp dir; always clean it to prevent leaks on invalid `duration_ms`/`duration_frames`.
  - Write the metrics manifest to a file via `--manifest` and run with `2>&1`, so plugin load/prepare/write failures surface instead of the opaque “did not return metrics JSON”.
  - Guard `out` against leading `-` (parity with `plugin`) to avoid option-style inputs.
  - Update `PULP_AUDIO_CAPTURE_ROLLING_FORMAT` comment to warn-and-default (env var can’t fail launch) instead of claiming CLI-level strictness.

<sup>Written for commit e108cfa32c513e405ca27757bb71fd0434bb2521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

