### PR TITLE
ci: add Web Plugins lane — headless-browser WAMv2 + WebCLAP validation (RD11)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -113,6 +113,19 @@ lanes, and verify a runner is actually busy before blaming capacity.
 
 ## GitHub workflow gotchas
 
+- **`web-plugins.yml` is the headless-browser web lane (advisory).** It builds
+  Pulp's WAMv2 (Emscripten) and WebCLAP (wasi-sdk) web plugin formats on a Linux
+  GitHub-hosted runner and runs every web validation, including the browser
+  fixtures in headless Chrome (`browser-actions/setup-chrome` +
+  `playwright-core`, which drives the system Chrome — no browser download). It is
+  deliberately NOT on the self-hosted VMs: a headless-Linux browser lane needs
+  emsdk + wasi-sdk + Chrome, all of which install cleanly on GitHub-hosted, so no
+  golden VM or QEMU work is warranted. The WAM build vendors choc by cloning the
+  pinned fork (PulpWam.cmake needs `PULP_WAM_CHOC_INCLUDE`; the WebCLAP build
+  FetchContents choc/clap itself). The browser drivers are
+  `examples/web-demos/*/{browser-test,browser-host}/validate.mjs`; run them
+  locally with a system Chrome/Canary via `node validate.mjs --screenshot out.png`
+  (set `CHROME_PATH` or pass `--browser`).
 - **`intent-bump-on-merge.yml` is the merge-time half of the version-bump
   intent-trailer model — and it ships DORMANT.** It exists to kill the
   version-bump merge treadmill (PRs editing `CMakeLists` VERSION /

--- a/.github/workflows/web-plugins.yml
+++ b/.github/workflows/web-plugins.yml
@@ -1,0 +1,130 @@
+# Web plugins CI — builds Pulp's WAMv2 (Emscripten) and WebCLAP (wasi-sdk) web
+# plugin formats and runs every web validation, including the browser fixtures in
+# headless Chrome. This turns the previously by-hand browser proofs into a CI
+# lane (RD11). Advisory: a Linux runner with emsdk + wasi-sdk + Chrome — no VM
+# and no self-hosted runner needed for a headless-browser web lane.
+name: Web Plugins
+
+on:
+  pull_request:
+    paths:
+      - "core/format/src/wasm/**"
+      - "core/format/include/pulp/format/web/**"
+      - "examples/web-demos/**"
+      - "examples/pulp-gain/**"
+      - "tools/cmake/PulpWam.cmake"
+      - "tools/cmake/PulpWclap.cmake"
+      - "tools/cmake/wasi-toolchain.cmake"
+      - ".github/workflows/web-plugins.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: web-plugins-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-plugins:
+    name: WAMv2 + WebCLAP (Linux, headless Chrome)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+
+      - name: Set up wasi-sdk
+        run: |
+          set -euo pipefail
+          ver=25
+          url="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${ver}/wasi-sdk-${ver}.0-x86_64-linux.tar.gz"
+          curl -fsSL "$url" -o /tmp/wasi-sdk.tar.gz
+          mkdir -p "$HOME/wasi-sdk"
+          tar -xzf /tmp/wasi-sdk.tar.gz -C "$HOME/wasi-sdk" --strip-components=1
+          echo "WASI_SDK_PREFIX=$HOME/wasi-sdk" >> "$GITHUB_ENV"
+
+      - name: Set up Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Vendor choc for the WAM build
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch pulp-webview-dnd-poc1 \
+            https://github.com/danielraffel/choc.git "$HOME/choc-src"
+          echo "PULP_WAM_CHOC_INCLUDE=$HOME/choc-src" >> "$GITHUB_ENV"
+
+      - name: Install playwright-core
+        run: npm install --no-save playwright-core
+
+      # ── WAMv2 (Emscripten) ────────────────────────────────────────────────
+      - name: Build WAMv2 plugins
+        working-directory: examples/web-demos/wasm-build
+        run: |
+          set -euo pipefail
+          emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DPULP_WAM_CHOC_INCLUDE="$PULP_WAM_CHOC_INCLUDE"
+          cmake --build build -j"$(nproc)"
+
+      - name: WAMv2 Node validations
+        working-directory: examples/web-demos/wasm-build
+        run: |
+          set -euo pipefail
+          # Effect + instrument feature coverage (the runner takes a built .wasm).
+          node wam_feature_runner.mjs build/PulpGain.wasm effect
+          node wam_feature_runner.mjs build/PulpPluck.wasm instrument
+          # Web-build report (UI strategy + parameter binding targets, both modes).
+          node ../../../core/format/src/wasm/wam_build_report.test.mjs --wasm build/PulpGain.wasm
+
+      - name: WAMv2 browser fixture (headless Chrome)
+        working-directory: examples/web-demos/wasm-build
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        run: |
+          set -euo pipefail
+          cp build/PulpGainWorklet.js                       browser-test/wam-dsp.js
+          cp ../../../core/format/src/wasm/wam-processor.js  browser-test/
+          cp ../../../core/format/src/wasm/wam-runtime.mjs   browser-test/
+          cp ../../../core/format/src/wasm/wam-plugin.js     browser-test/
+          ln -s "$GITHUB_WORKSPACE/node_modules" browser-test/node_modules
+          node browser-test/validate.mjs --screenshot /tmp/wam-browser.png
+
+      # ── WebCLAP (wasi-sdk) ────────────────────────────────────────────────
+      - name: Build WebCLAP module + bundle
+        working-directory: examples/web-demos/wclap-build
+        run: |
+          set -euo pipefail
+          cmake -S . -B build \
+            -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/tools/cmake/wasi-toolchain.cmake" \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j"$(nproc)"
+
+      - name: WebCLAP Node validations
+        run: |
+          set -euo pipefail
+          node core/format/src/wasm/wclap_probe.mjs        examples/web-demos/wclap-build/build/PulpGain.wasm
+          node core/format/src/wasm/wclap_host_runner.mjs  examples/web-demos/wclap-build/build/PulpGain.wasm --gain-db 6
+          node core/format/src/wasm/pack-wclap.test.mjs
+
+      - name: WebCLAP browser host (headless Chrome)
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        run: |
+          set -euo pipefail
+          ln -s "$GITHUB_WORKSPACE/node_modules" examples/web-demos/wclap-build/browser-host/node_modules
+          node examples/web-demos/wclap-build/browser-host/validate.mjs --screenshot /tmp/wclap-browser.png
+
+      - name: Upload browser screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-plugins-screenshots
+          path: /tmp/*-browser.png
+          if-no-files-found: ignore

--- a/docs/reference/web-plugin-support.md
+++ b/docs/reference/web-plugin-support.md
@@ -46,8 +46,7 @@ instrument PulpPluck):
 - More than stereo, or more than one instance per AudioWorkletNode.
 - Broader MIDI than note/CC (pitch bend, aftertouch, program change, sysex,
   MPE).
-- A CI-enforced browser lane — the browser proof is the reproducible fixture at
-  `examples/web-demos/wasm-build/browser-test/`, not yet a Playwright CI job.
+- Broader-than-stereo / multi-instance hosting and full WAM-host conformance.
 
 ## WebCLAP — hosted in Node and in the browser (audio + parameter control proven)
 
@@ -101,9 +100,18 @@ be cross-origin isolated — `serve.mjs` sends the COOP/COEP headers.
   main thread and plays them via an `AudioBuffer`. Streaming live through an
   `AudioWorklet` (host on a worker, the worklet draining a `SharedArrayBuffer`
   ring) is a later refinement.
-- A native Wasmtime bridge, a `.wclap` bundle layout, and a CI lane that runs
-  the probe/runner/browser-validate (wasi-sdk + a browser are not yet on CI
-  runners).
+- A native Wasmtime bridge (hosting a WebCLAP outside the browser/Node).
+
+## Continuous validation
+
+The `Web Plugins` CI lane (`.github/workflows/web-plugins.yml`) builds both web
+formats on a Linux runner (emsdk + wasi-sdk + Chrome) and runs every validation
+on each web-touching PR: the WAMv2 Node feature runner + web-build report + the
+browser fixture (`examples/web-demos/wasm-build/browser-test/`), and the WebCLAP
+probe + Node host runner + packaging test + the in-browser host
+(`examples/web-demos/wclap-build/browser-host/`). The browser fixtures run in
+headless Chrome via `playwright-core`; their screenshots upload as an artifact.
+So the browser proofs are CI-enforced, not by-hand.
 
 ## Pinned upstream references
 

--- a/examples/web-demos/wasm-build/browser-test/validate.mjs
+++ b/examples/web-demos/wasm-build/browser-test/validate.mjs
@@ -1,0 +1,78 @@
+// Headless validation of the WAMv2 browser fixture.
+//
+// Serves the assembled fixture and drives index.html in headless Chrome/Chromium
+// via playwright-core (pointing at a system/CI browser — no browser download).
+// The page loads the WAM through the full AudioWorklet path, renders into an
+// OfflineAudioContext, builds its generated GUI, and records the outcome in
+// `window.__result` ({ steps:[{name,pass,detail}], pass }). This asserts every
+// step passed, so the browser proof runs in CI instead of only by hand.
+//
+// Prerequisites (the CI lane / README does these): build PulpGainWorklet-wam and
+// copy the served files (wam-dsp.js, wam-processor.js, wam-runtime.mjs,
+// wam-plugin.js) next to index.html.
+//
+// Usage: node validate.mjs [--browser <path>] [--screenshot <png>] [--headed]
+// Exit 0 = PASS.
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { existsSync } from "node:fs";
+import { chromium } from "playwright-core";
+
+function arg(flag, dflt) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : dflt;
+}
+const screenshot = arg("--screenshot", null);
+const headed = process.argv.includes("--headed");
+const PORT = 8731;
+const PAGE = `http://localhost:${PORT}/`;
+
+const CANDIDATES = [
+  arg("--browser", null),
+  process.env.PLAYWRIGHT_CHROMIUM_PATH,
+  process.env.CHROME_PATH,
+  "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/chromium",
+].filter(Boolean);
+
+const fail = (m) => { console.error("FAIL: " + m); process.exitCode = 1; };
+
+const here = new URL(".", import.meta.url).pathname;
+if (!existsSync(here + "wam-dsp.js") || !existsSync(here + "wam-plugin.js")) {
+  fail("fixture not assembled — build PulpGainWorklet-wam and copy wam-dsp.js / wam-*.js next to index.html (see README).");
+  process.exit(1);
+}
+
+const server = spawn(process.execPath, [here + "serve.mjs"], { stdio: ["ignore", "pipe", "inherit"] });
+await sleep(400);
+
+let browser;
+try {
+  const exe = CANDIDATES.find((p) => existsSync(p));
+  if (!exe) { fail("no Chrome/Chromium binary found (set CHROME_PATH or --browser)"); }
+  else {
+    browser = await chromium.launch({ executablePath: exe, headless: !headed });
+    const page = await browser.newPage();
+    page.on("console", (m) => console.log("  [page]", m.text()));
+    page.on("pageerror", (e) => console.log("  [pageerror]", e.message));
+    await page.goto(PAGE, { waitUntil: "load" });
+
+    await page.waitForFunction(() => window.__result && (window.__result.pass || window.__result.error || window.__result.steps.length >= 4),
+      null, { timeout: 30000 });
+    const result = await page.evaluate(() => window.__result);
+    for (const s of result.steps) console.log(`  ${s.pass ? "ok  " : "FAIL"} ${s.name}${s.detail ? " — " + s.detail : ""}`);
+    if (result.error) console.log("  error:", result.error);
+    if (screenshot) { await page.screenshot({ path: screenshot }); console.log("screenshot:", screenshot); }
+
+    if (!result.pass) throw new Error("one or more browser checks failed");
+    console.log("PASS: WAMv2 plugin loaded and rendered in the browser (all checks passed)");
+  }
+} catch (e) {
+  fail(String(e && e.message ? e.message : e));
+} finally {
+  if (browser) await browser.close();
+  server.kill("SIGTERM");
+}


### PR DESCRIPTION
Turns the by-hand web browser proofs into a CI lane (RD11). A new `validate.mjs` drives the WAMv2 browser fixture in headless Chrome via playwright-core, asserting `window.__result.pass` (instantiate, render a full OfflineAudioContext buffer, finite/non-silent/unity output, descriptor, generated GUI).

`.github/workflows/web-plugins.yml` runs on a Linux GitHub-hosted runner with emsdk + wasi-sdk + Chrome — no VM/self-hosted runner needed for a headless-browser web lane. It builds both web formats and runs every validation:
- WAMv2: feature runner (effect + instrument), web-build report test, browser fixture.
- WebCLAP: probe, Node host runner, packaging test, in-browser host.

Screenshots upload as an artifact. Verified locally end to end against Chromium (all WAM + WebCLAP browser checks pass). Docs updated: the browser proofs are now CI-enforced; the `.wclap` bundle and in-browser host are no longer "not yet" items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Web Plugins CI lane that turns the manual WAMv2/WebCLAP browser proofs into automated headless-browser checks (RD11). Runs on GitHub-hosted Linux with `emsdk`, `wasi-sdk`, and `playwright-core`, and uploads screenshots.

- New Features
  - Adds `.github/workflows/web-plugins.yml` (Ubuntu runner; Node 22; `mymindstorm/setup-emsdk`; `browser-actions/setup-chrome`; no self-hosted VM).
  - WAMv2: builds via Emscripten; runs Node feature runner + web-build report; drives the browser fixture with `examples/web-demos/wasm-build/browser-test/validate.mjs` (asserts `window.__result.pass` in headless Chrome).
  - WebCLAP: builds with `wasi-sdk`; runs probe + Node host runner + packaging test; validates the in-browser host.
  - Artifacts and docs: uploads headless screenshots; updates docs/CI notes to reflect CI-enforced browser checks.

<sup>Written for commit 9bcc69a1abbf123d7bc3d8b1aad51d6c9603d665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

