### PR TITLE
fix(cli): honor create projects directory settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.528.0
+    VERSION 0.528.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/experimental/pulp-rs/src/cmd/create.rs
+++ b/experimental/pulp-rs/src/cmd/create.rs
@@ -51,6 +51,7 @@ use std::path::{Component, Path, PathBuf};
 
 use rand::RngCore;
 
+use super::create_paths;
 use crate::error::{CliError, Result};
 
 /// Parsed argument surface for `pulp-rs create`.
@@ -403,6 +404,15 @@ fn path_is_within(path: &Path, root: &Path) -> bool {
 /// or when the output path collides with an existing directory or violates
 /// create's standalone/in-tree containment policy.
 pub fn resolve_out_dir(args: &CreateArgs, root: Option<&Path>, cwd: &Path) -> Result<PathBuf> {
+    resolve_out_dir_with_projects_base(args, root, cwd, None)
+}
+
+fn resolve_out_dir_with_projects_base(
+    args: &CreateArgs,
+    root: Option<&Path>,
+    cwd: &Path,
+    projects_base: Option<&Path>,
+) -> Result<PathBuf> {
     let lower = to_lower_name(&args.name);
     let out_dir = if let Some(o) = args.output.as_deref() {
         if o.is_absolute() {
@@ -418,12 +428,15 @@ pub fn resolve_out_dir(args: &CreateArgs, root: Option<&Path>, cwd: &Path) -> Re
         };
         root.join("examples").join(&lower)
     } else {
-        // Standalone default: alongside the Pulp repo root when known,
-        // otherwise cwd. Matches C++ `resolve_create_projects_base_dir`
-        // collapsed to the common case.
-        let base = root
-            .and_then(Path::parent)
-            .map_or_else(|| cwd.to_path_buf(), Path::to_path_buf);
+        // Standalone default: explicit user projects base when configured,
+        // then alongside the Pulp repo root when known, otherwise cwd.
+        let base = projects_base.map_or_else(
+            || {
+                root.and_then(Path::parent)
+                    .map_or_else(|| cwd.to_path_buf(), Path::to_path_buf)
+            },
+            Path::to_path_buf,
+        );
         base.join(&lower)
     };
 
@@ -831,7 +844,13 @@ pub fn run(cwd: &Path, args: &CreateArgs, out: &mut impl Write) -> Result<i32> {
         }
     };
 
-    let out_dir = resolve_out_dir(args, project_root.as_deref(), cwd)?;
+    let projects_base = create_paths::configured_projects_base_dir(cwd);
+    let out_dir = resolve_out_dir_with_projects_base(
+        args,
+        project_root.as_deref(),
+        cwd,
+        projects_base.as_deref(),
+    )?;
     if args.pin_sdk || args.debug_build {
         let ignored = if args.pin_sdk && args.debug_build {
             "--pin/--debug"
@@ -879,11 +898,7 @@ mod tests {
             "project({{CLASS_NAME}})\n",
         )
         .unwrap();
-        fs::write(
-            templates.join("test.cpp.template"),
-            "t={{LOWER_NAME}}\n",
-        )
-        .unwrap();
+        fs::write(templates.join("test.cpp.template"), "t={{LOWER_NAME}}\n").unwrap();
     }
 
     #[test]
@@ -1098,7 +1113,9 @@ mod tests {
             ..CreateArgs::default()
         };
         let err = resolve_out_dir(&args, Some(&root), td.path()).unwrap_err();
-        assert!(err.to_string().contains("--in-tree projects must live under"));
+        assert!(err
+            .to_string()
+            .contains("--in-tree projects must live under"));
     }
 
     #[test]
@@ -1222,7 +1239,10 @@ mod tests {
             "--targets".to_owned(),
             "android,ios".to_owned(),
         ]);
-        assert_eq!(p.output.as_deref().map(Path::to_str), Some(Some("/tmp/out")));
+        assert_eq!(
+            p.output.as_deref().map(Path::to_str),
+            Some(Some("/tmp/out"))
+        );
         assert_eq!(p.targets, vec!["android", "ios"]);
     }
 
