### PR TITLE
fix(view): skip redundant hot reloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.528.2
+    VERSION 0.529.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/hot_reload.hpp
+++ b/core/view/include/pulp/view/hot_reload.hpp
@@ -21,12 +21,15 @@
 #include <choc/platform/choc_FileWatcher.h>
 #endif
 
+#include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
-#include <atomic>
+#include <string_view>
 #include <unordered_map>
 
 namespace pulp::view {
@@ -69,7 +72,7 @@ private:
 #if !TARGET_OS_IPHONE
     std::unique_ptr<choc::file::Watcher> watcher_;
 #endif
-    std::unordered_map<std::string, std::filesystem::file_time_type> observed_write_times_;
+    std::unordered_map<std::string, std::uint64_t> observed_content_hashes_;
 
     std::mutex pending_mutex_;
     std::string pending_code_;
@@ -79,9 +82,11 @@ private:
 #if !TARGET_OS_IPHONE
     void on_file_changed(const choc::file::Watcher::Event& event);
 #endif
+    std::optional<std::string> try_read_file(const std::filesystem::path& path);
     std::string read_file(const std::filesystem::path& path);
-    void seed_observed_write_times();
+    void seed_observed_content_hashes();
     bool should_reload_for_modified_file(const std::filesystem::path& path);
+    static std::uint64_t content_hash(std::string_view content);
 };
 
 } // namespace pulp::view

