### PR TITLE
docs(cli): list operator commands in rust help

### DIFF
--- a/experimental/pulp-rs/src/help.rs
+++ b/experimental/pulp-rs/src/help.rs
@@ -172,6 +172,22 @@ pub const COMMANDS: &[Entry] = &[
         name: "coverage",
         summary: "Local coverage tooling (diff-cover gate mirror)",
     },
+    Entry {
+        name: "macos",
+        summary: "Per-PR macOS-runner retargeting (local/namespace/github-hosted)",
+    },
+    Entry {
+        name: "ci-host",
+        summary: "Onboard a Mac as a Tart-VM CI host (optional; wraps setup-ci-host.sh)",
+    },
+    Entry {
+        name: "overflow",
+        summary: "Configure macOS-runner overflow routing (status/enable/disable/threshold)",
+    },
+    Entry {
+        name: "tweaks",
+        summary: "Inspect the pulp-tweaks.json sidecar (diff against a design)",
+    },
 ];
 
 /// Script-delegate table — mirrors `script_commands[]`.

--- a/experimental/pulp-rs/tests/fixtures/help/expected_cpp.txt
+++ b/experimental/pulp-rs/tests/fixtures/help/expected_cpp.txt
@@ -33,6 +33,10 @@ Commands:
   project        Per-project SDK pin: pin, unpin, undo
   config         Read or write ~/.pulp/config.toml settings
   coverage       Local coverage tooling (diff-cover gate mirror)
+  macos          Per-PR macOS-runner retargeting (local/namespace/github-hosted)
+  ci-host        Onboard a Mac as a Tart-VM CI host (optional; wraps setup-ci-host.sh)
+  overflow       Configure macOS-runner overflow routing (status/enable/disable/threshold)
+  tweaks         Inspect the pulp-tweaks.json sidecar (diff against a design)
 
   ci-local       Local-first CI across configured hosts
   harness        Catalog-driven coverage harness (compat.json verifier)


### PR DESCRIPTION
## Summary

- Add the documented/statused C++ operator commands `macos`, `ci-host`, `overflow`, and `tweaks` to the installed Rust help inventory.
- Update the pinned C++ help fixture so Rust help parity covers those rows.

## Audit finding

`RA-CLI-054`: C++ dispatch plus public CLI docs/status expose these commands, but Rust help stopped at `coverage`. Runtime behavior already falls through C++-only commands to `pulp-cpp`, so this is a help/discoverability fix only.

## Validation

- `git diff --check`
- `rustfmt --edition 2021 --check experimental/pulp-rs/src/help.rs`
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml --test help_parity_test`
- `python3 tools/scripts/cli_sync_check.py --strict --json`
- `python3 tools/scripts/check_cli_mcp_parity.py --mode=report --no-color`
- `python3 tools/scripts/classify_changes.py --mode=diff --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`
- `bash tools/scripts/gates.sh origin/main`
- fast pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`

Do not merge without explicit user instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add operator commands to the Rust CLI help to match C++ and improve discoverability. Adds `macos`, `ci-host`, `overflow`, and `tweaks`, and updates the C++ help fixture for parity; no runtime changes (C++ commands still delegate to `pulp-cpp`).

<sup>Written for commit 0183748b869ccf9cf1eb1bcc50d17e4fb7ac2f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

