### PR TITLE
docs(view): correct ImageView status wording

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -257,7 +257,7 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | ScrollView (smooth scroll, fade bars) | usable | [view](modules.md#view) | |
 | Meter (RMS + peak hold), ProgressBar | usable | [view](modules.md#view) | |
 | XYPad, WaveformView, SpectrumView | usable | [view](modules.md#view) | |
-| ImageView | usable | [view](modules.md#view) | Placeholder rendering |
+| ImageView | usable | [view](modules.md#view) | File-backed image rendering on supported canvas backends; placeholder fallback for missing files or backends without image decode support |
 | TreeView, Tooltip, Panel, Icon | usable | [view](modules.md#view) | |
 | SpectrogramView (scrolling STFT) | usable | [view](modules.md#view) | |
 | MultiMeter, CorrelationMeter | usable | [view](modules.md#view) | |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -960,8 +960,14 @@ widgets:
   checkbox:         { status: usable, header: widgets.hpp }
   toggle_button:    { status: usable, header: widgets.hpp }
   icon:             { status: usable, header: widgets.hpp }
-  image_view:       { status: partial, header: widgets.hpp,
-                      notes: "Placeholder rendering; Skia decode planned." }
+  image_view:
+    status: usable
+    header: widgets.hpp
+    notes: >
+      File-backed images render through Canvas::draw_image_from_file /
+      draw_image_from_file_rect on supported backends; missing files or
+      canvas backends without image decode support fall back to a filename
+      placeholder.
   meter:            { status: usable, header: widgets.hpp }
   multi_meter:      { status: usable, header: widgets.hpp }
   correlation_meter: { status: usable, header: widgets.hpp }


### PR DESCRIPTION
## Summary
- Correct the schema-v2 `image_view` widget row from placeholder/planned wording to existing file-backed image rendering behavior.
- Update the public capabilities table so ImageView no longer reads as placeholder-only.
- Keep the fallback caveat explicit for missing files and canvas backends without image decode support.

## Validation
- `python3 tools/scripts/docs_noise_lint.py docs/status/support-matrix.yaml docs/reference/capabilities.md`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/check_status_ladder.py --mode=report`
- `tools/check-docs.sh` (passes with existing 109 warnings)
- `git diff --check origin/main...HEAD`
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/classify_changes.py --base origin/main --json` -> `native_build_required=false`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report --pr-title 'docs(view): correct ImageView status wording'`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `git merge-tree --write-tree origin/main HEAD` -> `b7b607f162836f0476491f91e8145e34a822d7ef`

## Audit / Review Notes
- Source evidence on current `origin/main`: `ImageView::paint` calls `Canvas::draw_image_from_file` / `draw_image_from_file_rect`; `SkiaCanvas` implements both; `test_image_view_cache.cpp` covers the ImageView draw/source-rect/object-fit paths.
- Strict local code-health review found no must-fix or should-fix-soon issues. This is a two-file docs/status correction with no runtime/importer/rendering/layout/platform boundary change.
- `docs/status/support-matrix.yaml` is already over 1k LOC as a status manifest; this PR adds only a focused row correction and does not broaden that structure.
- Claude bridge review was attempted but unavailable: `Not logged in · Please run /login`.
- Shipyard PR path was attempted first, but failed before PR creation because the `mac` backend reported `gh auth status failed`; this PR was opened through the GitHub connector fallback. Pre-push gates passed with `PULP_SKIP_DIFF_COVER=1` for this docs-only diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected ImageView docs to reflect current file-backed image rendering and “usable” status. Updated the support matrix and capabilities table to remove placeholder-only wording and note the fallback for missing files or backends without image decode.

<sup>Written for commit db185e1d7c26cddcf063cdf9bb108df639e331e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

