### PR TITLE
test(format): make rolling WAV env test portable

### DIFF
--- a/test/test_standalone_audio_capture_rolling_wav.cpp
+++ b/test/test_standalone_audio_capture_rolling_wav.cpp
@@ -18,11 +18,39 @@
 #include <filesystem>
 #include <cstdlib>
 #include <functional>
+#include <string>
 #include <vector>
 
 namespace {
 
 namespace fs = std::filesystem;
+
+void set_rolling_format_env(const char* value) {
+#if defined(_WIN32)
+    _putenv_s("PULP_AUDIO_CAPTURE_ROLLING_FORMAT", value ? value : "");
+#else
+    if (value) ::setenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT", value, 1);
+    else ::unsetenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT");
+#endif
+}
+
+class ScopedRollingFormatEnv {
+public:
+    ScopedRollingFormatEnv() {
+        if (const char* value = std::getenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT")) {
+            had_value_ = true;
+            old_value_ = value;
+        }
+    }
+
+    ~ScopedRollingFormatEnv() {
+        set_rolling_format_env(had_value_ ? old_value_.c_str() : nullptr);
+    }
+
+private:
+    bool had_value_ = false;
+    std::string old_value_;
+};
 
 // Append one block of a per-channel, absolute-frame ramp to the rolling buffer.
 void append_block(pulp::audio::RollingAudioCaptureBuffer& rolling, int channels,
@@ -178,9 +206,9 @@ TEST_CASE("rolling capture WAV with an empty path or unprepared buffer is a no-o
 
 TEST_CASE("PULP_AUDIO_CAPTURE_ROLLING_FORMAT env parses int24/float and ignores junk",
           "[standalone][audio-capture-rolling]") {
+    ScopedRollingFormatEnv env_guard;
     auto parse = [](const char* value) {
-        if (value) ::setenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT", value, 1);
-        else ::unsetenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT");
+        set_rolling_format_env(value);
         pulp::format::StandaloneConfig cfg;
         cfg = pulp::format::detail::standalone_config_from_environment(cfg);
         return cfg.audio_capture_rolling_int24;
@@ -191,7 +219,6 @@ TEST_CASE("PULP_AUDIO_CAPTURE_ROLLING_FORMAT env parses int24/float and ignores 
     CHECK(parse("int32") == false);
     CHECK(parse("INT24") == false);
     CHECK(parse(nullptr) == false);  // unset → default float
-    ::unsetenv("PULP_AUDIO_CAPTURE_ROLLING_FORMAT");
 }
 
 #if PULP_ENABLE_AUDIO_PROBES


### PR DESCRIPTION
## Summary
- Replaces POSIX-only `::setenv` / `::unsetenv` calls in the rolling WAV env parser test with a test-local cross-platform helper.
- Uses `_putenv_s` on Windows and restores the prior `PULP_AUDIO_CAPTURE_ROLLING_FORMAT` value after the test.
- Keeps the fix scoped to the one test that was breaking MSVC compile; no runtime behavior changes.

## Validation
- `git diff --check origin/main..HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `dd9c30bbb47609bc1658a0447a507b01469fd61a`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --pr-title 'test(format): make rolling WAV env test portable'`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build-nogpu -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build-nogpu --target pulp-test-standalone-audio-capture-rolling-wav --parallel 8`
- `./build-nogpu/test/pulp-test-standalone-audio-capture-rolling-wav --reporter compact` -> `27` assertions / `6` test cases
- `ctest --test-dir build-nogpu -R 'rolling capture|PULP_AUDIO_CAPTURE_ROLLING_FORMAT|rolling-capture-only' --output-on-failure` -> `6/6`

## Adversarial Review
- Must-fix before PR: none found.
- Should-fix soon: none found.
- Acceptable for now: helper stays test-local because only this test needs this exact env var, avoiding a new shared test utility surface.
- Claude bridge second opinion was attempted but unavailable locally: `Not logged in`.
- Local Windows QEMU ARM64 was considered but not used because hosted Windows x64 is the authoritative proof for the original MSVC compile failure.
