### PR TITLE
test(canvas): add Linux font golden baselines

### DIFF
--- a/test/test_font_rendering_goldens.cpp
+++ b/test/test_font_rendering_goldens.cpp
@@ -12,12 +12,12 @@
 // Design choices (read this header before "fixing" a failure):
 //
 //  1. Goldens live in the source file (not on disk). The
-//     committed expected values are the contract — a real font
-//     regression manifests as a hash mismatch on a host where
-//     the rendering used to be stable. There is no golden-file
-//     sync workflow to forget about. If a Skia bump genuinely
-//     changes rendering, update the constants in this file
-//     deliberately as part of the bump PR.
+//     committed expected values are the contract for each CI host
+//     class — a real font regression manifests as a hash mismatch
+//     on a host where the rendering used to be stable. There is no
+//     golden-file sync workflow to forget about. If a Skia bump
+//     genuinely changes rendering, update the constants in this
+//     file deliberately as part of the bump PR.
 //
 //  2. We use a *structural* digest, not a byte-exact pixel hash.
 //     The structural fingerprint is
@@ -215,14 +215,16 @@ void expect_digest_matches(const Digest& actual, const Digest& expected,
     REQUIRE(ok);
 }
 
-// ── Committed expected digests (macOS-arm64 reference) ──────────
+// ── Committed expected digests ──────────────────────────────────
 //
-// These numbers were captured on a macOS-arm64 host running the
-// repo's pinned Skia. The 5% tolerance above keeps them stable
-// across minor Skia point releases. If a future Skia bump shifts
-// these by more than 5% on the reference host, regenerate the
-// constants in the same PR as the bump and keep the LOC diff
-// auditable.
+// These numbers were captured on CI hosts running the repo's
+// pinned Skia. The 5% tolerance above keeps each host-class
+// baseline stable across minor Skia point releases while avoiding
+// false equivalence between CoreText-backed macOS rasterization
+// and FreeType/fontconfig-backed Linux rasterization. If a future
+// Skia bump shifts these by more than 5% on a reference host,
+// regenerate the constants in the same PR as the bump and keep
+// the LOC diff auditable.
 //
 // Reference host: macos-arm64 · Xcode 26.5 (17F42) · Skia chrome/m149.
 // The 'Hello'/Inter digest was regenerated for the Xcode 26.4.1→26.5
@@ -234,16 +236,34 @@ void expect_digest_matches(const Digest& actual, const Digest& expected,
 // from the INFO line into the constants below, rebuild, rerun,
 // expect green.
 
-constexpr Digest kHelloInter14 {
-    /*width=*/128, /*height=*/32,
-    /*opaque_pixels=*/244,
-    /*darkness_sum=*/31403,
-};
-
 constexpr Digest kCjkInter14 {
     /*width=*/128, /*height=*/32,
     /*opaque_pixels=*/190,
     /*darkness_sum=*/24749,
+};
+
+// Hosted Linux x64 renders the bundled Latin fonts through
+// FreeType/fontconfig, which produces stable but lighter AA than
+// the macOS CoreText reference. Keep separate constants instead
+// of widening the global tolerance and weakening the regression
+// signal on every platform.
+#if defined(__linux__)
+constexpr Digest kHelloInter14 {
+    /*width=*/128, /*height=*/32,
+    /*opaque_pixels=*/197,
+    /*darkness_sum=*/23436,
+};
+
+constexpr Digest kHelloWorldMono12 {
+    /*width=*/128, /*height=*/32,
+    /*opaque_pixels=*/332,
+    /*darkness_sum=*/34617,
+};
+#else
+constexpr Digest kHelloInter14 {
+    /*width=*/128, /*height=*/32,
+    /*opaque_pixels=*/244,
+    /*darkness_sum=*/31403,
 };
 
 constexpr Digest kHelloWorldMono12 {
@@ -251,6 +271,7 @@ constexpr Digest kHelloWorldMono12 {
     /*opaque_pixels=*/355,
     /*darkness_sum=*/47560,
 };
+#endif
 
 } // namespace
 


### PR DESCRIPTION
## Summary
- Add Linux-specific committed digests for the two raster font golden tests that repeatedly fail on hosted Linux x64 with stable FreeType/fontconfig output.
- Keep the macOS CoreText reference values and the existing 5% structural tolerance unchanged.
- Do not add skips or weaken the global font-rendering contract.

## Evidence
- #5200 hosted Linux x64 and #5153 hosted Linux x64 both failed only the same two raster font golden cases with the same observed digests: Inter 14px `opaque=197 darkness=23436`, JetBrains Mono 12px `opaque=332 darkness=34617`.
- The failing branches were unrelated to font rendering, so this is shared CI/platform drift rather than branch-owned behavior.

## Validation
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `b405b7b8ddbb118d0d132a34098fd17951510701`
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` -> native build required for `test/test_font_rendering_goldens.cpp`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode report` -> no bump needed
- Skia-enabled Release configure/build for `pulp-test-font-rendering-goldens`
- `./build-font-goldens-skia/test/pulp-test-font-rendering-goldens` -> 22 assertions / 4 cases
- `ctest --test-dir build-font-goldens-skia -R 'font rendering golden' --output-on-failure` -> 4/4 passed
- Pre-push hook completed cleanly

## Adversarial Review
- Must-fix before PR: none found locally.
- Should-fix soon: none for this patch; the separate Windows x64 post-#5186 CTest failures remain a shared blocker to inspect next.
- Acceptable for now: one platform preprocessor split in an existing platform-sensitive rendering test. This keeps per-host contracts explicit without widening tolerance globally.
- Claude bridge review was attempted but stayed silent and was stopped; no Claude approval is claimed.

Do not merge without explicit maintainer instruction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Linux-specific golden baselines for two raster font tests to match stable FreeType/fontconfig output and stop repeated CI failures on hosted Linux x64. macOS CoreText values and the 5% structural tolerance stay the same.

- **Bug Fixes**
  - Added Linux digests for Inter 14 "Hello" and JetBrains Mono 12 "Hello world", selected via `#if defined(__linux__)`.
  - Kept macOS digests unchanged; no skips and no tolerance changes.
  - Updated comments to document per-host baselines without weakening the contract.

<sup>Written for commit b80747d808025bfb2dc10ff91342101b7414efc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

