### PR TITLE
ci: keep workflow_dispatch builds example-free

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -609,10 +609,12 @@ signed/notarized `.dmg`, so the version and asset metadata must move together.
   workflow only needs the PulpEffect AU/VST3/CLAP bundles, not GPU examples
   such as `pulp-design-tool`.
 - **Build-and-Test workflow_dispatch is Shipyard PR validation.** Preserve
-  `-DPULP_ENABLE_GPU=OFF` on the workflow_dispatch configure path in
-  `.github/workflows/build.yml`: the local self-hosted macOS runner may not
-  have the pinned Skia archive, while pull_request validation already disables
-  example bundles and release workflows own GPU/SDK coverage.
+  `-DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF` on the
+  workflow_dispatch configure path in `.github/workflows/build.yml`: the local
+  self-hosted macOS runner may not have the pinned Skia archive, and no-GPU
+  dispatches must not link example bundles that require the GPU plugin view
+  host. Pull-request validation also disables example bundles, while nightly /
+  release workflows own full example/product and GPU coverage.
   When adding optional shell arguments in `build.yml` (for example macOS-only
   `-G Ninja`), use bash arrays and expand them as `"${args[@]}"`; scalar
   `$args` trips actionlint/shellcheck word-splitting checks.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.267.2",
+      "version": "0.267.3",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.267.2"
+  "version": "0.267.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.267.2",
+  "version": "0.267.3",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -739,18 +739,19 @@ jobs:
           fi
 
       - name: Configure
-        # On pull_request events, skip the examples tree
+        # On PR and Shipyard workflow_dispatch validation, skip the examples tree
         # (PulpDrums / PulpSynth / PulpMpeSynth / PulpPluck /
         # AraPitchTracker × VST3/AU/CLAP format variants — the heavy
         # build targets). Core tests still build + run; example-local
         # tests registered from examples/*/CMakeLists.txt are deferred
-        # with the plugin product bundles. Trades ~10-20 min per PR for
-        # the nightly / workflow_dispatch validation that examples still
-        # compile.
-        # On workflow_dispatch, Shipyard PR validation keeps examples
-        # enabled but disables GPU-only targets: the self-hosted macOS
-        # runner does not carry the pinned Skia archive, and GPU release
-        # coverage lives in the release workflow.
+        # with the plugin product bundles. Trades ~10-20 min per PR/ship
+        # dispatch for the nightly / release lanes that still compile the
+        # example/product bundles.
+        # On workflow_dispatch, Shipyard PR validation also disables GPU:
+        # the self-hosted macOS runner may not carry the pinned Skia archive,
+        # and GPU release coverage lives in the release workflow. Keep
+        # examples OFF there too so no-GPU validation does not link example
+        # bundles that require the GPU plugin view host.
         run: |
           set -euo pipefail
           # macOS builds with Ninja — it schedules parallelism more
@@ -792,11 +793,11 @@ jobs:
             # reliably on GitHub-hosted Windows runners.
             cmake_extra=(-DFETCHCONTENT_BASE_DIR="$PWD/fc")
           fi
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF
-          else
-            cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF
+          cmake_args=(-DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            cmake_args+=(-DPULP_ENABLE_GPU=OFF)
           fi
+          cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} "${cmake_args[@]}"
           # Mark the build in-progress; the Build step clears it on success, so a
           # build interrupted/cancelled before completion is detected next run
           # (ODR guard above). Harmless on github-hosted (fresh dir each run).

--- a/tools/scripts/test_workflow_build_dirs.py
+++ b/tools/scripts/test_workflow_build_dirs.py
@@ -59,6 +59,24 @@ class WorkflowBuildDirTests(unittest.TestCase):
             text,
         )
 
+    def test_build_workflow_shipyard_dispatch_skips_examples_with_gpu_off(self) -> None:
+        text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "cmake_args=(-DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF)",
+            text,
+        )
+        self.assertIn(
+            """if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            cmake_args+=(-DPULP_ENABLE_GPU=OFF)
+          fi""",
+            text,
+        )
+        self.assertIn(
+            'cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} "${cmake_args[@]}"',
+            text,
+        )
+
     def test_sanitizer_jobs_use_distinct_build_dirs(self) -> None:
         text = SANITIZERS_WORKFLOW.read_text(encoding="utf-8")
 
