### PR TITLE
docs(view): align accessibility status evidence

### DIFF
--- a/core/view/include/pulp/view/accessibility.hpp
+++ b/core/view/include/pulp/view/accessibility.hpp
@@ -132,23 +132,22 @@ enum class AnnouncementPriority {
     Assertive,
 };
 
-/// Request the current platform screen reader speak `text`. On platforms
-/// without a wired backend (or when no screen reader is active) the call
-/// is logged at info level and otherwise a no-op — it is always safe to
-/// call, including from test harnesses.
+/// Request the installed accessibility announcement sink speak `text`. When no
+/// sink is installed (or no screen reader is active), the call is logged at info
+/// level and otherwise a no-op — it is always safe to call, including from test
+/// harnesses.
 ///
-/// Backends (populated via set_announcement_sink at window-attach time):
-///   macOS   — NSAccessibilityAnnouncementRequestedNotification
-///   iOS     — UIAccessibilityPostNotification(AnnouncementNotification)
-///   Android — Kotlin-side TalkBack TYPE_ANNOUNCEMENT (pending)
-///   Windows — UIA UiaRaiseNotificationEvent (not wired yet)
-///   Linux   — AT-SPI object:announcement (not wired yet)
+/// The C++ API and sink plumbing are present. Built-in platform bridge sinks are
+/// still pending: macOS/iOS should install the native announcement notification
+/// path, Android should route through TalkBack TYPE_ANNOUNCEMENT, Windows
+/// through UiaRaiseNotificationEvent, and Linux through AT-SPI announcement
+/// events.
 void announce_accessibility(std::string_view text,
                             AnnouncementPriority priority = AnnouncementPriority::Polite);
 
