### PR TITLE
fix(view): hosted-editor hover — plugin host window opts into mouse-moved delivery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.549.1
+    VERSION 0.549.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -772,11 +772,23 @@ static bool pulp_plugin_forward_key_to_host(NSView* self, NSEvent* event) {
 - (void)viewDidMoveToWindow {
     [super viewDidMoveToWindow];
     if (self.onWindowChange) self.onWindowChange();
-    // Accept dragged files/text so the editor's drop targets work when hosted in a
-    // DAW (the NSDraggingDestination behavior lives in drag_drop_mac.mm). Without
-    // this, drag-drop worked only in the standalone PulpView.
-    if (self.window)
+    if (self.window) {
+        // Accept dragged files/text so the editor's drop targets work when hosted
+        // in a DAW (the NSDraggingDestination behavior lives in drag_drop_mac.mm).
+        // Without this, drag-drop worked only in the standalone PulpView.
         [self registerForDraggedTypes:@[ NSPasteboardTypeFileURL, NSPasteboardTypeString ]];
+        // The hover tracking area installed in -updateTrackingAreas carries
+        // NSTrackingMouseMoved, but a tracking area only fans -mouseMoved: out to
+        // its owner when the window itself accepts mouse-moved events, and NSWindow
+        // defaults that flag to NO. This window is owned by the foreign host (a DAW,
+        // or a JUCE/iPlug2 embed), not by Pulp, so nothing sets the flag for us and
+        // -mouseMoved: never arrives — CSS :hover / on_hover_enter / on_hover_leave
+        // stay dead in a hosted editor even though the same tree hovers correctly in
+        // the standalone window. Opt the host window into mouse-moved delivery so the
+        // shared -mouseMoved: -> simulate_hover path reaches the view tree, matching
+        // what the standalone window host does (window_host_mac.mm).
+        self.window.acceptsMouseMovedEvents = YES;
+    }
     [self setNeedsDisplay:YES];
 }
 
@@ -1415,10 +1427,17 @@ private:
 - (void)viewDidMoveToWindow {
     [super viewDidMoveToWindow];
     if (self.onWindowChange) self.onWindowChange();
-    // Accept dragged files/text when hosted in a DAW (drop dispatch lives in
-    // drag_drop_mac.mm) — same as the CPU host above and the standalone PulpView.
-    if (self.window)
+    if (self.window) {
+        // Accept dragged files/text when hosted in a DAW (drop dispatch lives in
+        // drag_drop_mac.mm) — same as the CPU host above and the standalone PulpView.
         [self registerForDraggedTypes:@[ NSPasteboardTypeFileURL, NSPasteboardTypeString ]];
+        // Opt the host-owned window into mouse-moved delivery so the hover tracking
+        // area's -mouseMoved: -> simulate_hover path fires in a hosted editor. See
+        // the identical note in PulpPluginView above: a tracking area only receives
+        // -mouseMoved: when the window accepts those events, and a foreign host's
+        // window defaults the flag to NO.
+        self.window.acceptsMouseMovedEvents = YES;
+    }
 }
 
 - (void)viewDidChangeBackingProperties {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1446,6 +1446,14 @@ if(APPLE AND NOT PULP_IOS)
         PRIVATE pulp::view Catch2::Catch2WithMain "-framework AppKit")
     catch_discover_tests(pulp-test-text-accessibility-macos)
 endif()
+# macOS hover delivery for a hosted PluginViewHost (tracking area +
+# host-window acceptsMouseMovedEvents).
+if(APPLE AND NOT PULP_IOS)
+    add_executable(pulp-test-plugin-view-hover-macos test_plugin_view_host_hover_macos.mm)
+    target_link_libraries(pulp-test-plugin-view-hover-macos
+        PRIVATE pulp::view Catch2::Catch2WithMain "-framework AppKit")
+    catch_discover_tests(pulp-test-plugin-view-hover-macos)
+endif()
 # Windows UIA backend — compile-gated on _WIN32 in the
 # source. The sentinel test case keeps the binary present + named
 # consistently on non-Windows hosts so ctest output stays stable.

--- a/test/test_plugin_view_host_hover_macos.mm
+++ b/test/test_plugin_view_host_hover_macos.mm
@@ -1,0 +1,105 @@
+// macOS hover delivery for an embedded/hosted PluginViewHost.
+//
+// A hosted editor (a DAW, or a JUCE/iPlug2 embed) parents Pulp's child NSView
+// into a window it owns. The NSView installs a hover NSTrackingArea carrying
+// NSTrackingMouseMoved, but AppKit only fans -mouseMoved: out to a tracking
+// area's owner when the window itself accepts mouse-moved events — and NSWindow
+// defaults that flag to NO. Nothing on the host side sets it, so -mouseMoved:
+// never arrives and CSS :hover / on_hover_enter / on_hover_leave stay dead even
+// though the same view tree hovers correctly in the standalone window host.
+//
+// The plugin view host fixes this by opting its host window into mouse-moved
+// delivery when the NSView moves into a window. This suite pins both halves of
+// the causal chain:
+//   1. the hover dispatch itself (simulate_hover -> set_hovered -> on_hover_enter)
+//      fires the registered callback, and
+//   2. attaching the host's NSView into a window sets acceptsMouseMovedEvents,
+//      which is the AppKit precondition for -mouseMoved: (and thus hover) to be
+//      delivered at all in the hosted case.
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#import <AppKit/AppKit.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/view.hpp>
+
+#include <memory>
+
+using namespace pulp::view;
+
+TEST_CASE("hover dispatch fires the registered callback",
+          "[view][hover][macos]") {
+    // A child that arms an on_hover_enter callback the way WidgetBridge's
+    // registerHover(id) does for a scripted-UI element.
+    View root;
+    root.set_bounds({0, 0, 200, 120});
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 80, 40});
+    bool entered = false;
+    bool left = false;
+    child->on_hover_enter = [&] { entered = true; };
+    child->on_hover_leave = [&] { left = true; };
+    View* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    // A mouse move into the child's rect must set it hovered and fire enter.
+    root.simulate_hover(pulp::view::Point{30, 25});
+    REQUIRE(child_ptr->is_hovered());
+    REQUIRE(entered);
+    REQUIRE_FALSE(left);
+
+    // A move back out clears hover and fires leave.
+    root.simulate_hover(pulp::view::Point{150, 100});
+    REQUIRE_FALSE(child_ptr->is_hovered());
+    REQUIRE(left);
+}
+
+TEST_CASE("hosted plugin view opts its window into mouse-moved delivery",
+          "[view][hover][macos]") {
+    @autoreleasepool {
+        View root;
+        root.set_bounds({0, 0, 320, 200});
+
+        auto host = PluginViewHost::create(root, PluginViewHost::Size{320, 200});
+        REQUIRE(host != nullptr);
+
+        NSWindow* window = [[NSWindow alloc]
+            initWithContentRect:NSMakeRect(0, 0, 320, 200)
+                      styleMask:NSWindowStyleMaskBorderless
+                        backing:NSBackingStoreBuffered
+                          defer:NO];
+        REQUIRE(window != nil);
+        REQUIRE(window.contentView != nil);
+
+        // A foreign host's freshly created window does not accept mouse-moved
+        // events — this is the AppKit default the bug rode on.
+        REQUIRE_FALSE(window.acceptsMouseMovedEvents);
+
+        // Parent Pulp's child NSView into the host window, the same operation a
+        // DAW / JUCE NSViewComponent performs.
+        host->attach_to_parent((__bridge void*) window.contentView);
+        REQUIRE(host->is_attached());
+
+        // Moving into the window must have opted it into mouse-moved delivery, so
+        // the hover tracking area's -mouseMoved: (and hence simulate_hover) can
+        // actually fire in the hosted editor.
+        REQUIRE(window.acceptsMouseMovedEvents);
+
+        host->detach();
+    }
+}
+
+#else
+
+#include <catch2/catch_test_macros.hpp>
+
+// Sentinel so the target exists and ctest output stays stable off macOS.
+TEST_CASE("plugin view host hover is macOS-only", "[view][hover]") {
+    SUCCEED("macOS-only suite");
+}
+
+#endif

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "test/CMakeLists.txt",
-      "max_loc":     6237,
+      "max_loc":     6245,
       "note": "shared test registration hotspot; exact ceiling tracks current registered CMake test manifest"
     },
     {


### PR DESCRIPTION
## Problem
CSS `:hover` / `onMouseEnter` / `onMouseLeave` never fire when a Pulp UI is embedded in a foreign host (JUCE/DAW), even though `registerHover(id)` correctly arms the callbacks.

## Root cause (verified against code)
Pulp's plugin-host NSView **already** installs a hover `NSTrackingArea` and implements `mouseMoved:` → `simulate_hover` → `set_hovered` → `on_hover_enter`. The one missing link: a tracking area only receives `mouseMoved:` when the owning `NSWindow` has `acceptsMouseMovedEvents == YES`, and **NSWindow defaults that flag to NO**. The standalone window host sets it explicitly (`window_host_mac.mm`); the plugin host never did. In a hosted editor the window is owned by the DAW / JUCE `NSViewComponent`, which doesn't set it → `mouseMoved:` is never delivered.

## Fix
Set `self.window.acceptsMouseMovedEvents = YES` in `viewDidMoveToWindow` on both the CPU (`PulpPluginView`) and GPU (`PulpGpuPluginView`) host views. Vendor-neutral (no host-specific types in core), so hover works for **every** foreign host at once — no per-host (JUCE/iPlug2/…) forwarding code needed.

## Test
`test/test_plugin_view_host_hover_macos.mm` (2 cases, 11 assertions): proves the AppKit default is NO (the bug precondition) and that attaching the host into a window flips it on; plus the `simulate_hover → on_hover_enter/leave` dispatch. Verified building + passing locally with no regressions in neighboring view tests.

Supersedes the JUCE-side mouse-forwarding approach (pulp-embed-juce #2), which was dead code on macOS. The `pulp_embed_dispatch_mouse_*` C ABI (pulp-view-embed #1) remains valid for the offscreen/host-composited and non-Apple seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken hover in hosted macOS editors by opting the host window into mouse-move events. CSS `:hover` and `onMouseEnter/Leave` now work when the Pulp UI is embedded in a DAW/JUCE host.

- **Bug Fixes**
  - Set `self.window.acceptsMouseMovedEvents = YES` in `viewDidMoveToWindow` for `PulpPluginView` and `PulpGpuPluginView`.
  - Vendor-neutral approach; no per-host mouse forwarding needed.
  - Added a macOS test to prove the AppKit default is NO, that attaching flips it to YES, and that hover callbacks fire.
  - Bumped version to `0.549.2`.

<sup>Written for commit 039fcb170643133e35fbcf046154cbea14781d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

