### PR TITLE
chore(shipyard): bump pin to v0.70.0 (matches deployed CI Macs)

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -67,7 +67,7 @@
 #   rather than double-running the PR). This is why Pulp moves to this pin —
 #   it removes a whole class of "wedged same-PR ship" stalls. Bundles #349
 #   (self-hosted empty-log diagnostics point at the ctest artifact).
-version = "v0.68.0"
+version = "v0.70.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Bumps `tools/shipyard.toml` from v0.68.0 → v0.70.0 to match what's actually deployed.

All three CI Macs now run shipyard **0.70.0**:
- **m3** (Mac Studio) — already on 0.70.0; serves the required `macos` gate (proven-good).
- **m1** (MacBook Pro) and **m5** (BlackBook) — updated via `shipyard update --to v0.70.0` + `shipyard daemon refresh`; daemons verified running/healthy.

Pin-only change; no `ci` skill behavior change (skip trailer recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `shipyard` pin from v0.68.0 to v0.70.0 to match the version running on all CI Macs (m1/m3/m5).
Pin-only change; no CI behavior changes.

<sup>Written for commit a5cbb58dd0b2f5d76814a06e76d5b426c98248f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