-/// Install a platform-specific announcement sink. Called by accessibility
-/// bridges at window-attach time. Pass nullptr to detach (the default
-/// logger is restored). Not thread-safe — UI thread only.
+/// Install a platform-specific announcement sink when a live-region backend is
+/// available. Pass nullptr to detach (the default logger is restored). Not
+/// thread-safe — UI thread only.
 using AnnouncementSink =
     std::function<void(std::string_view text, AnnouncementPriority)>;
 void set_announcement_sink(AnnouncementSink sink);

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -35,8 +35,8 @@ The following section is auto-generated from the `limitations:` block of `docs/s
 | `midi_io.coremidi` | MIDI 2.0 channel-voice input is flattened to MIDI 1.0 where representable; per-note and other unsupported UMP statuses are not delivered through MidiInputCallback. | [link](../../planning/production-readiness/02-audio-midi-io.md#2.6) |
 | `midi_io.win32_midi` | Default legacy mmeapi path has no Windows MIDI Services / MIDI 2.0 transport and no hotplug; SysEx input is routed via MIM_LONGDATA. The opt-in WinRT MIDI 2.0 backend requires PULP_HAS_WINRT_MIDI and the Windows MIDI Services SDK. | [link](../../planning/production-readiness/02-audio-midi-io.md#2.4) |
 | `midi_io.alsa_midi` | Hotplug notifications depend on runtime libudev/udevd; when unavailable, the port-change callback is stored but will not fire, so clients must re-enumerate manually. | [link](../../planning/production-readiness/02-audio-midi-io.md#2.5) |
-| `platform_maturity.accessibility.windows` | UIA provider tree and event emission pending (UIAutomationCore linked, session init wired). | [link](../../planning/production-readiness/04-accessibility.md#4.1) |
-| `platform_maturity.accessibility.linux` | AT-SPI per-view accessible objects and events pending (D-Bus bridge bootstrap in place). | [link](../../planning/production-readiness/04-accessibility.md#4.2) |
+| `platform_maturity.accessibility.windows` | Direct UIA client and screen-reader regression tests remain pending; provider tree, WM_GETOBJECT, and value/focus/name event helpers are implemented in source. | [link](../../planning/production-readiness/04-accessibility.md#4.1) |
+| `platform_maturity.accessibility.linux` | Real AT-SPI registry/Orca signal receipt remains pending; per-widget Accessible/Component/Value objects and event-hook marshalling are loopback-tested on the session bus. | [link](../../planning/production-readiness/04-accessibility.md#4.2) |
 <!-- generated:end id=limitations -->
 
 ---
@@ -298,8 +298,8 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | VoiceOver accessibility | usable | macOS | NSAccessibilityElement + AccessRole |
 | VoiceOver accessibility | usable | iOS | UIAccessibilityElement with slider increment/decrement |
 | TalkBack accessibility | usable | Android | JNI bridge: role, label, value, table metadata, actions |
-| UIA accessibility | partial | Windows | Role map only; provider pending (production-readiness 04) |
-| AT-SPI accessibility | partial | Linux | Role map only; D-Bus registration pending (production-readiness 04) |
+| UIA accessibility | partial | Windows | Provider tree, WM_GETOBJECT, and value/focus/name event helpers exist; direct UIA client regression still pending |
+| AT-SPI accessibility | partial | Linux | Direct D-Bus provider exposes per-widget tree/value paths with loopback tests; real registry/Orca signal receipt still pending |
 | IME composition (marked text) | usable | macOS | Full NSTextInputClient |
 | Right-click context menu | partial | all | on_context_menu/registerContextMenu fire; view-tree ContextMenu is actionable; native showContextMenu currently renders only on macOS and does not report selection |
 | Keyboard shortcuts | usable | all | registerShortcut bridge |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -565,10 +565,18 @@ platform_maturity:
       notes: TalkBack via JNI bridge exposing role, label, value, table metadata, and click/increment/decrement actions. See core/view/platform/android/accessibility_android.cpp.
     windows:
       status: partial
-      notes: UIA stub — role mapping defined, IRawElementProviderSimple/WM_GETOBJECT/event firing pending. See production-readiness workstream 04.
+      notes: >
+        UIA provider tree, WM_GETOBJECT hook, per-widget fragments, and
+        value/focus/name event helpers are implemented in
+        core/view/platform/win/accessibility_win.cpp. Direct UIA client and
+        screen-reader regression tests are still pending.
     linux:
       status: partial
-      notes: AT-SPI2 over direct D-Bus (no libatk) — a11y-bus connect, root Accessible/Application export, and Socket.Embed registration done; per-widget tree + value/events pending. See core/view/platform/linux/accessibility_linux.cpp and production-readiness workstream 04.
+      notes: >
+        AT-SPI2 over direct D-Bus (no libatk) exports root/application objects,
+        per-widget Accessible/Component/Value objects, and event-hook
+        marshalling; session-bus loopback tests cover tree/value behavior.
+        Real registry/Orca signal receipt remains pending.
   ime_composition:
     status: usable
     platform: macos
@@ -935,15 +943,14 @@ limitations:
     - text: "Hotplug notifications depend on runtime libudev/udevd; when unavailable, the port-change callback is stored but will not fire, so clients must re-enumerate manually."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.5"
   platform_maturity.accessibility.windows:
-    # UIA bootstrap is in place (UIAutomationCore linked, session init
-    # wired). Remaining: IRawElementProviderSimple provider tree +
-    # WM_GETOBJECT integration + value/focus/selection event emission.
-    - text: "UIA provider tree and event emission pending (UIAutomationCore linked, session init wired)."
+    # UIA provider tree + event helpers are implemented in source. Remaining:
+    # direct client/screen-reader regression coverage and hardening.
+    - text: "Direct UIA client and screen-reader regression tests remain pending; provider tree, WM_GETOBJECT, and value/focus/name event helpers are implemented in source."
       tracked_in: "planning/production-readiness/04-accessibility.md#4.1"
   platform_maturity.accessibility.linux:
-    # AT-SPI D-Bus bridge bootstrap is in place. Remaining: per-view
-    # AtkObject model + value/text/focus event emission.
-    - text: "AT-SPI per-view accessible objects and events pending (D-Bus bridge bootstrap in place)."
+    # AT-SPI object tree and event-hook marshalling are loopback-tested on the
+    # session bus. Remaining: real a11y registry / Orca signal receipt.
+    - text: "Real AT-SPI registry/Orca signal receipt remains pending; per-widget Accessible/Component/Value objects and event-hook marshalling are loopback-tested on the session bus."
       tracked_in: "planning/production-readiness/04-accessibility.md#4.2"
 
 # ── Schema-v2 additions ──────────────────────────────────────────────────────
@@ -1035,11 +1042,25 @@ accessibility_features:
     status: planned
     notes: Per-widget std::vector<Action> exposure planned.
   live_region_announce:
-    status: planned
-    notes: announce(text, politeness) cross-platform API planned.
+    status: partial
+    notes: >
+      announce_accessibility(text, priority) and set_announcement_sink() are
+      implemented and covered by pulp-test-announce. Built-in platform bridges
+      do not install live-region sinks yet, so calls log/no-op unless a host or
+      platform backend supplies one.
   tree_invalidation_events:
-    status: planned
-    notes: View-tree change notifications (NSAccessibilityPostNotification / UiaRaiseAutomationEvent / object:text-changed) planned.
+    status: partial
+    notes: >
+      Cross-platform provider event helpers exist, Windows raises UIA
+      structure/value/focus/name events, and Linux rebuilds AT-SPI trees plus
+      marshals value/focus/name events. test/test_accessibility_provider.cpp
+      and test/test_accessibility_tree.cpp cover the no-op/live helper paths.
+      macOS/iOS/Android notification parity and real client signal receipt are
+      still pending.
   a11y_test_harness:
-    status: planned
-    notes: Headless AX introspection tests per platform planned.
+    status: partial
+    notes: >
+      Headless cross-platform snapshots are covered by
+      test/test_accessibility_tree.cpp, and Linux has a session-bus AT-SPI
+      loopback harness. Direct per-platform assistive-client harnesses remain
+      planned.


### PR DESCRIPTION
## Summary
- Correct `accessibility.hpp` live-region comments so the API/sink plumbing is described accurately without implying built-in platform sinks are installed.
- Align Windows/Linux accessibility status with current UIA/AT-SPI provider evidence while keeping direct client/screen-reader gaps explicit.
- Move live-region announce, tree invalidation, and accessibility harness rows from `planned` to precise `partial` status with remaining platform/client work listed.

## Validation
- `python3 tools/docs_generate.py generate`
- `python3 tools/docs_generate.py check`
- `python3 tools/check-docs-consistency.py`
- `python3 tools/check_status_ladder.py --mode=report`
- `bash tools/check-docs.sh` (passes with existing 109 warnings)
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report docs/reference/capabilities.md docs/status/support-matrix.yaml`
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`
- `cmake -S . -B build-a11y-status -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build-a11y-status --target pulp-test-announce pulp-test-accessibility-provider pulp-test-accessibility-tree --parallel 8`
- `./build-a11y-status/test/pulp-test-announce --reporter compact` (9 assertions / 3 cases)
- `./build-a11y-status/test/pulp-test-accessibility-provider --reporter compact` (1 assertion / 1 case on macOS placeholder path)
- `./build-a11y-status/test/pulp-test-accessibility-tree --reporter compact` (77 assertions / 12 cases)
- `ctest --test-dir build-a11y-status -R "announce_accessibility|set_announcement_sink|announcement sink|accessibility_provider|snapshot excludes root|count_announceable|snapshot walks" --output-on-failure` (7/7)
- Pre-push full hook: `10743/10743` CTest passed, real time 1143.78s; diff coverage passed (`No lines with coverage information in this diff.`)

## Review Notes
- Strict local architecture/code-health review found no must-fix item for this patch.
- Should-fix-soon/deferred accessibility work remains: built-in platform live-region sinks, direct UIA client/screen-reader regression tests, real AT-SPI registry/Orca signal receipt, macOS/iOS/Android notification parity, and possible future split of the pre-existing >1k-line `docs/status/support-matrix.yaml`.
- Shipyard PR submission is blocked locally by `mac` `gh auth status failed` plus unconfigured Ubuntu/Windows SSH targets; branch push used a supervised fallback after full local validation.
- Claude bridge is unavailable locally (`Not logged in · Please run /login`), and RepoPrompt Oracle failed to launch, so no external second-opinion approval is claimed.
- Local QEMU Windows ARM64 runner is idle/additive only; hosted Windows x64/MSVC remains the authoritative Windows gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align accessibility docs and API comments with current Windows UIA and Linux AT-SPI evidence, moving live‑region announce, tree invalidation events, and the a11y test harness from planned to partial. Clarifies that `announce_accessibility` uses an installable announcement sink (no built‑in platform sinks yet) and updates Windows/Linux notes to reflect implemented provider trees and event helpers while calling out pending client/screen‑reader tests.

<sup>Written for commit 736e12a4b3c2150feb9563034a895b97eaceb891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

