### PR TITLE
feat(format): package WebCLAP modules into .wclap bundles

### DIFF
--- a/core/format/src/wasm/pack-wclap.mjs
+++ b/core/format/src/wasm/pack-wclap.mjs
@@ -1,0 +1,80 @@
+// Package a built WebCLAP module into a `.wclap` bundle (and optional .tar.gz).
+//
+// The WebCLAP bundle format (free-audio/web-clap) is a DIRECTORY named
+// `<name>.wclap` containing a mandatory `module.wasm` plus an arbitrary set of
+// resource files (factory presets, GUI assets, wavetables). There is no required
+// manifest — plugin metadata comes from the module's `clap_entry` descriptor.
+// For web distribution the bundle is served as `<name>.wclap.tar.gz`, and a host
+// exposes the whole directory through the WASI filesystem.
+//
+// This tool produces exactly that layout:
+//   <out>/<name>.wclap/module.wasm
+//   <out>/<name>.wclap/<resources copied from --resources>
+//   <out>/<name>.wclap.tar.gz            (with --tar)
+//
+// Usage:
+//   node pack-wclap.mjs --wasm <module.wasm> --name <PluginName> --out <dir>
+//        [--resources <dir>] [--tar]
+//
+// Exit 0 on success; prints the bundle path.
+import { mkdir, copyFile, cp, rm, readdir, stat, lstat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, basename } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function arg(flag, dflt = null) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : dflt;
+}
+const has = (flag) => process.argv.includes(flag);
+
+const wasm = arg("--wasm");
+const name = arg("--name");
+const out = arg("--out", ".");
+const resources = arg("--resources");
+const makeTar = has("--tar");
+
+if (!wasm || !name) {
+  console.error("usage: node pack-wclap.mjs --wasm <module.wasm> --name <PluginName> --out <dir> [--resources <dir>] [--tar]");
+  process.exit(2);
+}
+if (!existsSync(wasm)) { console.error(`FAIL: wasm not found: ${wasm}`); process.exit(1); }
+
+const bundleName = `${name}.wclap`;
+const bundleDir = join(out, bundleName);
+
+// Fresh bundle dir.
+await rm(bundleDir, { recursive: true, force: true });
+await mkdir(bundleDir, { recursive: true });
+
+// The mandatory module.wasm (always named module.wasm inside the bundle).
+await copyFile(wasm, join(bundleDir, "module.wasm"));
+
+// Optional resources: copy the directory's contents into the bundle root.
+if (resources) {
+  if (!existsSync(resources)) { console.error(`FAIL: resources dir not found: ${resources}`); process.exit(1); }
+  for (const entry of await readdir(resources)) {
+    // WebCLAP bundles must avoid symlinks (the WASI FS may not support them).
+    // lstat (not stat) is required to detect a symlink — stat resolves it first.
+    const src = join(resources, entry);
+    if ((await lstat(src)).isSymbolicLink()) {
+      console.error(`FAIL: symlink in resources not allowed: ${entry}`);
+      process.exit(1);
+    }
+    await cp(src, join(bundleDir, entry), { recursive: true });
+  }
+}
+
+console.log(`bundle: ${bundleDir}/`);
+console.log(`  module.wasm  (${(await stat(join(bundleDir, "module.wasm"))).size} bytes)`);
+
+// Optional .tar.gz for web distribution: `<name>.wclap.tar.gz` whose top-level
+// entry is the `<name>.wclap/` directory.
+if (makeTar) {
+  const tarPath = join(out, `${bundleName}.tar.gz`);
+  const r = spawnSync("tar", ["-czf", tarPath, "-C", out, bundleName], { stdio: "inherit" });
+  if (r.status !== 0) { console.error("FAIL: tar failed"); process.exit(1); }
+  console.log(`archive: ${tarPath}`);
+}
+
+console.log(`PASS: packaged ${basename(wasm)} → ${bundleName}`);

