### PR TITLE
docs(cli): clarify focus-mode monitor scope

### DIFF
--- a/docs/guides/focus-mode.md
+++ b/docs/guides/focus-mode.md
@@ -3,6 +3,11 @@
 > Status: **experimental**. The CLI persists focus state and runs the normal
 > watch loop; surrounding tooling can read the focus marker for
 > single-platform iteration workflows.
+>
+> Current scope: the focus marker and normal watch loop are implemented today.
+> Automatic PR-state monitoring and archive-splice helpers are still deferred;
+> their flags are compatibility surfaces that print diagnostics and leave the
+> manual playbook below as the current workflow.
 
 ## Background
 
@@ -16,7 +21,9 @@ ran a tight dev loop that closed 5 framework gaps in about 2 hours:
 5. Upstream agents picked up all 6 sub-issues; PRs merged within 2 hours, auto-released as v0.54.0–v0.56.0.
 6. Bumped the consumer's SDK pin from `0.52.0 → 0.56.0` in one shot. Massive visible parity gain confirmed via screenshot.
 
-`pulp loop` codifies this loop as an explicit, opt-in mode.
+`pulp loop` codifies the available CLI part of this loop as an explicit,
+opt-in mode. The broader analyzer, local-prototype, and upstream-monitoring
+steps remain a documented manual playbook until their dedicated helpers land.
 
 ## When to use focus mode
 
@@ -56,7 +63,9 @@ Full flag reference: [`docs/reference/cli.md#loop`](../reference/cli.md#loop).
 
 ## Recommended playbook
 
-The leveraged-prototype loop has five steps.
+The leveraged-prototype loop has five steps. Today, `pulp loop` automates the
+focus marker plus watch loop; the surrounding analyzer, local-prototype,
+PR-monitor, and SDK-bump steps are still manual.
 
 ### 1. Analyze the consumer's bundle
 
@@ -84,9 +93,12 @@ small and validate the patched SDK before treating the result as proof.
 
 ### 4. Monitor upstream PR state flips
 
-Use GitHub issue and PR searches to watch the upstream batch. The important
-signal is when each PR linked to a filed gap merges and the SDK release that
-contains it is available to the consumer.
+Automatic `pulp loop --watch-issues` monitoring is deferred today. The current
+CLI recognizes the flag, prints a diagnostic, and continues the normal loop.
+
+Use GitHub issue and PR searches to watch the upstream batch manually. The
+important signal is when each PR linked to a filed gap merges and the SDK
+release that contains it is available to the consumer.
 
 ### 5. Bump the SDK pin and validate cross-platform
 


### PR DESCRIPTION
## Summary

- Clarifies `docs/guides/focus-mode.md` so the public guide matches current `pulp loop` behavior.
- States that the implemented surface is the focus marker plus normal watch loop.
- Marks automatic PR-state monitoring / archive-splice helpers as deferred/manual today.

## Audit Finding

`RA-CLI-052`: `docs/guides/focus-mode.md` still read as though the historical upstream PR-state monitor was part of the current loop. Current code and tests show a narrower surface: `tools/cli/cmd_loop.cpp` accepts `--watch-issues`, prints a recognized-but-not-implemented diagnostic, and continues the normal loop; `test/test_cli_shellout_loop.cpp` pins that behavior. `docs/reference/cli.md`, `docs/status/cli-commands.yaml`, and `.agents/skills/prototype-loop/SKILL.md` already describe the deferred state.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/guides/focus-mode.md`
- `python3 tools/docs_generate.py check`
- `python3 tools/scripts/docs_sync_check.py --config tools/scripts/docs_sync_map.json`
- `tools/check-docs.sh` (passes with existing 109 warnings)
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=false`)
- `bash tools/scripts/gates.sh origin/main`
- pre-push fast gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`

## Review

Strict local code-health review found no must-fix or should-fix-soon item: this is one small docs-only correction in a 134-line guide, no source/API/state/layer-boundary change, no new abstraction, and no large-file growth. The prototype-loop skill already carried the deferred-monitor guidance, so the commit uses a `Skill-Update` skip trailer instead of duplicating prose.

Claude bridge second-opinion was attempted, but returned only an `error_during_execution` / `aborted_streaming` envelope after being stopped for silence (`session_id=0690d683-988a-4d47-939f-1b04ea733e0f`). No Claude approval is claimed.

## Shipyard Note

`shipyard pr` currently has no create-only/no-auto-merge mode. This PR was opened directly with `gh pr create` to preserve the active audit rule: do not merge without explicit user instruction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/guides/focus-mode.md` to reflect current `pulp loop` scope: only the focus marker and the normal watch loop are implemented.
Clarifies that automatic PR-state monitoring and archive-splice helpers remain deferred; flags like `--watch-issues` are recognized but only print a diagnostic, and the manual playbook is the path today.

<sup>Written for commit a144f44594f11a8aa567e51c4c4cc441aa52bf56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

