### PR TITLE
docs(view): clarify CSS background status

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -734,7 +734,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+        "test/test_widget_bridge_wave5_css.cpp::Wave5 css/backgroundPosition wires JS \u2192 bridge \u2192 View slot"
       ],
       "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
       "issue": ""
@@ -752,10 +752,9 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge_css_misc.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
-        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+        "test/test_widget_bridge_css_misc.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View"
       ],
-      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
+      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op; the entry is supported because the declared value parses and round-trips, with this storage-only paint caveat recorded here. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
       "issue": "1552"
     },
     "css/backgroundSize": {
@@ -770,7 +769,7 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+        "test/test_widget_bridge_wave5_css.cpp::Wave5 css/backgroundSize wires JS \u2192 bridge \u2192 View slot"
       ],
       "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader \u2014 without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
       "issue": ""

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -161,9 +161,9 @@ specifics are out of scope.
     multiple-bg / size-in-shorthand are `arch-single-bg`. `backgroundClip text` is
     `arch-paint-deferred` (SkBlendMode::kSrcIn against text glyphs is
     queued; the slot stores the value). `backgroundPosition` /
-    `backgroundSize` are `partial-deferred-paint-time` — the JS shim
-    type-guards the bridge call, parser is ready, bridge fn
-    registration lands in a follow-up.
+    `backgroundSize` are `partial-deferred-paint-time`: the JS shim
+    routes to registered bridge functions, and the bridge stores the
+    value on the View for future raster background paint to consume.
   * **Mask family (2 entries — `mask`, `maskImage`):** mask
     sub-properties (mode/repeat/position/size/origin/clip/composite)
     are `arch-paint-deferred`; the shorthand routes mask-image to
@@ -436,8 +436,8 @@ specifics are out of scope.
   `background_repeat_` (storage-only — paint-time honoring lands
   with the `background-image: url(...)` / repeating-gradient work).
   Reclassified `css/lineClamp` and `css/webkitLineClamp` to
-  `supported`; `css/backgroundRepeat` stays `partial` with the
-  honest "storage-only" caveat.
+  `supported`; `css/backgroundRepeat` is also `supported` as a stored
+  and queryable value, with the honest "storage-only" paint caveat.
 - **Already-implemented CSS features promoted to catalog entries** —
   13 already-implemented CSS features
   promoted to first-class catalog entries. Pure catalog add — no
@@ -690,12 +690,12 @@ specifics are out of scope.
   translator forwards `'NN%'` strings verbatim and the bridge
   routes them via `FlexStyle.dim_*` / `YGNodeStyleSet*Percent`).
   `css/backgroundSize`, `css/backgroundPosition`, `css/backgroundRepeat`,
-  `css/lineClamp`, `css/webkitLineClamp`, and `css/wordWrap` flipped
-  `missing` → `partial` to reflect that the JS translator (in
-  `web-compat-style-decl.js`) already routes them; the bridge functions
-  remain unregistered so the values silently drop at runtime, but the
-  catalog status now matches the harness verdict (DIVERGE). Drift on
-  these six entries is cleared. Nine remaining `css/animation*` and
+  `css/lineClamp`, `css/webkitLineClamp`, and `css/wordWrap` were
+  refreshed to match the JS translator and bridge surface. The
+  background size/position/repeat bridge functions are now registered
+  and store the values on View; visual paint for raster backgrounds
+  remains deferred. Drift on these six entries is cleared. Nine remaining
+  `css/animation*` and
   `css/touchAction` entries closed via the `noop` vocabulary extension
   (see next entry).
 - **Catalog vocabulary extension** — The harness
@@ -777,31 +777,16 @@ specifics are out of scope.
 - `css/__hover_pseudo`: new entry. Documents the bounded `:hover`
   support in `web-compat-document.js`.
 
-## Silent no-ops (parser exists, backend stub)
+## No-op And Storage-Only Caveats
 
-The JS adapter parses these and calls the bridge function; the bridge
-function is **not registered**, so the value is silently dropped.
-`typeof` guards prevent runtime errors.
+Use `compat.json` as the source of truth for current noop, partial, and
+storage-only CSS entries. This narrative avoids a hand-maintained static
+list because these properties move as bridge functions land.
 
