### PR TITLE
docs(view): clarify loadFont bridge comment

### DIFF
--- a/core/view/src/widget_bridge/storage_assets_api.cpp
+++ b/core/view/src/widget_bridge/storage_assets_api.cpp
@@ -258,11 +258,10 @@ void WidgetBridge::register_font_assets_api() {
     BridgeApiContext api{engine_};
 
     // Font loading: loadFont(path) -> success boolean.
+    // This is an existence probe for web-compat callers; actual renderer font
+    // registration is handled by registerFont(family, path) below.
     register_bridge_function(api, "loadFont", [](choc::javascript::ArgumentList args) {
         auto path = args.get<std::string>(0, "");
-        // Font loading is platform-dependent; this registers the font path
-        // for use by canvas.set_font() and Label font_family
-        // Currently a stub that acknowledges the request
         bool exists = !path.empty() && std::filesystem::exists(path);
         return choc::value::createBool(exists);
     });


### PR DESCRIPTION
## Summary

- Clarifies that `loadFont(path)` is an existence probe for web-compat callers.
- Points actual renderer font registration at the existing `registerFont(family, path)` bridge.
- Leaves behavior unchanged and keeps full `loadFont` semantic registration deferred because the family/API contract is not obvious.

## Validation

Exact head: `69bc1a4fd3f30419c7f89a1edc239ccc86248389`  
Base: `a4d50921baac31707b81630f22dfc8c1a24985ee`

- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=true` because `core/**` source changed, though the diff is comment-only)
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode report --pr-title 'docs(view): clarify loadFont bridge comment'`
- `bash tools/scripts/gates.sh origin/main`
- Release/no-GPU configure: `cmake -S . -B build-ra-font-comment -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build-ra-font-comment --target pulp-test-widget-bridge-animation -j$(sysctl -n hw.ncpu)`
- `./build-ra-font-comment/test/pulp-test-widget-bridge-animation "WidgetBridge loadFont reports existing and missing paths"`
- `ctest --test-dir build-ra-font-comment -R '^WidgetBridge loadFont reports existing and missing paths$' --output-on-failure`

## Review

Strict local adversarial/code-health review found no must-fix: one 287-line file, comment-only diff, no behavior/API/state/control-flow change, no new helper/abstraction, and docs/tests already match the existence-probe contract.

`claude -p` review was attempted but unavailable (`Not logged in · Please run /login`), so no Claude approval is claimed. Shipyard PR submission was attempted first and failed before PR creation because target `mac` reported `gh auth status failed`; the branch push used the supervised fallback marker after local validation.