### PR TITLE
docs(view): align ContentSharer API comment

### DIFF
--- a/core/view/include/pulp/view/file_browser.hpp
+++ b/core/view/include/pulp/view/file_browser.hpp
@@ -88,14 +88,18 @@ private:
     std::vector<FileTreeNode> nodes_;
 };
 
-/// Content sharer — platform-native share sheet for files/text.
-/// On macOS: NSSharingServicePicker. On other platforms: stub.
+/// Content opener for files and text.
+/// Current backends launch the platform's default opener where available:
+/// macOS uses `/usr/bin/open`, Windows uses `ShellExecuteW`, and Linux uses
+/// `xdg-open`. Text opening is implemented on macOS by writing a temporary
+/// file and opening it. Android paths and unsupported text paths are currently
+/// no-ops.
 class ContentSharer {
 public:
-    /// Share a file via the system share sheet.
+    /// Open a file with the platform's default opener when supported.
     static void share_file(const std::filesystem::path& file, void* parent_window = nullptr);
 
-    /// Share text via the system share sheet.
+    /// Open text through a temporary file on supported platforms.
     static void share_text(const std::string& text, void* parent_window = nullptr);
 };
 


### PR DESCRIPTION
## Summary
- Replace the false `NSSharingServicePicker` / share-sheet comment on `ContentSharer` with current implementation reality.
- Document the default-opener backends: macOS `/usr/bin/open`, Windows `ShellExecuteW`, Linux `xdg-open`, macOS text temp-file opening, and current no-op paths.
- Leave behavior unchanged.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --pr-title "docs(view): align ContentSharer API comment"`
- `tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/classify_changes.py --mode diff --base origin/main --json` (`native_build_required=true` for public header input)
- `cmake --build build --target pulp-view-core --parallel 8`
- `git merge-tree --write-tree origin/main HEAD`
- Pre-push fast gates passed with `PULP_SKIP_DIFF_COVER=1`.

Validation note: I also attempted to build/run `pulp-test-file-browser` in the Release/no-GPU tree, but the executable link failed on pre-existing `PulpGpuPluginView` linkage from `drag_drop_mac.mm` after the core libraries built. This PR is comment-only and does not affect linkage; the failure should be tracked separately.

## Adversarial review
- Local architecture/code-health review: no must-fix or should-fix for this diff. One small public header comment changed; no runtime/importer/rendering/layout/platform boundaries, state flow, abstractions, or helper modules changed.
- Claude adversarial review initially flagged invented `host-provided share bridge` wording and a size implication; both were removed before push. Final Claude verdict: no must-fix, ship it. Follow-up only: `ContentSharer::share_*` is now honestly documented as default-opener behavior, but the public API name remains a longer-term misnomer to consider separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `ContentSharer` docs with actual behavior: it opens files/text with the platform’s default handler, not a share sheet. Documents macOS `/usr/bin/open`, Windows `ShellExecuteW`, Linux `xdg-open`, macOS temp-file for text, and notes no-ops on unsupported paths; no behavior change.

<sup>Written for commit b2a4f656d0afa758ccb4c5e62aef8ec709830ca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