--- a/core/view/src/hot_reload.cpp
+++ b/core/view/src/hot_reload.cpp
@@ -43,7 +43,7 @@ HotReloader::HotReloader(const std::filesystem::path& js_file, ReloadCallback on
     , entry_file_(js_file.filename().string())
     , on_reload_(std::move(on_reload))
 {
-    seed_observed_write_times();
+    seed_observed_content_hashes();
 
     auto dir = js_file.parent_path();
     watcher_ = std::make_unique<choc::file::Watcher>(
@@ -62,7 +62,7 @@ HotReloader::HotReloader(const std::filesystem::path& directory,
     , entry_file_(entry_file)
     , on_reload_(std::move(on_reload))
 {
-    seed_observed_write_times();
+    seed_observed_content_hashes();
 
     watcher_ = std::make_unique<choc::file::Watcher>(
         directory,
@@ -120,24 +120,28 @@ void HotReloader::on_file_changed(const choc::file::Watcher::Event& event) {
 }
 #endif  // !TARGET_OS_IPHONE
 
-std::string HotReloader::read_file(const std::filesystem::path& path) {
-    std::ifstream file(path);
-    if (!file.is_open()) return {};
+std::optional<std::string> HotReloader::try_read_file(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) return std::nullopt;
     std::ostringstream ss;
     ss << file.rdbuf();
     return ss.str();
 }
 
-void HotReloader::seed_observed_write_times() {
+std::string HotReloader::read_file(const std::filesystem::path& path) {
+    return try_read_file(path).value_or(std::string{});
+}
+
+void HotReloader::seed_observed_content_hashes() {
     auto remember = [this](const std::filesystem::path& path) {
         const auto ext = path.extension().string();
         if (ext != ".js" && ext != ".mjs")
             return;
 
-        std::error_code ec;
-        const auto write_time = std::filesystem::last_write_time(path, ec);
-        if (!ec)
-            observed_write_times_[path.lexically_normal().string()] = write_time;
+        if (auto content = try_read_file(path)) {
+            const auto key = path.lexically_normal().string();
+            observed_content_hashes_[key] = content_hash(*content);
+        }
     };
 
     std::error_code ec;
@@ -158,18 +162,30 @@ void HotReloader::seed_observed_write_times() {
 }
 
 bool HotReloader::should_reload_for_modified_file(const std::filesystem::path& path) {
-    std::error_code ec;
-    const auto write_time = std::filesystem::last_write_time(path, ec);
-    if (ec)
+    auto content = try_read_file(path);
+    if (!content)
         return false;
 
     const auto key = path.lexically_normal().string();
-    auto it = observed_write_times_.find(key);
-    if (it != observed_write_times_.end() && write_time <= it->second)
+    const auto next_hash = content_hash(*content);
+    auto hash_it = observed_content_hashes_.find(key);
+    if (hash_it != observed_content_hashes_.end() && next_hash == hash_it->second)
         return false;
 
-    observed_write_times_[key] = write_time;
+    observed_content_hashes_[key] = next_hash;
     return true;
+}
+
+std::uint64_t HotReloader::content_hash(std::string_view content) {
+    constexpr std::uint64_t offset = 14695981039346656037ull;
+    constexpr std::uint64_t prime = 1099511628211ull;
+
+    std::uint64_t hash = offset;
+    for (unsigned char c : content) {
+        hash ^= c;
+        hash *= prime;
+    }
+    return hash;
 }
 
 } // namespace pulp::view

--- a/test/test_hot_reload.cpp
+++ b/test/test_hot_reload.cpp
@@ -201,7 +201,7 @@ TEST_CASE("HotReloader directory watching", "[view][hotreload]") {
     std::filesystem::remove_all(tmp_dir);
 }
 
-TEST_CASE("HotReloader seeds observed JS files and ignores stale events",
+TEST_CASE("HotReloader seeds observed JS file content",
           "[view][hotreload]") {
     auto tmp_dir = make_temp_dir("pulp_hotreload_seed");
     auto entry = tmp_dir / "main.js";
@@ -214,9 +214,9 @@ TEST_CASE("HotReloader seeds observed JS files and ignores stale events",
 
     HotReloader reloader(tmp_dir, "main.js", [](const std::string&) {});
 
-    REQUIRE(reloader.observed_write_times_.count(entry.lexically_normal().string()) == 1);
-    REQUIRE(reloader.observed_write_times_.count(module.lexically_normal().string()) == 1);
-    REQUIRE(reloader.observed_write_times_.count(ignored.lexically_normal().string()) == 0);
+    REQUIRE(reloader.observed_content_hashes_.count(entry.lexically_normal().string()) == 1);
+    REQUIRE(reloader.observed_content_hashes_.count(module.lexically_normal().string()) == 1);
+    REQUIRE(reloader.observed_content_hashes_.count(ignored.lexically_normal().string()) == 0);
     std::string reloaded_code;
     HotReloader changed_reloader(tmp_dir, "main.js", [&](const std::string& code) {
         reloaded_code = code;
@@ -240,8 +240,52 @@ TEST_CASE("HotReloader file seed skips non-JS files and missing paths",
 
     HotReloader reloader(text_file, [](const std::string&) {});
 
-    REQUIRE(reloader.observed_write_times_.empty());
+    REQUIRE(reloader.observed_content_hashes_.empty());
     REQUIRE_FALSE(reloader.poll_reload());
+
+    std::filesystem::remove_all(tmp_dir);
+}
+
+TEST_CASE("HotReloader ignores same-content rewrites",
+          "[view][hotreload]") {
+    auto tmp_dir = make_temp_dir("pulp_hotreload_same_content");
+    auto entry = tmp_dir / "main.js";
+
+    write_js_file(entry, "// entry v1");
+
+    HotReloader reloader(entry, [](const std::string&) {});
+    REQUIRE(reloader.observed_content_hashes_.count(entry.lexically_normal().string()) == 1);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    write_js_file(entry, "// entry v1");
+    REQUIRE_FALSE(reloader.should_reload_for_modified_file(entry));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    write_js_file(entry, "// entry v2");
+    REQUIRE(reloader.should_reload_for_modified_file(entry));
+
+    std::filesystem::remove_all(tmp_dir);
+}
+
+TEST_CASE("HotReloader content hash still reloads changed modules",
+          "[view][hotreload]") {
+    auto tmp_dir = make_temp_dir("pulp_hotreload_module_hash");
+    auto entry = tmp_dir / "main.js";
+    auto module = tmp_dir / "module.mjs";
+
+    write_js_file(entry, "// entry v1");
+    write_js_file(module, "// module v1");
+
+    HotReloader reloader(tmp_dir, "main.js", [](const std::string&) {});
+    REQUIRE(reloader.observed_content_hashes_.count(module.lexically_normal().string()) == 1);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    write_js_file(module, "// module v1");
+    REQUIRE_FALSE(reloader.should_reload_for_modified_file(module));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    write_js_file(module, "// module v2");
+    REQUIRE(reloader.should_reload_for_modified_file(module));
 
     std::filesystem::remove_all(tmp_dir);
 }


### PR DESCRIPTION
## Summary

- Track observed hot-reload `.js` / `.mjs` content by hash instead of filesystem write time.
- Ignore same-content rewrites and duplicate watcher events while still reloading changed entry files and changed modules.
- Treat transient unreadable files as no-reload without poisoning the remembered baseline.
- Read watched source files in binary mode so the content hash reflects the actual file bytes.
- Bump SDK/CLI to `0.529.0` as required for this user-facing `fix:` branch.

This is intentionally narrow: it improves the existing standalone/scripted JS UI hot reloader. It does not implement Truce-style live DSP reload or an in-DAW dynamic plugin shell.

## Validation

Exact pushed head: `9fd2a1ef555fae45b7854eb00d50bdfa585f6afb`  
Current base: `origin/main` `764798026a92898f9408b3e2afda81ed07c62dbc`

- `cmake --build build --target pulp-test-hot-reload -j$(sysctl -n hw.ncpu)` (`Pulp 0.529.0`)
- `./build/test/pulp-test-hot-reload --reporter compact` -> `60` assertions / `13` cases
- `ctest --test-dir build -R "HotReloader|hot reload|hot_reload" --output-on-failure` -> `13/13`
- Release proof: `build/CMakeCache.txt` has `CMAKE_BUILD_TYPE=Release`
- Release flag proof: `pulp-view-script` and `pulp-test-hot-reload` flags include `-O3 -DNDEBUG`
- `bash tools/scripts/gates.sh origin/main`
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/classify_changes.py --base origin/main --json` -> `native_build_required=true`
- `git merge-tree --write-tree origin/main HEAD` -> `8aada4c861eb2c8e37d9908c302331aaeaa04969`
- Pre-push fast gates passed during `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --force-with-lease origin feature/cleanup-audit-hotreload-content-hash`

`tools/scripts/local_diff_cover.sh pulp-test-hot-reload` is not counted as evidence. An earlier run ignored the narrow target and entered the broad coverage CTest path; it was stopped and the focused Release proof above is the validation record for this PR.

## Review

Strict local adversarial/code-health review found no must-fix before PR:

- Four touched files; largest touched file is `CMakeLists.txt` at `504` LOC and largest touched test/source file is `test/test_hot_reload.cpp` at `388` LOC.
- The implementation stays inside the existing view hot-reload component.
- No public API is added.
- No runtime/importer/rendering/layout/platform boundary moves.
- The content-hash helper remains private to `HotReloader`.

Should-fix-soon / deferred:

- Truce-level DSP/plugin-shell hot reload remains a separate architecture item, not part of this PR.
- Custom editor/UI-backend reload behavior and DAW-host hot reload semantics still need a dedicated design if Pulp decides to pursue them.

Claude bridge review was attempted on this exact head but returned only an execution error after interruption (`error_during_execution`, `aborted_streaming`, session `4b7f0c54-0882-4c34-8329-5182aaee3228`), so no Claude approval is claimed.