### PR TITLE
docs(cli): list package commands in top-level help

### DIFF
--- a/experimental/pulp-rs/src/help.rs
+++ b/experimental/pulp-rs/src/help.rs
@@ -24,8 +24,9 @@
 //!   re-implement them; the banner just lists them so users can see
 //!   they're available on the C++ binary).
 //! - `binary_commands[]` — built-binary delegates (same treatment).
-//! - Package-manager pseudo-commands (`add`, `audit`) — parked in a
-//!   second block to match the C++ banner's shape.
+//! - Inline/trailing pseudo-commands (`audit`, package/tool commands,
+//!   `help`) — parked in a second block to match the C++ banner's
+//!   shape.
 //!
 //! Entries are ordered to match the C++ banner byte-for-byte. The
 //! `help_parity_test` integration test pins that.
@@ -218,8 +219,8 @@ pub const BINARY_COMMANDS: &[Entry] = &[
     },
 ];
 
-/// Package-manager + legacy pseudo-entries — mirrors the last three
-/// lines in the C++ banner (`audit`, `add`, `help`).
+/// Package-manager + legacy pseudo-entries — mirrors the trailing
+/// inline entries in the C++ banner.
 pub const PACKAGE_EXTRAS: &[Entry] = &[
     Entry {
         name: "audit",
@@ -228,6 +229,34 @@ pub const PACKAGE_EXTRAS: &[Entry] = &[
     Entry {
         name: "add",
         summary: "Add a component to the project",
+    },
+    Entry {
+        name: "remove",
+        summary: "Remove a previously added package",
+    },
+    Entry {
+        name: "list",
+        summary: "Show installed packages",
+    },
+    Entry {
+        name: "search",
+        summary: "Search the package registry",
+    },
+    Entry {
+        name: "update",
+        summary: "Check for and apply package updates",
+    },
+    Entry {
+        name: "suggest",
+        summary: "Context-aware package recommendations",
+    },
+    Entry {
+        name: "target",
+        summary: "Manage project platform targets",
+    },
+    Entry {
+        name: "tool",
+        summary: "Manage third-party developer tools",
     },
     Entry {
         name: "help",
@@ -252,8 +281,9 @@ pub const EXAMPLES: &[&str] = &[
 /// native-Rust ports.
 #[must_use]
 pub fn known_commands() -> Vec<&'static str> {
-    let mut v =
-        Vec::with_capacity(COMMANDS.len() + SCRIPT_COMMANDS.len() + BINARY_COMMANDS.len() + 4);
+    let mut v = Vec::with_capacity(
+        COMMANDS.len() + SCRIPT_COMMANDS.len() + BINARY_COMMANDS.len() + PACKAGE_EXTRAS.len(),
+    );
     for e in COMMANDS {
         v.push(e.name);
     }
@@ -263,12 +293,10 @@ pub fn known_commands() -> Vec<&'static str> {
     for e in BINARY_COMMANDS {
         v.push(e.name);
     }
-    // Package-manager commands handled inline in the C++ if-ladder —
-    // list them here so the suggester can land on them too.
-    v.extend_from_slice(&[
-        "add", "remove", "list", "search", "update", "suggest", "target", "audit", "tool",
-    ]);
-    v.push("help");
+    // Package-manager commands handled inline in the C++ if-ladder.
+    for e in PACKAGE_EXTRAS {
+        v.push(e.name);
+    }
     v
 }
 
@@ -404,20 +432,43 @@ pub fn suggest_hint(typed: &str, binary: &str, threshold: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    fn assert_banner_rows(output: &str, entries: &[Entry]) {
+        for e in entries {
+            let row = format!("  {:<14} {}", e.name, e.summary);
+            assert!(
+                output.lines().any(|line| line == row),
+                "banner missing row `{row}`:\n{output}"
+            );
+        }
+    }
 
     #[test]
     fn usage_banner_lists_every_native_command() {
         let mut buf = Vec::new();
         write_usage(&mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
-        for e in COMMANDS {
-            assert!(s.contains(e.name), "banner missing `{}`:\n{s}", e.name);
-            assert!(
-                s.contains(e.summary),
-                "banner missing summary for `{}`:\n{s}",
-                e.name
-            );
+        assert_banner_rows(&s, COMMANDS);
+    }
+
+    #[test]
+    fn usage_banner_lists_every_package_extra() {
+        let mut buf = Vec::new();
+        write_usage(&mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert_banner_rows(&s, PACKAGE_EXTRAS);
+    }
+
+    #[test]
+    fn command_tables_do_not_duplicate_names() {
+        let mut seen = HashSet::new();
+        for entries in [COMMANDS, SCRIPT_COMMANDS, BINARY_COMMANDS, PACKAGE_EXTRAS] {
+            for e in entries {
+                assert!(seen.insert(e.name), "duplicate command `{}`", e.name);
+            }
         }
+        assert_eq!(known_commands().len(), seen.len());
     }
 
     #[test]
@@ -475,9 +526,11 @@ mod tests {
     #[test]
     fn known_commands_contains_help_and_package_surface() {
         let c = known_commands();
-        assert!(c.contains(&"help"));
-        assert!(c.contains(&"add"));
-        assert!(c.contains(&"remove"));
-        assert!(c.contains(&"tool"));
+        for name in [
+            "help", "add", "remove", "list", "search", "update", "suggest", "target", "audit",
+            "tool",
+        ] {
+            assert!(c.contains(&name), "known_commands missing `{name}`");
+        }
     }
 }

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1195,9 +1195,27 @@ TEST_CASE("pulp help output lists the top-level subcommands",
     // from the dispatch table, this fails loudly.
     for (const char* cmd : {"build", "test", "run", "validate", "ship",
                             "version", "doctor", "create", "clean",
-                            "docs", "status", "inspect"}) {
+                            "docs", "status", "inspect", "audit", "add",
+                            "remove", "list", "search", "update", "suggest",
+                            "target", "tool", "help"}) {
         INFO("help output missing subcommand: " << cmd);
         REQUIRE(r.stdout_output.find(cmd) != std::string::npos);
+    }
+
+    for (const char* row : {
+             "  audit          License and clean-room audit",
+             "  add            Add a component to the project",
+             "  remove         Remove a previously added package",
+             "  list           Show installed packages",
+             "  search         Search the package registry",
+             "  update         Check for and apply package updates",
+             "  suggest        Context-aware package recommendations",
+             "  target         Manage project platform targets",
+             "  tool           Manage third-party developer tools",
+             "  help           Show this help",
+         }) {
+        INFO("help output missing package/tool row: " << row);
+        REQUIRE(r.stdout_output.find(row) != std::string::npos);
     }
 }
 

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -160,6 +160,13 @@ static void print_usage() {
     }
     std::cout << "  " << std::left << std::setw(14) << "audit" << " License and clean-room audit\n";
     std::cout << "  " << std::left << std::setw(14) << "add" << " Add a component to the project\n";
+    std::cout << "  " << std::left << std::setw(14) << "remove" << " Remove a previously added package\n";
+    std::cout << "  " << std::left << std::setw(14) << "list" << " Show installed packages\n";
+    std::cout << "  " << std::left << std::setw(14) << "search" << " Search the package registry\n";
+    std::cout << "  " << std::left << std::setw(14) << "update" << " Check for and apply package updates\n";
+    std::cout << "  " << std::left << std::setw(14) << "suggest" << " Context-aware package recommendations\n";
+    std::cout << "  " << std::left << std::setw(14) << "target" << " Manage project platform targets\n";
+    std::cout << "  " << std::left << std::setw(14) << "tool" << " Manage third-party developer tools\n";
     std::cout << "  " << std::left << std::setw(14) << "help" << " Show this help\n";
     std::cout << "\nExamples:\n";
     std::cout << "  pulp create MyPlugin              # Create a new effect plugin\n";


### PR DESCRIPTION
Do not merge without explicit user instruction.

## Summary
- RA-CLI-057: expose existing package/tool commands in the top-level C++ help banner.
- Mirror the same inline package/tool surface in Rust help and `known_commands()`.
- Add focused C++ shellout row assertions plus Rust exact-row and duplicate-command-table tests.

## Validation
- `rustfmt --check src/help.rs`
- `cargo test --lib help::tests` (`11` tests; existing unrelated missing-doc warnings only)
- `cmake --build build-audit-cli-help --target pulp-cli pulp-test-cli-shellout --parallel 8`
- `PULP_UPDATE_CHECK_DISABLED=1 build-audit-cli-help/tools/cli/pulp-cpp help | rg ...` showed `audit/add/remove/list/search/update/suggest/target/tool/help`
- `build-audit-cli-help/test/pulp-test-cli-shellout "pulp help output lists the top-level subcommands"` (`33` assertions / `1` case)
- `python3 tools/scripts/cli_sync_check.py`
- `python3 tools/scripts/check_cli_mcp_parity.py --mode=report`
- `git diff --check origin/main...HEAD`
- `bash tools/scripts/gates.sh origin/main`
- Pre-push fast gates passed during supervised direct branch push with diff-cover demoted after focused validation.

## Review
Strict adversarial review found no must-fix before PR. The review's small test-hardening suggestions were folded in. Deferred cleanup: C++ and Rust help metadata are still duplicated; a future sync check or generated/shared source could reduce that drift risk.

Claude bridge was attempted and remains unavailable locally (`Not logged in`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose package and tool commands in the top-level `pulp help` for both C++ and Rust CLIs to improve discoverability. Fulfills RA-CLI-057 and keeps the help banners in sync.

- **New Features**
  - C++: add help rows for `audit`, `add`, `remove`, `list`, `search`, `update`, `suggest`, `target`, `tool`, `help`.
  - Rust: mirror the same inline entries via `PACKAGE_EXTRAS` and include them in `known_commands()`.
  - Tests: add C++ shellout assertions for exact rows; add Rust tests for exact-row presence and duplicate-command detection.

<sup>Written for commit 981f70b31121ae7766f39be1f6d7f832213e8805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

