### PR TITLE
docs(cli): clarify dev watch fallback

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1438,6 +1438,15 @@ Set `PULP_HOME` to relocate the SDK cache, asset cache, and config root.
 
 Unified development loop. Combines `build --watch` with optional test, validate, and launch-an-app steps in a single command so you can keep one terminal open while iterating.
 
+The live watch/relaunch loop is implemented by the C++ delegate (`pulp-cpp`).
+Normal installed/source builds ship the Rust `pulp` front end with that sibling
+delegate, so `pulp dev` forwards to the full watch loop when `pulp-cpp` is
+available. If the delegate is unavailable or fallthrough is disabled, the Rust
+fallback runs one configure/build pass, optionally runs tests, optionally
+launches once, and prints a watch-loop stub notice instead of watching for
+changes. The `--validate` and `--allow-unsupported-sdk` dev-loop behavior is
+therefore part of the delegated C++ path.
+
 ```bash
 pulp dev                                      # Watch and rebuild
 pulp dev --test                               # Watch, rebuild, run tests
@@ -1454,13 +1463,13 @@ Flags:
 
 | Flag | Description |
 |------|-------------|
-| `--test`, `-t` | Run tests after each successful build |
+| `--test`, `-t` | Run tests after each successful watch build, or after the Rust fallback's one build pass |
 | `--test-filter=PATTERN` | Run only tests matching PATTERN (implies `--test`) |
-| `--validate` | Run quick plugin dlopen validation after build |
-| `--run TARGET` | Launch TARGET from the build dir; relaunch on rebuild |
-| `--design SCRIPT` | Build `pulp-design-tool` and launch it with SCRIPT |
+| `--validate` | Delegated C++ path: run quick plugin dlopen validation after build |
+| `--run TARGET` | Launch TARGET from the build dir; delegated watch mode relaunches on rebuild, Rust fallback launches once |
+| `--design SCRIPT` | Build `pulp-design-tool` and launch it with SCRIPT; delegated watch mode relaunches on rebuild, Rust fallback launches once |
 | `--target T` | Pass `--target T` to `cmake --build` |
-| `--allow-unsupported-sdk` | Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported) |
+| `--allow-unsupported-sdk` | Delegated C++ path: bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported) |
 | `-- args...` | Arguments passed to the launched app |
 
 `pulp dev` runs the same active-project compatibility preflight as `pulp build`. If the project pins an SDK or `cli_min_version` newer than the installed CLI, the command stops before SDK resolution/build and points at `pulp upgrade`.

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -1694,29 +1694,29 @@ commands:
 
   - name: dev
     status: usable
-    summary: Unified development loop — watch, rebuild, and optionally test, validate, or relaunch an app on every change.
+    summary: Unified development loop — the Rust front end delegates to `pulp-cpp` for the live watch/rebuild loop when the sibling delegate is available; the Rust-only fallback performs one build/test/run pass and prints a watch-loop stub notice.
     args:
       - name: --test
         kind: flag
-        description: Run tests after each successful build
+        description: Run tests after each successful build in delegated watch mode, or after the one Rust fallback build pass
       - name: --test-filter
         kind: option
         description: Run only tests matching PATTERN (implies --test)
       - name: --validate
         kind: flag
-        description: Run quick plugin dlopen validation after build
+        description: Run quick plugin dlopen validation after build in the delegated C++ dev loop; Rust fallback prints a validator-not-ported notice and continues without validation
       - name: --run
         kind: option
-        description: Launch a build-dir binary and relaunch it on rebuild
+        description: Launch a build-dir binary and relaunch it on rebuild in delegated watch mode; Rust fallback launches once
       - name: --design
         kind: option
-        description: Build pulp-design-tool and launch it with the given JS script
+        description: Build pulp-design-tool and launch it with the given JS script; delegated watch mode relaunches on rebuild, Rust fallback launches once
       - name: --target
         kind: option
         description: Pass --target to cmake --build
       - name: --allow-unsupported-sdk
         kind: flag
-        description: Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported)
+        description: Bypass the CLI-vs-project SDK compatibility guard in the delegated C++ dev loop and continue anyway (unsupported)
       - name: passthrough
         kind: passthrough
         description: Arguments after `--` are forwarded to the launched binary


### PR DESCRIPTION
## Summary
- Clarifies that the full live `pulp dev` watch/relaunch loop is implemented by the C++ `pulp-cpp` delegate.
- Documents the Rust-only fallback as a one-shot configure/build/test/run path with a watch-loop stub notice.
- Aligns `docs/status/cli-commands.yaml` dev command descriptions with the current Rust/C++ split.

## Audit Finding
`docs/reference/cli.md` and `docs/status/cli-commands.yaml` described `pulp dev` as an unconditional watch/rebuild/relaunch loop. Current code shows the Rust front end delegates `pulp dev` to `pulp-cpp` when available, but falls back to a one-shot path if the delegate is unavailable or fallthrough is disabled (`experimental/pulp-rs/src/cmd/dev.rs`). The C++ delegate remains the implementation of the live watch loop (`tools/cli/cmd_dev.cpp`).

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py docs/reference/cli.md docs/status/cli-commands.yaml`
- `python3 tools/docs_generate.py check`
- `python3 tools/scripts/docs_sync_check.py --config tools/scripts/docs_sync_map.json`
- `tools/check-docs.sh` (passes with existing 109 warnings)
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` (`native_build_required=false`)
- `bash tools/scripts/gates.sh origin/main`
- pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`

## Review
Strict local code-health review found no must-fix or should-fix-soon item: this is a two-file docs/status alignment, no source/API/state/runtime/importer/rendering/layout/platform boundary change, and no new abstraction. Acceptable-for-now: the Rust fallback remains one-shot; this PR documents that existing behavior rather than changing it.

Claude bridge review was attempted on the exact committed diff, but it stayed silent for about a minute and returned only an aborted execution envelope (`error_during_execution`, `aborted_tools`, session `642debd3-0196-44d9-a1c9-9370a5175bfc`), so no Claude approval is claimed.

Opened with `gh pr create` because `shipyard pr` is still a one-shot ship flow without a create-only/no-merge mode. Do not merge without explicit user instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `pulp dev`’s live watch/relaunch loop is implemented by `pulp-cpp`, and documents the Rust-only fallback as a one-shot build/test/run with a watch-loop stub notice. Updates `docs/reference/cli.md` and `docs/status/cli-commands.yaml` to align summaries and flag descriptions with the Rust/C++ split.

<sup>Written for commit 14263b51bce0d8e7be9723e9460eaf46d18824c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

