### PR TITLE
test(cli): make Rust parity tests hermetic

### DIFF
--- a/experimental/pulp-rs/tests/orchestrate_parity_test.rs
+++ b/experimental/pulp-rs/tests/orchestrate_parity_test.rs
@@ -32,11 +32,18 @@ use std::process::Command;
 use assert_cmd::prelude::*;
 use tempfile::tempdir;
 
-/// Shell out to the built `pulp-rs` binary with a fresh `PULP_HOME`
-/// pointing at a test-owned tempdir.
+/// Shell out to the built `pulp-rs` binary with common test-only
+/// environment cleanup. Callers set `PULP_HOME` when they need a
+/// test-owned config/cache root.
 fn pulp_rs() -> Command {
     let mut c = Command::cargo_bin("pulp").expect("pulp-rs binary");
     c.env_remove("PULP_UPDATE_CHECK_DISABLED");
+    c
+}
+
+fn pulp_rs_no_fallthrough() -> Command {
+    let mut c = pulp_rs();
+    c.env("PULP_RS_NO_FALLTHROUGH", "1");
     c
 }
 
@@ -106,7 +113,7 @@ fn sdk_clean_removes_cache_roots_and_reports_count() {
 #[test]
 fn sdk_install_prints_stub_notice_and_exits_non_zero() {
     let home = tempdir().unwrap();
-    let out = pulp_rs()
+    let out = pulp_rs_no_fallthrough()
         .arg("sdk")
         .arg("install")
         .env("PULP_HOME", home.path())
@@ -235,7 +242,10 @@ fn projects_remove_without_path_is_bad_usage() {
 
 #[test]
 fn pr_errors_cleanly_when_native_flag_is_used() {
-    let out = pulp_rs().args(["pr", "--native"]).output().expect("run");
+    let out = pulp_rs_no_fallthrough()
+        .args(["pr", "--native"])
+        .output()
+        .expect("run");
     assert!(!out.status.success());
     let combined = format!(
         "{}{}",

--- a/experimental/pulp-rs/tests/phase6d_parity_test.rs
+++ b/experimental/pulp-rs/tests/phase6d_parity_test.rs
@@ -129,7 +129,15 @@ fn create_help_lists_all_options() {
 
 #[test]
 fn create_rejects_without_ci_flag() {
-    let output = run_anywhere(&["create", "demo"]);
+    let td = tempfile::tempdir().unwrap();
+    let output = Command::cargo_bin("pulp")
+        .expect("binary")
+        .current_dir(td.path())
+        .args(["create", "demo"])
+        .env("PULP_RS_NO_FALLTHROUGH", "1")
+        .env_remove("NO_COLOR")
+        .output()
+        .expect("run");
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8(output.stderr).expect("utf8");
     assert!(stderr.contains("--ci"), "expected --ci hint, got: {stderr}");

--- a/experimental/pulp-rs/tests/snapshots/snapshot_test__config_list_empty.snap
+++ b/experimental/pulp-rs/tests/snapshots/snapshot_test__config_list_empty.snap
@@ -6,6 +6,11 @@ expression: v
   "config_path": "<CONFIG_PATH>",
   "entries": [
     {
+      "key": "pr.workflow",
+      "value": "shipyard",
+      "default": true
+    },
+    {
       "key": "update.mode",
       "value": "prompt",
       "default": true
@@ -33,6 +38,11 @@ expression: v
     {
       "key": "import_design.default_emit",
       "value": "js",
+      "default": true
+    },
+    {
+      "key": "claude.send_user_file",
+      "value": "on",
       "default": true
     }
   ]

--- a/experimental/pulp-rs/tests/snapshots/snapshot_test__config_list_populated.snap
+++ b/experimental/pulp-rs/tests/snapshots/snapshot_test__config_list_populated.snap
@@ -6,6 +6,11 @@ expression: v
   "config_path": "<CONFIG_PATH>",
   "entries": [
     {
+      "key": "pr.workflow",
+      "value": "github",
+      "default": false
+    },
+    {
       "key": "update.mode",
       "value": "auto",
       "default": false
@@ -33,6 +38,11 @@ expression: v
     {
       "key": "import_design.default_emit",
       "value": "cpp",
+      "default": false
+    },
+    {
+      "key": "claude.send_user_file",
+      "value": "off",
       "default": false
     }
   ]


### PR DESCRIPTION
## Summary
- Make Rust parity tests that assert Rust stub behavior explicitly set `PULP_RS_NO_FALLTHROUGH=1`.
- Keep fallthrough-enabled tests unchanged where they intentionally exercise C++ delegation.
- Refresh config JSON snapshots so they include the existing `pr.workflow` and `claude.send_user_file` config keys.

## Validation
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml --test orchestrate_parity_test --test phase6d_parity_test --test snapshot_test`
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml`
- `rustfmt --edition 2021 --check experimental/pulp-rs/tests/orchestrate_parity_test.rs experimental/pulp-rs/tests/phase6d_parity_test.rs`
- `git diff --check origin/main...HEAD`
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report --pr-title 'test(cli): make Rust parity tests hermetic'`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `python3 tools/scripts/classify_changes.py --base origin/main --json`
- `git merge-tree --write-tree origin/main HEAD` -> `9e84705bb476a477570c932ba6a66c17cc0301e3`

## Audit / Review Notes
- Current `origin/main` reproduces the fixed failures: orchestrate parity can fall through to real `pulp-cpp`, `phase6d` can delegate `pulp create demo` into the full C++ create/build path, and config snapshots omit keys already present in `config.rs`.
- Strict local code-health review found no must-fix items after removing a single-use helper pair and correcting a stale test-helper comment.
- No production code changes; no file-size or module-boundary risk.
- Claude bridge review was attempted but unavailable: `Not logged in · Please run /login`.
- Shipyard PR path was attempted first, but failed before PR creation because `mac` backend reported `gh auth status failed`; this PR was opened through the GitHub connector fallback. Pre-push gates passed with `PULP_SKIP_DIFF_COVER=1` after focused/full Rust validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made Rust parity tests hermetic by enforcing stub-only behavior with `PULP_RS_NO_FALLTHROUGH=1`, preventing accidental delegation to `pulp-cpp`. Refreshed config snapshots to include `pr.workflow` and `claude.send_user_file`.

<sup>Written for commit 13cb52e4bed72e9617a7fb6baddc16405a5389db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

