### PR TITLE
docs(view): correct table widget status

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -271,7 +271,8 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | ColorPicker, Lasso, PropertyList, CodeEditor | usable | [view](modules.md#view) | |
 | CanvasWidget (25 draw commands) | usable | [view](modules.md#view) | [custom-rendering](../guides/custom-rendering.md) |
 | ModulationMatrixWidget (source-to-destination routes) | usable | [view](modules.md#view) | [widgets](widgets.md#audio-specific) |
-| A/B compare, sortable TableView | planned | [view](modules.md#view) | Production-readiness workstream 07 |
+| TableListBox (sortable columns) | partial | [view](modules.md#view) | Click-to-sort columns and themed rows are implemented; built-in table scrolling/scrollbar remains planned |
+| A/B compare | planned | [view](modules.md#view) | Production-readiness workstream 07 |
 
 ### Web-Compat Layer
 

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -993,8 +993,12 @@ widgets:
   graph_editor_view: { status: usable, header: graph_editor_view.hpp,
                        notes: "Canvas-based node editor driving SignalGraph." }
   canvas_widget:    { status: usable, header: canvas_widget.hpp }
-  table:            { status: partial, header: table.hpp,
-                      notes: "Basic rows; sortable columns + virtualization planned." }
+  table:
+    status: partial
+    header: table.hpp
+    notes: >
+      Rows, themed cells, and click-to-sort columns are implemented; built-in
+      table scrolling/scrollbar remains planned.
   modulation_matrix:   { status: usable, header: modulation_matrix_widget.hpp,
                           notes: "Source-to-destination route widget backed by ModulationMatrix; focused data-model and widget interaction tests exist." }
   ab_compare:          { status: planned, notes: "Planned A/B comparison widget." }


### PR DESCRIPTION
## Summary
- Stop grouping sortable TableView with planned A/B compare in the capabilities table.
- Record the current TableListBox reality: rows, themed cells, and click-to-sort columns are implemented.
- Keep table status `partial` because built-in table scrolling/scrollbar behavior is still planned.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/status/support-matrix.yaml docs/reference/capabilities.md`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/check_status_ladder.py --mode=report`
- `tools/check-docs.sh` (passes with existing 109 warnings)
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/classify_changes.py --base origin/main --json` -> `native_build_required=false`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report --pr-title 'docs(view): correct table widget status'`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `git merge-tree --write-tree origin/main HEAD` -> `fd05d90b34ce4a80a73f5408717eb862186bcce1`

## Audit / Review Notes
- Source evidence on current `origin/main`: `TableColumn::sortable`, `TableListBox::on_mouse_down` header click sorting, `SimpleTableModel::sort`, `TableModel::toggle_sort`, `test_table_model.cpp`, `test_table_list_box.cpp`, and `docs/reference/widgets.md` all show sortable table columns are real.
- The status stays `partial` because `TableListBox` has no public built-in table scrollbar/scroll-wheel path; the previous docs overcorrected by saying sortable columns themselves were planned.
- Strict local code-health review found no must-fix or should-fix-soon issues. This is a docs/status-only correction with no runtime/importer/rendering/layout/platform boundary change.
- Claude bridge review was attempted but unavailable: `Not logged in · Please run /login`.
- Shipyard PR path was attempted first, but failed before PR creation because the `mac` backend reported `gh auth status failed`; this PR was opened through the GitHub connector fallback. Pre-push gates passed with `PULP_SKIP_DIFF_COVER=1` for this docs-only diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the table widget status in the docs: records that TableListBox has rows, themed cells, and click-to-sort columns, while keeping status as partial because built-in scrolling/scrollbars are still planned. Separates A/B compare from the table entry to avoid conflation in the capabilities table and support matrix.

<sup>Written for commit bc11c013d803430f9e6ff32cdd91f6b6e6d3f54c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

