### PR TITLE
docs(cli): refresh config dispatcher comment

### DIFF
--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -59,11 +59,8 @@ static const Command commands[] = {
     {"pr",       "One-shot push-a-PR: gates + bump + ship",   cmd_pr},
     {"projects", "Manage the ~/.pulp/projects.json registry", cmd_projects},
     {"project",  "Per-project SDK pin: pin, unpin, undo", cmd_project},
-    // Regression fix: #562 added `{"config", ..., cmd_config}` to this dispatch
-    // table, but the #563 merge dropped the line, leaving `pulp config`
-    // (and the update.mode / channel / check_interval_hours surface
-    // it guards) completely unreachable. Restore so the
-    // cmd_config.cpp fixes are actually observable behaviour.
+    // Keep the config command in the primary dispatcher so every key
+    // accepted by cmd_config.cpp is reachable from the installed CLI.
     {"config",   "Read or write ~/.pulp/config.toml settings", cmd_config},
     {"coverage", "Local coverage tooling (diff-cover gate mirror)", cmd_coverage},
     {"macos",    "Per-PR macOS-runner retargeting (local/namespace/github-hosted)", cmd_macos},


### PR DESCRIPTION
Reality audit item: RA-CLI-055

Summary:
- Replaces the stale issue-specific `pulp config` dispatcher comment with a stable invariant: the primary command table must keep `cmd_config.cpp` reachable.
- No command behavior, public docs, config keys, or runtime paths changed.

Validation:
- `git diff --check`
- `python3 tools/scripts/cli_sync_check.py --strict --json` (0 issues; existing advisory warnings only)
- `python3 tools/scripts/check_cli_mcp_parity.py --mode=report --no-color` (OK; existing MCP-only warnings)
- `python3 tools/scripts/classify_changes.py --mode=files tools/cli/pulp_cli.cpp` (`native_build_required=true` because CLI source changed)
- `bash tools/scripts/gates.sh origin/main`
- Fast pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`; first push correctly blocked on the CLI-maintenance skill trailer, amended commit adds the explicit comment-only skip trailer, second push passed.

Adversarial review:
- Local strict review found no must-fix and no should-fix-soon issues. The diff removes obsolete historical detail from the command registry without adding abstraction, API surface, state flow, runtime/importer/rendering/layout/platform coupling, or file-size risk.
- Claude bridge was attempted for a second opinion but remains unavailable locally: `Not logged in`. No Claude approval is claimed.

Do not merge without explicit user instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `pulp config` dispatcher comment to document a stable invariant: keep the config command in the primary dispatcher so all keys in `cmd_config.cpp` remain reachable. No command behavior, docs, config keys, or runtime paths changed.

<sup>Written for commit 9bc2bc17cfbd1485b2e005c76c6d7623b2be3604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

