### PR TITLE
feat(format): emit a WAMv2 web-build report (UI strategy + binding targets)

### DIFF
--- a/core/format/src/wasm/wam_build_report.mjs
+++ b/core/format/src/wasm/wam_build_report.mjs
@@ -1,0 +1,80 @@
+// Emit a "web-build report" for a WAMv2 plugin.
+//
+// When an existing Pulp plugin is built for the web, two things about its UI are
+// worth stating explicitly, because they are easy to get wrong silently:
+//
+//   1. A NATIVE editor (Processor::create_view → a Skia/Dawn or platform view)
+//      cannot run in a headless web build. The web host shows GENERATED controls
+//      instead. A developer who imported or hand-built a native editor should
+//      see, at build time, that the web target falls back to generated controls.
+//
+//   2. The plugin's PARAMETERS are the stable binding targets. A design-import
+//      UI binds a knob/slider to a parameter by id; the WAM generated controls
+//      are built from the same parameter metadata, so a binding to parameter id
+//      N routes to the generated control for parameter id N. The report lists
+//      those ids/labels/ranges so the binding contract is visible and testable.
+//
+// The report is data only — it reads the built module's descriptor + parameters
+// through the same bridge the worklet/host use, so it cannot drift from what the
+// plugin actually exposes. Whether the plugin has a native editor is a developer
+// declaration (--native-editor), since a headless WAM build has no view to
+// introspect.
+//
+// Usage:
+//   node wam_build_report.mjs --wasm <plugin.wasm> --out <report.json> [--native-editor]
+// Exit 0 on success; prints the report path.
+import { readFileSync, writeFileSync } from "node:fs";
+import { makeWasmImports, makeBridge } from "./wam-runtime.mjs";
+
+function arg(flag, dflt = null) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : dflt;
+}
+const wasm = arg("--wasm");
+const out = arg("--out");
+const nativeEditor = process.argv.includes("--native-editor");
+
+if (!wasm || !out) {
+  console.error("usage: node wam_build_report.mjs --wasm <plugin.wasm> --out <report.json> [--native-editor]");
+  process.exit(2);
+}
+
+let instance = new WebAssembly.Instance(
+  new WebAssembly.Module(readFileSync(wasm)),
+  makeWasmImports(() => instance.exports.memory));
+const wam = makeBridge(instance.exports);
+wam.callCtors(); // --no-entry build: construct the global bridge before init
+if (!wam.init(48000, 128)) { console.error("FAIL: wam_init failed"); process.exit(1); }
+
+const descriptor = JSON.parse(wam.descriptorJson());
+const parameters = JSON.parse(wam.parametersJson()).map((p) => ({
+  id: p.id, label: p.label, type: p.type, unit: p.unit,
+  defaultValue: p.defaultValue, minValue: p.minValue, maxValue: p.maxValue,
+}));
+
+const note = nativeEditor
+  ? "This plugin declares a native editor (Processor::create_view). A native editor " +
+    "cannot run in a headless web build, so the web host renders generated parameter " +
+    "controls instead. The parameters below are the binding targets a design-import UI " +
+    "maps to by id."
+  : "No native editor declared. The web host renders generated parameter controls for the " +
+    "parameters below — the binding targets a design-import UI maps to by id.";
+
+const report = {
+  plugin: descriptor.name,
+  format: "wam",
+  descriptor,
+  ui: {
+    strategy: "generated-controls",
+    nativeEditorDeclared: nativeEditor,
+    note,
+  },
+  // The parameter contract that survives into the web build's generated controls.
+  parameters,
+};
+
+writeFileSync(out, JSON.stringify(report, null, 2) + "\n");
+console.log(`web-build report: ${out}`);
+console.log(`  ${descriptor.name} (wam) — ${parameters.length} parameter binding target(s); ` +
+            `native editor ${nativeEditor ? "declared → generated-controls fallback" : "not declared"}`);
+console.log("PASS: web-build report written");

