### PR TITLE
test(cli): normalize config shellout newlines

### DIFF
--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -722,7 +722,7 @@ TEST_CASE("pulp config set/get/list round-trips isolated update settings",
     auto get_mode = run_pulp({"config", "get", "update.mode"}, 10000);
     REQUIRE_FALSE(get_mode.timed_out);
     REQUIRE(get_mode.exit_code == 0);
-    REQUIRE(get_mode.stdout_output == "manual\n");
+    REQUIRE(normalize_newlines(get_mode.stdout_output) == "manual\n");
 
     auto set_channel = run_pulp({"config", "set", "update.channel", "beta"}, 10000);
     REQUIRE_FALSE(set_channel.timed_out);

--- a/test/test_cli_shellout_helpers.hpp
+++ b/test/test_cli_shellout_helpers.hpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/child_process.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -142,6 +143,11 @@ inline std::string read_file(const fs::path& path) {
     if (!f.is_open()) return {};
     return std::string(std::istreambuf_iterator<char>(f),
                        std::istreambuf_iterator<char>());
+}
+
+inline std::string normalize_newlines(std::string text) {
+    text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());
+    return text;
 }
 
 inline void write_text(const fs::path& path, const std::string& text) {


### PR DESCRIPTION
## Summary

- Normalize CRLF in the config shellout roundtrip assertion so Windows text-mode stdout does not fail a production-correct `pulp config get update.mode` result.
- Add the normalization helper to the existing shellout test helper surface and apply it only to the `manual\n` assertion.

## Validation

- Release/no-GPU build of `pulp-test-cli-shellout`
- Same-worktree GPU-enabled Release build of `pulp-cli`
- `PULP_CLI_PATH=/private/tmp/pulp-ra-config-crlf/build-ra-config-crlf-cli/tools/cli/pulp-cpp ./build-ra-config-crlf/test/pulp-test-cli-shellout "pulp config set/get/list round-trips isolated update settings" --reporter compact` (`39` assertions / `1` case)
- `PULP_CLI_PATH=/private/tmp/pulp-ra-config-crlf/build-ra-config-crlf-cli/tools/cli/pulp-cpp ctest --test-dir build-ra-config-crlf -R "^pulp config set/get/list round-trips isolated update settings$" --output-on-failure` (`1/1`)
- Release proof: both CMake caches have `CMAKE_BUILD_TYPE=Release`; relevant target flags include `-O3 -DNDEBUG`
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=true`)
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode report --pr-title "test(cli): normalize config shellout newlines"` (`no bump needed`)
- `bash tools/scripts/gates.sh origin/main`
- `git merge-tree --write-tree origin/main HEAD` -> `73cd1b0f2d597fdbd39c22bcfb846b395fba10a5`
- Supervised fallback branch push with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`; fast pre-push gates passed

## Review

Strict local adversarial/code-health review found no must-fix before PR. The diff is two test files / 7 insertions / 1 deletion; no runtime, importer, rendering, layout, or platform boundary changes. `test/test_cli_shellout.cpp` is a pre-existing oversized file, but the one-line assertion belongs in the existing config shellout case. Importing this shellout helper into the non-shellout `test_cli_project_command.cpp` solely to dedupe another local newline helper would increase coupling, so that consolidation remains deferred.

Claude bridge review was attempted but is unavailable locally (`Not logged in · Please run /login`, session `6e52c988-b8b9-4bd3-9a60-b3a37e7e5a48`). Hosted Windows x64/MSVC remains the authoritative proof for the original failure family; local QEMU Windows ARM64 is additive only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize CRLF in the CLI shellout test so Windows text-mode stdout doesn’t fail the `pulp config get update.mode` round-trip. Adds a `normalize_newlines` helper and uses it only for the `manual\n` assertion; no runtime changes.

<sup>Written for commit ea994f4e7eed830fc37c62140d6c396a13865f11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

