### PR TITLE
docs(import): clarify generated static control values

### DIFF
--- a/core/view/src/design_cpp_codegen.cpp
+++ b/core/view/src/design_cpp_codegen.cpp
@@ -985,7 +985,7 @@ void emit_widget_specific(std::ostringstream& out,
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_label(" + cpp_string_literal(text) + ");");
             const auto value = float_expr(ctx, semantics.normalized_value);
             const auto default_value = float_expr(ctx, semantics.normalized_default);
-            emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_value(/* TODO: bind to param */ " + value + ");");
+            emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_value(/* imported static param value */ " + value + ");");
             emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_default_value(" + default_value + ");");
             if (semantics.widget_schema)
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_widget_schema(" + cpp_string_literal(*semantics.widget_schema) + ");");
@@ -997,7 +997,7 @@ void emit_widget_specific(std::ostringstream& out,
             if (!text.empty())
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_label(" + cpp_string_literal(text) + ");");
             emit_line(out, depth, opts.indent_spaces,
-                      std::string(var) + "->set_value(/* TODO: bind to param */ " +
+                      std::string(var) + "->set_value(/* imported static param value */ " +
                           float_expr(ctx, semantics.normalized_value) + ");");
             if (semantics.horizontal)
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_orientation(pulp::view::Fader::Orientation::horizontal);");
@@ -1025,7 +1025,7 @@ void emit_widget_specific(std::ostringstream& out,
             const auto value = float_expr(ctx, semantics.normalized_value);
             const auto peak = float_expr(ctx, semantics.peak_value);
             emit_line(out, depth, opts.indent_spaces,
-                      std::string(var) + "->set_level(/* TODO: bind to meter */ " + value + ", " + peak + ");");
+                      std::string(var) + "->set_level(/* imported static meter level */ " + value + ", " + peak + ");");
             if (semantics.horizontal)
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_orientation(pulp::view::Meter::Orientation::horizontal);");
             break;

--- a/test/fixtures/design_import_generated_cpp_fixture.cpp
+++ b/test/fixtures/design_import_generated_cpp_fixture.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<pulp::view::View> build_imported_ui() {
     drive_flex.preferred_height = 72.0f;
     drive_flex.dim_height = {72.0f, pulp::view::DimensionUnit::px};
     node_1->set_label("Drive");
-    node_1->set_value(/* TODO: bind to param */ 0.5f);
+    node_1->set_value(/* imported static param value */ 0.5f);
     node_1->set_default_value(0.5f);
     node_0->add_child(std::move(node_1));
 

--- a/test/test_design_import_cpp_codegen.cpp
+++ b/test/test_design_import_cpp_codegen.cpp
@@ -3120,18 +3120,18 @@ TEST_CASE("typed DesignIR smoke emits typed baked C++ controls",
     REQUIRE(result.source.find("std::make_unique<pulp::view::View>()") != std::string::npos);
 
     REQUIRE(result.source.find("->set_label(\"Drive\");") != std::string::npos);
-    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.7f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* imported static param value */ 0.7f);") != std::string::npos);
     REQUIRE(result.source.find("->set_default_value(0.4f);") != std::string::npos);
     REQUIRE(result.source.find("->set_label(\"Mix\");") != std::string::npos);
-    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.25f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* imported static param value */ 0.25f);") != std::string::npos);
     REQUIRE(result.source.find("->set_thumb_shape(pulp::view::Fader::ThumbShape::rectangle);") != std::string::npos);
     REQUIRE(result.source.find("->set_thumb_size(17.0f, 5.0f);") != std::string::npos);
     REQUIRE(result.source.find("->set_thumb_corner_radius(1.0f);") != std::string::npos);
     REQUIRE(result.source.find("->set_label(\"Trim\");") != std::string::npos);
-    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.55f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* imported static param value */ 0.55f);") != std::string::npos);
     REQUIRE(result.source.find("->set_thumb_shape(pulp::view::Fader::ThumbShape::circle);") != std::string::npos);
     REQUIRE(result.source.find("->set_thumb_size(12.0f, 12.0f);") != std::string::npos);
-    REQUIRE(result.source.find("->set_level(/* TODO: bind to meter */ 0.62f, 0.62f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_level(/* imported static meter level */ 0.62f, 0.62f);") != std::string::npos);
     REQUIRE(result.source.find("->set_orientation(pulp::view::Meter::Orientation::horizontal);") != std::string::npos);
     REQUIRE(result.source.find("->set_x(0.3f);") != std::string::npos);
     REQUIRE(result.source.find("->set_y(0.8f);") != std::string::npos);
@@ -3229,7 +3229,7 @@ TEST_CASE("Chainer route overlay can lower one knob to typed C++ with binding si
     REQUIRE(count_occurrences(result.source, "std::make_unique<pulp::view::Knob>()") == 1);
     REQUIRE(result.source.find("->set_anchor_id(\"pr_2c\");") != std::string::npos);
     REQUIRE(result.source.find("->set_label(\"freq\");") != std::string::npos);
-    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.35f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* imported static param value */ 0.35f);") != std::string::npos);
     REQUIRE(result.source.find("->set_default_value(0.35f);") != std::string::npos);
     REQUIRE(result.source.find("->set_widget_schema(") != std::string::npos);
     REQUIRE(result.source.find("->set_show_label(false);") != std::string::npos);
@@ -4007,8 +4007,8 @@ TEST_CASE("Chainer route overlay can lower meter bars to typed C++ with meter in
     REQUIRE(count_occurrences(result.source, "std::make_unique<pulp::view::Meter>()") == 2);
     REQUIRE(result.source.find("->set_anchor_id(\"pr_6v\")") != std::string::npos);
     REQUIRE(result.source.find("->set_anchor_id(\"pr_6z\")") != std::string::npos);
-    REQUIRE(result.source.find("->set_level(/* TODO: bind to meter */ 0.72f, 0.72f);") != std::string::npos);
-    REQUIRE(result.source.find("->set_level(/* TODO: bind to meter */ 0.65f, 0.65f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_level(/* imported static meter level */ 0.72f, 0.72f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_level(/* imported static meter level */ 0.65f, 0.65f);") != std::string::npos);
     REQUIRE(result.header.find("bind_imported_ui(pulp::view::View& root, pulp::view::NativeImportBindingContext& ctx)") != std::string::npos);
     REQUIRE(count_occurrences(result.source, "ctx.bind_meter(") == 2);
 
@@ -7292,8 +7292,8 @@ TEST_CASE("baked C++ exporter emits ownable C++ source artifacts",
     REQUIRE(result.source.find("assets::kLogo") != std::string::npos);
     REQUIRE(result.source.find("// auto-extracted: structural name \"Header\"") != std::string::npos);
     REQUIRE(result.source.find("std::unique_ptr<pulp::view::View> build_header()") != std::string::npos);
-    REQUIRE(result.source.find("/* TODO: bind to param */") != std::string::npos);
-    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.2f);") != std::string::npos);
+    REQUIRE(result.source.find("/* imported static param value */") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* imported static param value */ 0.2f);") != std::string::npos);
     REQUIRE(result.source.find("->set_default_value(0.75f);") != std::string::npos);
     REQUIRE(result.source.find("std::make_unique<pulp::view::Knob>()") != std::string::npos);
     REQUIRE(result.source.find("build_native_view_tree") == std::string::npos);

--- a/test/test_import_design_tool.cpp
+++ b/test/test_import_design_tool.cpp
@@ -597,7 +597,7 @@ TEST_CASE("pulp-import-design validates phase 0.5 import vocabulary",
         REQUIRE(source.find("std::make_unique<pulp::view::Knob>()") != std::string::npos);
         REQUIRE(source.find("->set_anchor_id(\"pr_2c\");") != std::string::npos);
         REQUIRE(source.find("->set_label(\"freq\");") != std::string::npos);
-        REQUIRE(source.find("->set_value(/* TODO: bind to param */ 0.35f);") != std::string::npos);
+        REQUIRE(source.find("->set_value(/* imported static param value */ 0.35f);") != std::string::npos);
         REQUIRE(source.find("tokens::kChainerOrange") != std::string::npos);
         REQUIRE(binding_manifest.find("\"id\": \"chainer.knob.0.osc_freq\"") != std::string::npos);
         REQUIRE(binding_manifest.find("\"native_primitive\": \"knob\"") != std::string::npos);


### PR DESCRIPTION
## Summary

- Clarifies generated C++ comments for imported static param/meter values.
- Replaces misleading generated `TODO: bind...` comments with `imported static param value` / `imported static meter level`.
- Updates the focused generator tests and generated fixture expectations only.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-import-design-tool -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-import-design-tool "pulp-import-design validates phase 0.5 import vocabulary" --reporter compact` (`238` assertions / `1` case)
- `ctest --test-dir build -R "pulp-import-design validates phase 0.5 import vocabulary" --output-on-failure` (`1/1`)
- stale-string scan confirmed old `TODO: bind to param` / `TODO: bind to meter` strings are absent from the touched generator/test/fixture paths
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/classify_changes.py --mode=files --json ...` and `--mode=diff --base origin/main --json` (`native_build_required=true`)
- `bash tools/scripts/gates.sh origin/main`
- `git merge-tree --write-tree origin/main HEAD` -> `187e8ca408ae025d049e286e2ca9738782c9367d`
- Full pre-push gate completed in this worktree before branch push retry: full `build-cov` build, `ctest --test-dir build-cov --output-on-failure` (`10747/10747`, `0` failed, real time `1373.71s`), and local diff coverage (`100%`, threshold `75%`). The first direct push exited `141` after clean gates, before creating the remote ref; the branch was then pushed with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1` after the full gate had already passed.

Validation limitation: `pulp-test-design-import-cpp-codegen` is skipped on current `origin/main` because the recorded `planning` submodule pin lacks the generated native-ui C++ artifacts. The standalone import-design tool test exercises the same generator path and passed both focused and broad-suite runs.

## Adversarial Review

No must-fix before PR. The diff changes only generated-output wording and matching tests/fixture strings. It adds no abstraction, no branch/state behavior, no public API, and does not move runtime/importer/rendering/layout/platform boundaries. The touched generator and test files are already large, but this patch does not add responsibility or meaningful size.

Claude bridge review was attempted but unavailable locally: `Not logged in`, session `18593031-0ed2-42f2-a7c7-9941230ed3e0`. No Claude approval is claimed.

Do not merge without explicit user instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified generated C++ comments for imported static controls by replacing misleading TODO binding notes with explicit labels: "imported static param value" and "imported static meter level". Updated tests and fixtures to match; no behavior or API changes.

<sup>Written for commit 098d322ba4d5bcf449bd26ebfd26a294bc0c2aaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

