### PR TITLE
fix(web): find Chrome via CHROME_PATH in the WebCLAP host validator

### DIFF
--- a/examples/web-demos/wclap-build/browser-host/validate.mjs
+++ b/examples/web-demos/wclap-build/browser-host/validate.mjs
@@ -20,9 +20,14 @@ function arg(flag, dflt) {
 }
 const CANDIDATES = [
   arg("--browser", null),
+  process.env.PLAYWRIGHT_CHROMIUM_PATH,
+  process.env.CHROME_PATH,
   "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/chromium",
 ].filter(Boolean);
 const screenshot = arg("--screenshot", null);
 const headed = process.argv.includes("--headed");


### PR DESCRIPTION
The WebCLAP browser-host validate.mjs only checked macOS .app paths, so the Linux Web Plugins CI lane failed with "no Chrome binary found" despite CHROME_PATH being set. Add CHROME_PATH / PLAYWRIGHT_CHROMIUM_PATH + /usr/bin Linux paths (matching the WAM validator). Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Chrome detection in the WebCLAP browser-host validator on Linux by checking `CHROME_PATH`, `PLAYWRIGHT_CHROMIUM_PATH`, and common `/usr/bin` Chrome/Chromium paths. This unblocks the Linux Web Plugins CI lane by correctly finding the browser.

<sup>Written for commit 8232e42d64612e0b45079b7f8e694e069a76b3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