@@ -1245,11 +1265,7 @@ mod tests {
 
     #[test]
     fn parse_args_first_non_flag_wins_as_name() {
-        let p = parse_args(&[
-            "first".to_owned(),
-            "second".to_owned(),
-            "third".to_owned(),
-        ]);
+        let p = parse_args(&["first".to_owned(), "second".to_owned(), "third".to_owned()]);
         assert_eq!(p.name, "first");
     }
 
@@ -1376,5 +1392,99 @@ mod tests {
         };
         let resolved = resolve_out_dir(&args, None, td.path()).unwrap();
         assert_eq!(resolved, td.path().join("relout"));
+    }
+
+    #[test]
+    fn resolve_out_dir_uses_projects_base_for_standalone_default() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().join("pulp");
+        let projects = td.path().join("projects");
+        fs::create_dir_all(&root).unwrap();
+        let args = CreateArgs {
+            name: "Project Base".to_owned(),
+            ci_mode: true,
+            ..CreateArgs::default()
+        };
+
+        let resolved =
+            resolve_out_dir_with_projects_base(&args, Some(&root), td.path(), Some(&projects))
+                .unwrap();
+        assert_eq!(resolved, projects.join("project-base"));
+    }
+
+    #[test]
+    fn resolve_out_dir_keeps_explicit_output_ahead_of_projects_base() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().join("pulp");
+        let explicit = td.path().join("explicit");
+        let projects = td.path().join("projects");
+        fs::create_dir_all(&root).unwrap();
+        let args = CreateArgs {
+            name: "Explicit".to_owned(),
+            output: Some(explicit.clone()),
+            ci_mode: true,
+            ..CreateArgs::default()
+        };
+
+        let resolved =
+            resolve_out_dir_with_projects_base(&args, Some(&root), td.path(), Some(&projects))
+                .unwrap();
+        assert_eq!(resolved, explicit);
+    }
+
+    #[test]
+    fn resolve_out_dir_keeps_in_tree_ahead_of_projects_base() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().join("pulp");
+        let projects = td.path().join("projects");
+        fs::create_dir_all(root.join("examples")).unwrap();
+        let args = CreateArgs {
+            name: "Example Plug".to_owned(),
+            in_tree: true,
+            ci_mode: true,
+            ..CreateArgs::default()
+        };
+
+        let resolved =
+            resolve_out_dir_with_projects_base(&args, Some(&root), td.path(), Some(&projects))
+                .unwrap();
+        assert_eq!(resolved, root.join("examples").join("example-plug"));
+    }
+
+    #[test]
+    fn run_native_ci_uses_pulp_projects_dir_for_default_output() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().join("repo");
+        let projects = td.path().join("configured-projects");
+        fs::create_dir_all(root.join("core")).unwrap();
+        fs::write(root.join("CMakeLists.txt"), "project(Pulp)\n").unwrap();
+        write_minimal_effect_templates(
+            &root,
+            "#include <pulp/format/processor.hpp>\n        .accepts_midi = true,\n",
+        );
+        let _env = crate::test_support::EnvVarGuard::set_many(&[
+            ("PULP_PROJECTS_DIR", Some(projects.to_str().unwrap())),
+            ("PULP_HOME", None),
+        ]);
+
+        let mut buf = Vec::new();
+        let rc = run(
+            &root,
+            &CreateArgs {
+                name: "Configured Base".to_owned(),
+                ci_mode: true,
+                no_build: true,
+                ..CreateArgs::default()
+            },
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+        assert!(projects.join("configured-base").join("pulp.toml").is_file());
+        let stdout = String::from_utf8(buf).unwrap();
+        assert!(stdout.contains(&format!(
+            "Scaffolding complete at {}",
+            projects.join("configured-base").display()
+        )));
     }
 }

