### PR TITLE
docs(host): remove stale automation smoothing TODO

### DIFF
--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -374,7 +374,7 @@ public:
     // Source values are clamped to [0,1] then mapped linearly to
     // [range_lo, range_hi] in the plugin's plain parameter domain.
     //
-    // smoothing_ms applies a per-source linear slew before mixing (TODO).
+    // smoothing_ms applies a per-source linear slew before mix/clamp.
     // MixMode::Replace is the default; a second Replace edge targeting the
     // same (dest, param) is rejected. MixMode::Add sums multiple edges,
     // then clamps to the param's range.


### PR DESCRIPTION
## Summary

- Remove the stale `(TODO)` from the public `SignalGraph::connect_automation` `smoothing_ms` comment.
- Keep the documented behavior scoped to the existing per-source linear slew before mix/clamp.

## Audit Context

RA-HOST-011 found the comment was stale, not the implementation. Current `origin/main` already implements and tests automation smoothing:

- `core/host/src/signal_graph_reference_walk.cpp` applies the per-source linear slew.
- `core/host/src/signal_graph_executor_routing.cpp` carries `automation.smoothing_ms` into the routed executor spec.
- `test/test_host_signal_graph.cpp` covers slewed, bypassed, and eventual-target behavior.
- `test/test_signal_graph_executor_parity.cpp` covers routed parity with per-source slew state across blocks.
- `.agents/skills/hosting/SKILL.md` already documents per-connection automation slew state.

This PR is intentionally comment-only. No runtime behavior, API signature, docs/status manifest, or test behavior changes.

## Validation

- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `a04905c91b04dbe8c80548e2e48136a886153f7e`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main --json` -> `native_build_required=true` because a public host header changed
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `bash tools/scripts/gates.sh origin/main`
- stale-string grep for `smoothing_ms applies.*TODO`, `automation smoothing.*TODO`, and `before mixing (TODO)`
- pre-push fast gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`

Not run locally: native build/header self-containment. This worktree has no `build/compile_commands.json`; the diff is a one-line comment-only public-header cleanup and CI will run the header check.

## Review

Local adversarial/code-health review: no must-fix. One file, one comment line, no new abstraction, no state flow, no API change, no runtime/importer/rendering/layout/platform boundary movement. Acceptable for now: `signal_graph.hpp` is already >1k LOC, but this PR does not add to that structural debt beyond one wording swap.

Claude bridge review was attempted, but returned only an aborted/error envelope with no substantive review content (`session_id=1b76790a-311f-495a-a7eb-c73730857de8`). No Claude approval is claimed.

## Process Note

Opened directly with `gh pr create` rather than `shipyard pr` because this audit run is under a no-merge-without-explicit-instruction rule and `shipyard pr` has no create-only/no-auto-merge mode. Do not merge without explicit user instruction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale `(TODO)` in the public `SignalGraph::connect_automation` `smoothing_ms` comment and clarified the actual behavior: per‑source linear slew occurs before mix/clamp. No code or behavior changes.

<sup>Written for commit 5a16109424d43d3ea0e4e2d4ad0bf4ac84f5a081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