--- a/core/format/src/wasm/pack-wclap.test.mjs
+++ b/core/format/src/wasm/pack-wclap.test.mjs
@@ -1,0 +1,60 @@
+// Self-contained test for pack-wclap.mjs (the WebCLAP bundle packager).
+//
+// Exercises the file-level behavior with a dummy module — no real wasm or
+// toolchain needed — so it can run anywhere: bundle layout, the mandatory
+// module.wasm rename, resource copying, the .tar.gz archive, and the
+// unknown-args guard. Run: node pack-wclap.test.mjs   (exit 0 = PASS).
+import { mkdtemp, writeFile, mkdir, readFile, stat, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const PACK = fileURLToPath(new URL("./pack-wclap.mjs", import.meta.url));
+let failures = 0;
+const check = (cond, msg) => { if (!cond) { console.error("  ✗ " + msg); failures++; } else console.log("  ✓ " + msg); };
+const run = (args) => spawnSync(process.execPath, [PACK, ...args], { encoding: "utf8" });
+
+const work = await mkdtemp(join(tmpdir(), "wclap-pack-"));
+try {
+  // A dummy "module" stands in for a real .wasm — the packager is byte-agnostic.
+  const src = join(work, "PulpGain.wasm");
+  await writeFile(src, Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 1, 2, 3]));
+  const resDir = join(work, "res");
+  await mkdir(resDir, { recursive: true });
+  await writeFile(join(resDir, "Init.json"), '{"name":"Init"}');
+  const out = join(work, "out");
+  await mkdir(out, { recursive: true });
+
+  const r = run(["--wasm", src, "--name", "PulpGain", "--out", out, "--resources", resDir, "--tar"]);
+  check(r.status === 0, "exit 0 on a valid pack");
+  const bundle = join(out, "PulpGain.wclap");
+  check(existsSync(join(bundle, "module.wasm")), "bundle contains module.wasm");
+  check((await readFile(join(bundle, "module.wasm"))).equals(await readFile(src)), "module.wasm matches source bytes");
+  check(existsSync(join(bundle, "Init.json")), "resources copied into bundle");
+  check(existsSync(join(out, "PulpGain.wclap.tar.gz")), ".tar.gz archive produced");
+  check((await stat(join(out, "PulpGain.wclap.tar.gz"))).size > 0, ".tar.gz is non-empty");
+
+  // The tar's top-level entry must be the <name>.wclap/ directory.
+  const list = spawnSync("tar", ["-tzf", join(out, "PulpGain.wclap.tar.gz")], { encoding: "utf8" });
+  check(/PulpGain\.wclap\/module\.wasm/.test(list.stdout), "archive holds PulpGain.wclap/module.wasm");
+
+  // A symlink in resources is rejected (the WASI FS may not support symlinks).
+  const { symlink } = await import("node:fs/promises");
+  const symRes = join(work, "res-sym");
+  await mkdir(symRes, { recursive: true });
+  await symlink(src, join(symRes, "link.wasm"));
+  check(run(["--wasm", src, "--name", "X", "--out", out, "--resources", symRes]).status === 1,
+    "symlink in resources → exit 1");
+
+  // Missing required args → usage error (exit 2).
+  check(run(["--name", "X"]).status === 2, "missing --wasm → exit 2");
+  // Missing wasm file → failure (exit 1).
+  check(run(["--wasm", join(work, "nope.wasm"), "--name", "X", "--out", out]).status === 1, "missing wasm file → exit 1");
+
+  console.log(failures === 0 ? "PASS: pack-wclap.mjs" : `FAIL: ${failures} check(s) failed`);
+  process.exit(failures === 0 ? 0 : 1);
+} finally {
+  await rm(work, { recursive: true, force: true });
+}

--- a/examples/web-demos/wclap-build/CMakeLists.txt
+++ b/examples/web-demos/wclap-build/CMakeLists.txt
@@ -8,16 +8,22 @@
 #       -DCMAKE_BUILD_TYPE=Release
 #   cmake --build build
 #
-# Output: build/PulpGain.wasm — a WebCLAP module exporting clap_entry +
-# malloc/free/cabi_realloc + a growable function table + shared memory.
+# Output:
+#   build/PulpGain.wasm        — the bare WebCLAP module (exports clap_entry +
+#                                malloc/free/cabi_realloc + a growable function
+#                                table + shared memory). Used by the probe/host.
+#   build/PulpGain.wclap/      — the distributable bundle (module.wasm + any
+#                                resources), per free-audio/web-clap. Emitted as
+#                                a post-build step by pulp_add_wclap when node is
+#                                available.
+#   build/PulpGain.wclap.tar.gz — the web-distribution archive of the bundle.
 #
 # Validate the module is live (instantiate, run _initialize, resolve clap_entry):
-#   node ../../../core/format/src/wasm/wclap_probe.mjs build/PulpGain.wasm
+#   node ../../../core/format/src/wasm/wclap_probe.mjs build/PulpGain.wclap/module.wasm
 #
-# Host it for real — full CLAP lifecycle + audio + parameter control (needs
-# WebAssembly.Function, hence the Node flag):
-#   node --experimental-wasm-type-reflection \
-#     ../../../core/format/src/wasm/wclap_host_runner.mjs build/PulpGain.wasm --gain-db 6
+# Host it for real — full CLAP lifecycle + audio + parameter control (plain node;
+# the host vtable uses trampolines, no WebAssembly.Function):
+#   node ../../../core/format/src/wasm/wclap_host_runner.mjs build/PulpGain.wasm --gain-db 6
 #
 # The WebCLAP build logic (portable DSP/adapter source set, link flags, the
 # clap_entry/allocator export contract) lives in tools/cmake/PulpWclap.cmake —