--- a/experimental/pulp-rs/src/cmd/create_paths.rs
+++ b/experimental/pulp-rs/src/cmd/create_paths.rs
@@ -77,6 +77,7 @@ mod tests {
         let home = td.path().join("home");
         let _env = crate::test_support::EnvVarGuard::set_many(&[
             ("HOME", Some(home.to_str().unwrap())),
+            ("USERPROFILE", Some(home.to_str().unwrap())),
             ("PULP_HOME", None),
             ("PULP_PROJECTS_DIR", Some("~/Pulp Projects")),
         ]);
@@ -98,11 +99,34 @@ mod tests {
         .unwrap();
         let _env = crate::test_support::EnvVarGuard::set_many(&[
             ("HOME", Some(home.to_str().unwrap())),
+            ("USERPROFILE", Some(home.to_str().unwrap())),
             ("PULP_HOME", Some(pulp_home.to_str().unwrap())),
             ("PULP_PROJECTS_DIR", None),
         ]);
 
         let resolved = configured_projects_base_dir(td.path()).unwrap();
         assert_eq!(resolved, home.join("Configured Projects"));
+    }
+
+    #[test]
+    fn configured_projects_base_prefers_env_over_config() {
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path().join("home");
+        let pulp_home = td.path().join("pulp-home");
+        fs::create_dir_all(&pulp_home).unwrap();
+        fs::write(
+            pulp_home.join("config.toml"),
+            "[create]\nprojects_dir = \"~/Configured Projects\"\n",
+        )
+        .unwrap();
+        let _env = crate::test_support::EnvVarGuard::set_many(&[
+            ("HOME", Some(home.to_str().unwrap())),
+            ("USERPROFILE", Some(home.to_str().unwrap())),
+            ("PULP_HOME", Some(pulp_home.to_str().unwrap())),
+            ("PULP_PROJECTS_DIR", Some("~/Env Projects")),
+        ]);
+
+        let resolved = configured_projects_base_dir(td.path()).unwrap();
+        assert_eq!(resolved, home.join("Env Projects"));
     }
 }