-1. `css/animation*` (8 props) — `setAnimation` is registered but the
-   body is `(void)id; (void)prop; …` (widget_bridge.cpp:3242). All
-   `@keyframes` UIs animate nothing.
-2. `css/aspectRatio` — JS routes via `setFlex(id, "aspect_ratio", …)`
-   but `setFlex`'s C++ switch has no `aspect_ratio` branch.
-3. `css/boxSizing` — `setBoxSizing` referenced, never registered.
-4. `css/lineClamp` / `css/webkitLineClamp` — `setLineClamp` referenced,
-   never registered. Multi-line truncation impossible.
-5. `css/backgroundSize` / `css/backgroundPosition` /
-   `css/backgroundRepeat` — three setters referenced, none registered.
-   Tied to `backgroundImage: url()` which is also missing.
-6. `css/outline` / `css/outlineWidth` / `css/outlineColor` —
-   `setOutline` referenced, never registered. Affects accessibility
-   focus rings.
-7. `css/textShadow` — `setTextShadow` referenced, never registered.
-8. `css/wordBreak` / `css/overflowWrap` / `css/wordWrap` —
-   `setWordBreak` referenced, never registered.
-9. `css/touchAction` — parsed and stored on the JS Element instance
-   but never propagated to the C++ hit-test.
+The current background-size / background-position / background-repeat caveat is
+storage-only rather than missing bridge wiring: the JS style adapter calls the
+registered bridge functions, and View preserves the values. They have no visual
+effect until raster `background-image: url(...)` paint is wired.
 
 ## Known buggy-but-supported
 

--- a/docs/reference/w3c-coverage.md
+++ b/docs/reference/w3c-coverage.md
@@ -122,9 +122,9 @@ ctest --test-dir build --output-on-failure --exclude-regex AudioWorkgroup
 | `background-color` | ✅ | Full CSS Color L4 |
 | `background-image` (gradient) | ✅ | linear-gradient with multi-stop |
 | `background-image` (URL) | ❌ | Only gradients, not images |
-| `background-size` | ⚠️ | CSS parsed, bridge stub |
-| `background-position` | ⚠️ | CSS parsed, bridge stub |
-| `background-repeat` | ⚠️ | CSS parsed, bridge stub |
+| `background-size` | ⚠️ | CSS parsed and round-tripped to a storage-only View slot; raster background paint is deferred |
+| `background-position` | ⚠️ | CSS parsed and round-tripped to a storage-only View slot; raster background paint is deferred |
+| `background-repeat` | ⚠️ | CSS parsed and round-tripped to a storage-only View slot; raster background paint is deferred |
 | `border` (shorthand) | ✅ | width + style + color |
 | `border-top` / `right` / `bottom` / `left` | ✅ | Per-side borders |
 | `border-width` / `color` per-side | ✅ | |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -259,7 +259,9 @@ css_parity:
       CSS Backgrounds Level 3: background-color, linear-gradient (4 directions +
       multi-stop). Border: width, color, radius (per-corner planned). Box shadow:
       offset, blur, spread, color. JS bridge: setBackground, setBorder,
-      setBackgroundGradient, setBoxShadow.
+      setBackgroundGradient, setBackgroundRepeat, setBackgroundPosition,
+      setBackgroundSize, setBoxShadow. The size/position/repeat bridge slots
+      are storage-only until raster background-image paint is wired.
   filters:
     status: usable
     notes: >
@@ -361,7 +363,8 @@ css_parity:
     notes: >
       flex-flow, place-items, place-content, inset, box-sizing (parsed),
       margin-inline/block, padding-inline/block (CSS logical properties),
-      -webkit-line-clamp, background-repeat (parsed).
+      -webkit-line-clamp, background-repeat/position/size (parsed and
+      round-tripped; raster background paint deferred).
   media_queries:
     status: usable
     notes: >


### PR DESCRIPTION
## Summary

Repository reality audit finding `RA-VIEW-013`: CSS background subproperty documentation/status drifted behind the implementation.

