### PR TITLE
docs(view): clarify context menu selection status

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -296,7 +296,7 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | UIA accessibility | partial | Windows | Role map only; provider pending (production-readiness 04) |
 | AT-SPI accessibility | partial | Linux | Role map only; D-Bus registration pending (production-readiness 04) |
 | IME composition (marked text) | usable | macOS | Full NSTextInputClient |
-| Right-click context menu | usable | macOS | on_context_menu + PopupMenu |
+| Right-click context menu | partial | all | on_context_menu/registerContextMenu fire; view-tree ContextMenu is actionable; native showContextMenu currently renders only on macOS and does not report selection |
 | Keyboard shortcuts | usable | all | registerShortcut bridge |
 | File dialogs (open, save, folder) | usable | macOS | NSOpenPanel/NSSavePanel |
 | Drag and drop | usable | macOS | File + text drop targets |

--- a/docs/reference/js-bridge.md
+++ b/docs/reference/js-bridge.md
@@ -410,7 +410,9 @@ measureText(text, fontSize)       // Returns { width, ascent, descent, lineHeigh
 ```js
 // Context menus
 registerContextMenu(id, callbackName) // Register right-click handler: callbackName(x, y)
-showContextMenu(itemsJSON, x, y)      // Show native popup menu, returns selected id or -1
+showContextMenu(itemsJSON, x, y)      // Request platform popup menu; returns selected id only
+                                      // when the backend reports one, otherwise -1.
+                                      // Current in-tree backends do not report selection.
                                       // itemsJSON: '[{"id":1,"label":"Cut"},{"separator":true}]'
 
 // Keyboard shortcuts

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -567,8 +567,13 @@ platform_maturity:
     platform: macos
     notes: Full NSTextInputClient — setMarkedText, unmarkText, firstRectForCharacterRange for candidate window positioning.
   context_menu:
-    status: usable
-    notes: on_context_menu callback on View, rightMouseDown dispatch, showContextMenu/registerContextMenu bridge.
+    status: partial
+    notes: >-
+      on_context_menu callback, rightMouseDown dispatch, and view-tree
+      ContextMenu actions are usable. registerContextMenu dispatches coordinates
+      to JS; showContextMenu delegates to platform PopupMenu but current in-tree
+      backends return -1/no selection because native item selection is not wired
+      through the bridge yet.
   keyboard_shortcuts:
     status: usable
     notes: registerShortcut bridge function, shortcuts checked before global key dispatch.


### PR DESCRIPTION
## Summary
- Downgrade platform context-menu status from `usable` to `partial` where the docs were implying native `showContextMenu` can report selected ids.
- Clarify that `registerContextMenu` / `on_context_menu` and view-tree `ContextMenu` actions are usable, while native `showContextMenu` currently returns `-1` because in-tree `PopupMenu` backends do not report selection.
- Leave runtime behavior unchanged.

## Source evidence
- `WidgetBridge::showContextMenu` returns `result.value_or(-1)`.
- macOS `PopupMenu::show` creates `NSMenuItem`s with `action:nil` and returns `std::nullopt`.
- iOS/non-mac `PopupMenu` stubs return `std::nullopt`.
- View-tree `ContextMenu` is separately implemented and tested.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/scripts/docs_noise_lint.py docs/reference/js-bridge.md docs/status/support-matrix.yaml docs/reference/capabilities.md`
- `python3 tools/check_status_ladder.py --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --pr-title "docs(view): clarify context menu selection status"`
- `tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/classify_changes.py --mode diff --base origin/main --json` (`native_build_required=false`)
- `git merge-tree --write-tree origin/main HEAD`
- Pre-push fast gates passed with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1`.

## Adversarial review
- Local architecture/code-health review: no runtime/importer/rendering/layout/platform code changed, no API/state/helper/abstraction change, and the only >1k touched file is the pre-existing support matrix.
- Claude adversarial review found one platform-column wording issue in `capabilities.md`; fixed before push. Final Claude follow-up: no must-fix, ship.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified context menu docs to reflect current behavior. Downgraded support to `partial`, documented that `showContextMenu` often returns `-1` (selection not wired; renders only on macOS), and confirmed `registerContextMenu`/`on_context_menu` and view-tree `ContextMenu` are usable.

<sup>Written for commit 19dd81733b90a42b5af758168e33c0e9e99077c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