--- a/experimental/pulp-rs/src/cmd/create_paths.rs
+++ b/experimental/pulp-rs/src/cmd/create_paths.rs
@@ -1,0 +1,108 @@
+//! Path defaults shared by the Rust-native `pulp create` command.
+
+use std::path::{Path, PathBuf};
+
+use crate::config;
+
+fn strip_matching_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes.first() == Some(&b'"') && bytes.last() == Some(&b'"'))
+            || (bytes.first() == Some(&b'\'') && bytes.last() == Some(&b'\'')))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    if cfg!(windows) {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    } else {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+fn expand_configured_projects_path(raw: &str, cwd: &Path) -> Option<PathBuf> {
+    let configured = strip_matching_quotes(raw.trim()).trim();
+    if configured.is_empty() {
+        return None;
+    }
+
+    let path = if configured == "~" {
+        user_home_dir()?
+    } else if let Some(rest) = configured
+        .strip_prefix("~/")
+        .or_else(|| configured.strip_prefix("~\\"))
+    {
+        user_home_dir()?.join(rest)
+    } else {
+        PathBuf::from(configured)
+    };
+
+    Some(if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    })
+}
+
+/// Resolve the standalone project base from `PULP_PROJECTS_DIR` or
+/// `[create].projects_dir`.
+pub(super) fn configured_projects_base_dir(cwd: &Path) -> Option<PathBuf> {
+    if let Some(raw) = std::env::var_os("PULP_PROJECTS_DIR") {
+        if let Some(path) = expand_configured_projects_path(&raw.to_string_lossy(), cwd) {
+            return Some(path);
+        }
+    }
+
+    let doc = config::config_path()
+        .as_deref()
+        .and_then(|p| config::read(p).ok());
+    doc.as_ref().and_then(|doc| {
+        expand_configured_projects_path(&config::read_value(doc, "create", "projects_dir"), cwd)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    #[test]
+    fn configured_projects_base_prefers_pulp_projects_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path().join("home");
+        let _env = crate::test_support::EnvVarGuard::set_many(&[
+            ("HOME", Some(home.to_str().unwrap())),
+            ("PULP_HOME", None),
+            ("PULP_PROJECTS_DIR", Some("~/Pulp Projects")),
+        ]);
+
+        let resolved = configured_projects_base_dir(td.path()).unwrap();
+        assert_eq!(resolved, home.join("Pulp Projects"));
+    }
+
+    #[test]
+    fn configured_projects_base_reads_create_projects_dir_from_config() {
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path().join("home");
+        let pulp_home = td.path().join("pulp-home");
+        fs::create_dir_all(&pulp_home).unwrap();
+        fs::write(
+            pulp_home.join("config.toml"),
+            "[create]\nprojects_dir = \"~/Configured Projects\"\n",
+        )
+        .unwrap();
+        let _env = crate::test_support::EnvVarGuard::set_many(&[
+            ("HOME", Some(home.to_str().unwrap())),
+            ("PULP_HOME", Some(pulp_home.to_str().unwrap())),
+            ("PULP_PROJECTS_DIR", None),
+        ]);
+
+        let resolved = configured_projects_base_dir(td.path()).unwrap();
+        assert_eq!(resolved, home.join("Configured Projects"));
+    }
+}

--- a/experimental/pulp-rs/src/cmd/mod.rs
+++ b/experimental/pulp-rs/src/cmd/mod.rs
@@ -10,6 +10,7 @@
 pub mod audit;
 pub mod config;
 pub mod create;
+mod create_paths;
 pub mod design;
 pub mod dev;
 pub mod docs;


### PR DESCRIPTION
## Summary
- Makes Rust-native `pulp create --ci` honor the documented standalone output-base controls: `PULP_PROJECTS_DIR` first, then `[create].projects_dir` in the user config.
- Keeps `--output` and `--in-tree` precedence intact, then falls back to the existing repo-sibling/current-directory behavior.
- Extracts the env/config path resolver into `cmd/create_paths.rs` instead of adding more responsibility to the already-large `create.rs`.
- Bumps SDK/CLI patch version to `0.528.1`.

## Validation
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml cmd::create::`
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml cmd::create_paths::`
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report --pr-title 'fix(cli): honor create projects directory settings'`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `python3 tools/scripts/classify_changes.py --base origin/main --json` (`native_build_required=true`)
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `ff26a211a89c0fb019f06aee9b2fcea570d9b222`
- Pre-push fast gates passed; diff-cover was demoted locally with `PULP_DISABLE_PREPUSH_DIFF_COVER=1` after the focused Rust tests and gates above.

## Review Notes
Strict local adversarial/code-health review found one must-fix before PR: the new `~` expansion tests initially only set `HOME`, which would be wrong on Windows where the resolver uses `USERPROFILE`. Fixed before push, and added an env-over-config precedence test.

No remaining must-fix found. Should-fix soon: `experimental/pulp-rs/src/cmd/create.rs` remains a pre-existing large file (`1490` LOC after this extraction). Future Rust create parity should split parser/model, scaffolding/file generation, and orchestration/fallthrough instead of growing the command file further.

Claude bridge review was attempted and unavailable: `Not logged in · Please run /login`.

Full unfiltered `cargo test --manifest-path experimental/pulp-rs/Cargo.toml` was also attempted. It fails in `tests/orchestrate_parity_test.rs` on current `origin/main` as well, so it is not a branch regression: `sdk_install_prints_stub_notice_and_exits_non_zero` falls through to a real SDK download and 404s, and `pr_errors_cleanly_when_native_flag_is_used` does not see expected `--native` text. Recorded separately for the audit queue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rust-native `pulp create --ci` now uses the configured projects base for the default standalone output, preferring `PULP_PROJECTS_DIR` and then `[create].projects_dir`. `--output` and `--in-tree` precedence is unchanged; otherwise we fall back to repo-sibling or the current directory.

- **Bug Fixes**
  - Default standalone output honors `PULP_PROJECTS_DIR` > `[create].projects_dir`, with `~` expansion and Windows `USERPROFILE` support.
  - Keeps precedence: `--output` and `--in-tree` override; otherwise fall back to repo-sibling or cwd.

- **Refactors**
  - Extracted path resolution into `cmd/create_paths.rs` and added focused tests.

<sup>Written for commit 5bc3272fd3b4b154fddb55691b88ba64ef853156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