This PR updates the docs/status registry for `background-size`, `background-position`, and `background-repeat` to match current code: the JS style adapter routes these properties to registered bridge functions, and the bridge stores the values on `View`. It keeps the raster-paint caveat explicit: `background-image: url(...)` paint is still deferred, so these values are storage-only until that pipeline exists.

This is docs/status/compat-data only. It does not change runtime behavior.

## Evidence

Implementation already present on `origin/main`:

- `core/view/src/widget_bridge/style_storage_api.cpp` registers `setBackgroundRepeat`, `setBackgroundPosition`, and `setBackgroundSize`.
- `core/view/js/web-compat-style-decl-paint.js` routes `backgroundSize`, `backgroundPosition`, and `backgroundRepeat` to those bridge functions.
- `core/view/include/pulp/view/view.hpp` has storage-only slots for `background_repeat_`, `background_position_`, and `background_size_`.
- `test/test_widget_bridge_wave5_css.cpp` covers JS -> bridge -> View slot for `backgroundPosition` and `backgroundSize`.
- `test/test_widget_bridge_css_misc.cpp` covers `backgroundRepeat` round-trip.

## Validation

- `python3 -m json.tool compat.json`
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py docs/reference/compat/css.md docs/reference/w3c-coverage.md docs/status/support-matrix.yaml`
- `python3 tools/docs_generate.py check`
- `python3 tools/scripts/docs_sync_check.py --config tools/scripts/docs_sync_map.json`
- `python3 tools/scripts/compat_sync_check.py --mode=report --base origin/main`
- `tools/check-docs.sh` passed with existing 109 warnings
- `bash tools/scripts/gates.sh origin/main`
- `python3 tools/harness/verifier.py --surface css --json --no-docs` passed; stderr has no touched background-entry warnings
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` reports `native_build_required=true` because `compat.json` changed
- `git merge-tree --write-tree origin/main HEAD` -> `3a4707e2a2c7142b8498877c6fd33b00dc355593`
- Pre-push gates passed. Diff coverage was intentionally skipped locally with `PULP_DISABLE_PREPUSH_DIFF_COVER=1 PULP_SKIP_DIFF_COVER=1`; this PR is docs/status/compat data only, and CI still classifies it as native-build-required due `compat.json`.

## Architectural / Code-Health Review

Must-fix before PR: none found. The patch is constrained to docs/status/compat-data and does not alter runtime/importer/rendering/layout/platform boundaries.

Should-fix soon: `docs/status/support-matrix.yaml` is already over 1k LOC, and `compat.json` is a large registry-style file. This PR avoids broad restructuring, but future compatibility/status cleanup should keep pressure on generated or indexed views rather than adding more hand-maintained narrative. The CSS harness still emits unrelated stale-evidence warnings outside the touched background entries; those should be handled as separate focused audit items.

Acceptable for now: updating three existing `compat.json` entries and nearby docs is lower risk than adding new abstraction. The storage-only caveat is repeated in the status matrix, W3C coverage table, CSS compatibility narrative, and per-entry notes so the docs do not claim raster background image paint exists.

## Claude Review

Attempted a current-head Claude bridge review for the diff. The bridge returned `error_during_execution` / `aborted_streaming` after interruption, session `5243164c-088b-41d5-9a88-25b8789e1dff`, with no substantive review content. This PR does not claim Claude approval.

## PR Workflow Note

`shipyard pr` is the normal Pulp PR path, but this checkout's `shipyard pr --help` exposes create/validate/merge behavior and no create-only/no-auto-merge mode. I used direct `gh pr create` as a manual fallback so this audit PR is opened for review without arming an automatic merge. Do not merge without explicit user instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs and compatibility registry to reflect current CSS background support: `background-size`, `background-position`, and `background-repeat` now route through the JS style adapter to registered bridge functions and are stored on `View`. They’re documented as supported with a storage-only caveat; raster `background-image: url(...)` paint is still deferred, so these values have no visual effect yet.

<sup>Written for commit 05405da8f0ae7ffe07812422a081178abf39795b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