@@ -100,7 +118,7 @@ class MacosNinjaGeneratorTests(unittest.TestCase):
         self.assertIn("gen=()", self.text)
         self.assertIn("gen=(-G Ninja)", self.text)
         self.assertIn(
-            'cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} -DCMAKE_BUILD_TYPE=Release',
+            'cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} "${cmake_args[@]}"',
             self.text,
         )
 
@@ -110,7 +128,7 @@ class MacosNinjaGeneratorTests(unittest.TestCase):
         self.assertIn('if [ "${RUNNER_OS}" = "Windows" ]; then', self.text)
         self.assertIn('cmake_extra=(-DFETCHCONTENT_BASE_DIR="$PWD/fc")', self.text)
         self.assertIn(
-            'cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} -DCMAKE_BUILD_TYPE=Release',
+            'cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" ${cmake_extra[@]+"${cmake_extra[@]}"} "${cmake_args[@]}"',
             self.text,
         )
 


### PR DESCRIPTION
## Summary

- Keep Build-and-Test `workflow_dispatch` validation example-free while preserving the no-GPU dispatch path Shipyard uses.
- Collapse the duplicated Configure-step CMake invocation into a single `cmake_args` path so PR and dispatch validation cannot drift again.
- Add a workflow invariant test and update the CI skill with the no-GPU dispatch/examples-off contract.

## Evidence

Shipyard validation for #5153 failed on a `workflow_dispatch` run because `build.yml` set `-DPULP_ENABLE_GPU=OFF` for dispatch validation while leaving examples enabled. That combination let example/plugin bundles link against GPU view host symbols that are intentionally absent in a no-GPU build, producing `_OBJC_CLASS_$_PulpGpuPluginView` link failures.

PR validation already disables examples. This patch makes Shipyard dispatch validation follow the same examples-off shape, then appends GPU-off only for `workflow_dispatch`.

## Validation

- `python3 tools/scripts/test_workflow_build_dirs.py` (`9` tests)
- `git diff --check origin/main...HEAD`
- `tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --pr-title 'ci: keep workflow_dispatch builds example-free'`
- `python3 tools/scripts/docs_noise_lint.py --base origin/main --head HEAD .github/workflows/build.yml .agents/skills/ci/SKILL.md tools/scripts/test_workflow_build_dirs.py .claude-plugin/plugin.json .claude-plugin/marketplace.json`
- `actionlint -shellcheck= .github/workflows/build.yml`
- `yamllint -d relaxed .github/workflows/build.yml` (warnings were pre-existing line-length warnings)
- Pre-push fast gates with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1`

## Review

Strict local architecture/code-health review found no must-fix: the diff is limited to workflow/test/skill/plugin-version metadata, removes a drift-prone duplicated Configure branch, adds no runtime/importer/rendering/layout/platform coupling, and the only >1k touched files are pre-existing workflow/skill surfaces.

## Notes

`shipyard pr --base main --skip-target ubuntu --skip-target windows` was attempted first. Shipyard applied the plugin version bump, then stopped before PR creation because the local `mac` cloud target currently fails `gh auth status`. This PR was therefore opened through the supervised GitHub connector fallback after Shipyard's version/skill gates and the local fast gates passed.

Local QEMU Windows ARM64 is not useful evidence for this workflow-structure fix; hosted PR checks remain the authoritative cross-platform signal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Build-and-Test `workflow_dispatch` runs example-free and GPU-off to match PR validation and prevent `_OBJC_CLASS_$_PulpGpuPluginView` link errors. Consolidates Configure into a single `cmake_args` path, adds invariant tests, and bumps `pulp` plugin metadata to `0.267.3`.

- **Bug Fixes**
  - `workflow_dispatch` now sets `-DPULP_BUILD_EXAMPLES=OFF` and appends `-DPULP_ENABLE_GPU=OFF`, aligning with PR validation and avoiding no-GPU example links.
  - CI skill doc updated to reflect the examples-off + GPU-off dispatch contract.

- **Refactors**
  - Replaced duplicated CMake Configure branches with one `cmake_args` path; workflow tests assert the args and final `cmake` invocation in `build.yml`.

<sup>Written for commit 7d27120a9a88e2a76c03c40faae6d978d7ca83d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