--- a/tools/cmake/PulpWclap.cmake
+++ b/tools/cmake/PulpWclap.cmake
@@ -125,8 +125,11 @@ target_compile_definitions(pulp-wclap-dsp PUBLIC PULP_WCLAP=1 PULP_WASM=1)
 # Emits <Name>.wasm exporting clap_entry + malloc/free/cabi_realloc + a growable
 # function table + shared memory (the WebCLAP host contract). The reactor model,
 # memory, and table link flags come from wasi-toolchain.cmake.
+# Locate node once for the optional post-build bundling step.
+find_program(_PULP_WCLAP_NODE node)
+
 function(pulp_add_wclap NAME)
-    cmake_parse_arguments(ARG "" "ENTRY" "SOURCES;INCLUDES" ${ARGN})
+    cmake_parse_arguments(ARG "" "ENTRY;RESOURCES" "SOURCES;INCLUDES" ${ARGN})
     if(NOT ARG_ENTRY)
         message(FATAL_ERROR "pulp_add_wclap(${NAME}): ENTRY <entry.cpp> is required.")
     endif()
@@ -145,4 +148,28 @@ function(pulp_add_wclap NAME)
         OUTPUT_NAME "${NAME}"
         SUFFIX ".wasm"
         LINK_FLAGS "-Wl,--export=clap_entry -Wl,--no-entry")
+
+    # Emit the distributable WebCLAP bundle (<Name>.wclap/ with module.wasm +
+    # resources, per free-audio/web-clap) as a post-build step. The bare .wasm
+    # stays for the probe/host; the bundle is what a WebCLAP host or web
+    # distribution consumes. Requires node (the packager is JS); skipped with a
+    # status message otherwise so the wasm build never hard-fails on its absence.
+    if(_PULP_WCLAP_NODE)
+        set(_pack_args
+            "${_PULP_WCLAP_NODE}"
+            "${_PULP_WCLAP_ROOT}/core/format/src/wasm/pack-wclap.mjs"
+            --wasm "$<TARGET_FILE:${NAME}-wclap>"
+            --name "${NAME}"
+            --out "${CMAKE_CURRENT_BINARY_DIR}"
+            --tar)
+        if(ARG_RESOURCES)
+            list(APPEND _pack_args --resources "${ARG_RESOURCES}")
+        endif()
+        add_custom_command(TARGET ${NAME}-wclap POST_BUILD
+            COMMAND ${_pack_args}
+            COMMENT "Packaging ${NAME}.wclap bundle"
+            VERBATIM)
+    else()
+        message(STATUS "PulpWclap: node not found — skipping ${NAME}.wclap bundle (bare .wasm only).")
+    endif()
 endfunction()


### PR DESCRIPTION
Add the WebCLAP distributable. `pack-wclap.mjs` packages a built module into the free-audio/web-clap bundle layout: a `<name>.wclap/` directory with a mandatory `module.wasm` plus any resources, and a `<name>.wclap.tar.gz` archive for web distribution (no manifest — metadata comes from clap_entry, per the spec).

`pulp_add_wclap` now emits the bundle automatically as a post-build step when node is available, with an optional `RESOURCES <dir>`. Symlinks in resources are rejected (lstat) — the WASI filesystem may not support them.

`pack-wclap.test.mjs` covers bundle layout, the module.wasm rename, resource copy, the .tar.gz + its top-level entry, symlink rejection, and the arg guards (10 checks). Verified: the CMake build emits PulpGain.wclap/module.wasm + .tar.gz, and wclap_probe.mjs confirms the bundle's module.wasm is a live WebCLAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packages built WebCLAP modules into distributable `.wclap` bundles and an optional `.tar.gz`, and wires the bundling into CMake as a post-build step. This makes artifacts ready for hosts and web delivery out of the box.

- **New Features**
  - Added `pack-wclap.mjs` to create `<name>.wclap/` with `module.wasm` and optional resources, plus `<name>.wclap.tar.gz`.
  - `pulp_add_wclap` now runs the packer post-build when `node` is available; supports `RESOURCES <dir>` and rejects symlinks.
  - Added `pack-wclap.test.mjs` covering layout, rename, resource copy, archive structure, and arg/symlink guards.
  - Updated example CMake to document the new outputs and host/probe paths.

- **Migration**
  - Install `node` to get the `.wclap/` and `.tar.gz`; without it, only the bare `.wasm` is produced.
  - Include assets via `pulp_add_wclap(NAME ... RESOURCES <dir>)`. Avoid symlinks in resources.
  - Hosts should load `module.wasm` from `<name>.wclap/`; metadata comes from `clap_entry` (no manifest).

<sup>Written for commit b2d06f4e58605d7fe27ea2af15647204bb7c66f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

