### PR TITLE
docs(ci skill): arm GitHub auto-merge so a ship survives session death

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -559,6 +559,40 @@ diagnostics, experimental branches, existing Shipyard-managed PRs, or when
 `shipyard pr` itself is being debugged. Do not use them as the primary ship
 path.
 
+### A ship must survive the session dying — arm GitHub auto-merge as a backstop
+
+`shipyard pr` performs merge-on-green **inside the CLI/worker process**. If
+that process dies before the merge — the cmux app relaunching under resource
+starvation, or this Claude session running out of quota — the validated PR is
+**stranded unmerged** and its ship-state record **orphans**. This is a recurring
+real failure (521 orphaned records were reaped across the CI Macs on
+2026-06-30). The merge must not depend on any interactive session staying alive.
+
+**Standing policy — after creating/validating a pulp PR, arm GitHub-native
+auto-merge as a server-side backstop:**
+
+```bash
+ghapp pr merge <PR> --auto --merge      # merge commit, NOT --squash
+```
+
+GitHub then merges the moment required checks (`macos` + `Enforce version &
+skill sync`) go green, regardless of whether `shipyard pr`, cmux, or this
+session survive. Use `--merge` (merge commit), never `--squash`: a squash folds
+the `chore: bump versions` commit into the PR-title commit, which trips the
+auto-release watchdog into a false "merged without bump." It is safe alongside
+`shipyard pr` — whichever merges first wins; the other no-ops on already-merged.
+(The Shipyard repo has no branch protection, so GitHub auto-merge is
+unavailable there; the host-side queue janitor below covers it.)
+
+**Host-side backstop (both repos + orphan reaping):** a launchd queue-tick on
+each CI Mac (`tartci` `scripts/shipyard_queue_tick.sh`) periodically drives
+in-flight ship-state to completion via shipyard's own fail-closed `auto-merge`
+and reaps records whose PR GitHub reports merged/closed — independent of any
+session. Reap a stale local pile by hand with `shipyard ship-state list` →
+`shipyard ship-state discard <pr>` for each merged/closed PR (never discard an
+OPEN one). Full design: pulp
+`planning/2026-06-30-ship-queue-resilience-design.md`.
+
 ### Stale-SHA merge race — DO NOT push onto a PR that's being shipped
 
 **The failure mode (observed 2026-05-29):** Shipyard's `can_merge()`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.277.0",
+      "version": "0.277.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.277.0"
+  "version": "0.277.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.277.0",
+  "version": "0.277.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",


### PR DESCRIPTION
Adds a standing-policy section to the `ci` skill documenting the recurring queue-loss failure and its fix.

**Problem:** `shipyard pr` does merge-on-green inside the mortal CLI/worker. If that process dies before merging — cmux app relaunch under resource starvation, or a Claude session running out of quota — the validated PR is stranded unmerged and its ship-state orphans. 521 orphaned ship-state records were reaped across the CI Macs on 2026-06-30 (m3: 269, m5: 252; classification: 0 were live/dropped — pure stale accumulation).

**Policy:** after creating/validating a pulp PR, arm GitHub-native auto-merge (`ghapp pr merge <PR> --auto --merge`) as a server-side backstop. GitHub merges on green regardless of whether any local process survives. `--merge` (not `--squash`) preserves the `chore: bump versions` marker so the auto-release watchdog doesn't false-alarm.

Pairs with the host-side `tartci` queue janitor (danielraffel/tartci#25) for the Shipyard repo + orphan reaping. Full design: `planning/2026-06-30-ship-queue-resilience-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standing policy in the `ci` skill to arm GitHub auto-merge after PR validation with `ghapp pr merge <PR> --auto --merge` (use `--merge`, not `--squash`) so merges complete even if `shipyard pr` or the session stops. Notes the host-side `tartci` queue janitor to finish in-flight ships and clean orphans.

- **Dependencies**
  - Bump `pulp` plugin version to `0.277.1`.

<sup>Written for commit eab3091e446cf21a5d5946999414373a08992826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