--- a/core/format/src/wasm/wam_build_report.test.mjs
+++ b/core/format/src/wasm/wam_build_report.test.mjs
@@ -1,0 +1,63 @@
+// Test for wam_build_report.mjs (the WAMv2 web-build report generator).
+//
+// Needs a built WAM module (the generator reads its real descriptor +
+// parameters), so it takes --wasm or auto-locates the example build. It runs the
+// generator in both modes and asserts the report contract: the generated-controls
+// strategy, the parameter binding targets, and the native-editor fallback note.
+//
+// Usage: node wam_build_report.test.mjs [--wasm <plugin.wasm>]   (exit 0 = PASS)
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const GEN = fileURLToPath(new URL("./wam_build_report.mjs", import.meta.url));
+function arg(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const wasm = arg("--wasm") ||
+  [join(repoRoot, "examples/web-demos/wasm-build/build/PulpGain.wasm")].find(existsSync);
+if (!wasm || !existsSync(wasm)) {
+  console.error("SKIP: no built WAM module found — build PulpGain-wam first or pass --wasm.");
+  process.exit(2);
+}
+
+let failures = 0;
+const check = (cond, msg) => { if (!cond) { console.error("  ✗ " + msg); failures++; } else console.log("  ✓ " + msg); };
+
+const work = await mkdtemp(join(tmpdir(), "wam-report-"));
+try {
+  const gen = async (extra) => {
+    const outPath = join(work, "r.json");
+    const r = spawnSync(process.execPath, [GEN, "--wasm", wasm, "--out", outPath, ...extra], { encoding: "utf8" });
+    check(r.status === 0, `generator exit 0 (${extra.join(" ") || "default"})`);
+    return JSON.parse(await readFile(outPath, "utf8"));
+  };
+
+  const base = await gen([]);
+  check(base.plugin === "PulpGain", "plugin name is PulpGain");
+  check(base.format === "wam", "format is wam");
+  check(base.ui.strategy === "generated-controls", "ui strategy is generated-controls");
+  check(base.ui.nativeEditorDeclared === false, "nativeEditorDeclared false by default");
+  check(Array.isArray(base.parameters) && base.parameters.length >= 1, "parameters listed");
+  const p = base.parameters[0];
+  check(p && "id" in p && "label" in p && "minValue" in p && "maxValue" in p,
+    "parameter has id/label/min/max (binding target contract)");
+  check(/binding targets/.test(base.ui.note), "note explains the param binding-target contract");
+
+  const ed = await gen(["--native-editor"]);
+  check(ed.ui.nativeEditorDeclared === true, "nativeEditorDeclared true with --native-editor");
+  check(/native editor/i.test(ed.ui.note) && /generated/i.test(ed.ui.note),
+    "native-editor note explains the generated-controls fallback");
+  check(JSON.stringify(ed.parameters) === JSON.stringify(base.parameters),
+    "parameter binding targets are identical regardless of editor declaration");
+
+  console.log(failures === 0 ? "PASS: wam_build_report.mjs" : `FAIL: ${failures} check(s)`);
+  process.exit(failures === 0 ? 0 : 1);
+} finally {
+  await rm(work, { recursive: true, force: true });
+}

--- a/docs/guides/web-plugins.md
+++ b/docs/guides/web-plugins.md
@@ -43,6 +43,25 @@ Pulp Processor (C++ → WASM via Emscripten)
 - `core/format/include/pulp/format/web/wam_adapter.hpp` — C++ bridge
 - `core/format/src/wasm/wam_adapter.cpp` — implementation
 - `core/format/src/wasm/wam-plugin.js` — experimental WAMv2 JS runtime scaffold
+- `core/format/src/wasm/wam_build_report.mjs` — web-build report generator
+
+**Web-build report — what happens to a plugin's UI on the web:** `pulp_add_wam_plugin`
+emits a `<Name>.web-build.json` next to the module (post-build) documenting the
+UI strategy of the web build, so the "what happened to my editor / my imported
+design" question is answered at build time rather than discovered in the browser:
+
+- **Generated controls.** A headless WAM build has no view layer, so the web host
+  renders generated controls. The report lists the **parameter binding targets**
+  (`id`, `label`, range) the generated controls are built from. A design-import
+  UI binds a knob/slider to a parameter by `id`, and the generated control for
+  that `id` is the same target — so a binding to parameter `id` N routes to the
+  generated control for parameter `id` N. The report makes that contract explicit
+  and testable (`wam_build_report.test.mjs`).
+- **Native-editor fallback.** Declare `NATIVE_EDITOR` on `pulp_add_wam_plugin`
+  for a plugin whose native build has a `Processor::create_view()` editor; the
+  report then records that the native editor cannot run in a headless web build
+  and is replaced by generated controls. (A WAM build is headless, so this is a
+  developer declaration — the build has no view to introspect.)
 
 **Upstream references:**
 - [WAMv2 API](https://github.com/webaudiomodules/api) — interface definitions

--- a/tools/cmake/PulpWam.cmake
+++ b/tools/cmake/PulpWam.cmake
@@ -97,7 +97,7 @@ set(_PULP_WAM_EXPORTED_FUNCTIONS
 # as BASE64 with synchronous compilation, which is required to run inside an
 # AudioWorkletGlobalScope (no fetch / no async compile there).
 function(pulp_add_wam_plugin NAME)
-    cmake_parse_arguments(ARG "SINGLE_FILE" "ENTRY" "SOURCES;INCLUDES" ${ARGN})
+    cmake_parse_arguments(ARG "SINGLE_FILE;NATIVE_EDITOR" "ENTRY" "SOURCES;INCLUDES" ${ARGN})
     if(NOT ARG_ENTRY)
         message(FATAL_ERROR "pulp_add_wam_plugin(${NAME}): ENTRY <entry.cpp> is required.")
     endif()
@@ -140,4 +140,31 @@ function(pulp_add_wam_plugin NAME)
         OUTPUT_NAME "${NAME}"
         SUFFIX ".js"
         LINK_FLAGS "${_link_str}")
+
+    # Emit a web-build report (<Name>.web-build.json) documenting what the web
+    # build does with this plugin's UI: the generated-controls strategy, the
+    # parameter binding targets a design-import UI maps to by id, and — when
+    # NATIVE_EDITOR is declared — that the plugin's native editor is replaced by
+    # generated controls in the headless web build. Needs the separate .wasm, so
+    # it is skipped for SINGLE_FILE (worklet) targets, and skipped (with a status
+    # message) when node is unavailable.
+    if(NOT ARG_SINGLE_FILE)
+        find_program(_PULP_WAM_NODE node)
+        if(_PULP_WAM_NODE)
+            set(_report_args
+                "${_PULP_WAM_NODE}"
+                "${_PULP_WAM_ROOT}/core/format/src/wasm/wam_build_report.mjs"
+                --wasm "$<TARGET_FILE_DIR:${NAME}-wam>/${NAME}.wasm"
+                --out "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.web-build.json")
+            if(ARG_NATIVE_EDITOR)
+                list(APPEND _report_args --native-editor)
+            endif()
+            add_custom_command(TARGET ${NAME}-wam POST_BUILD
+                COMMAND ${_report_args}
+                COMMENT "Writing ${NAME}.web-build.json"
+                VERBATIM)
+        else()
+            message(STATUS "PulpWam: node not found — skipping ${NAME}.web-build.json report.")
+        endif()
+    endif()
 endfunction()


### PR DESCRIPTION
When a Pulp plugin is built for the web, a native editor cannot run in a headless web build, and a design-import UI's bindings only survive if parameter ids match. This makes both explicit and testable with a web-build report.

`wam_build_report.mjs` reads the built module's real descriptor + parameters and writes `<Name>.web-build.json`: the generated-controls UI strategy, the parameter binding targets (id/label/range) a design-import UI maps to by id, and — when the plugin declares `NATIVE_EDITOR` — that its native editor is replaced by generated controls. `pulp_add_wam_plugin` emits it as a post-build step (skipped for SINGLE_FILE worklet targets / when node is absent).

`wam_build_report.test.mjs` covers both modes (12 checks). Verified: the CMake build emits `PulpGain.web-build.json` listing Input/Output Gain + Bypass as the binding targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WAMv2 web-build report that documents the UI strategy and parameter binding targets for web plugins. Integrates report generation into `pulp_add_wam_plugin`, including a native-editor fallback note.

- **New Features**
  - `wam_build_report.mjs`: reads the built module and writes `<Name>.web-build.json` with `generated-controls` UI strategy, parameter binding targets (`id`, `label`, range), and `nativeEditorDeclared` when set.
  - CMake: `pulp_add_wam_plugin` emits the report post-build; skipped for `SINGLE_FILE` targets or when `node` is unavailable. Adds `NATIVE_EDITOR` option.
  - Tests: `wam_build_report.test.mjs` validates both modes and the report contract.

<sup>Written for commit d576ee9b511a49a792781f31a6f7e4495878ee31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

