### PR TITLE
fix(format): link AudioUnitSDK PRIVATE so it stops leaking onto pulp::format consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.549.2
+    VERSION 0.549.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -165,7 +165,20 @@ if(PULP_HAS_AUSDK)
         # pin it here explicitly for pulp-format.
         target_compile_features(pulp-format PRIVATE cxx_std_23)
     endif()
-    target_link_libraries(pulp-format PUBLIC ausdk)
+    # PRIVATE, not PUBLIC: pulp-format uses AudioUnitSDK only in its own AU v2
+    # .cpp sources, so it needs the headers at build time but must NOT export
+    # external/AudioUnitSDK/include onto every consumer of pulp::format. A
+    # PUBLIC link leaked ausdk's $<INSTALL_INTERFACE:external/AudioUnitSDK/include>
+    # to anything linking pulp::format (e.g. a JUCE plugin embedding Pulp via
+    # pulp-view-embed), colliding with the host's OWN vendored, differently-
+    # versioned AudioUnitSDK. Pulp's own AU plugins don't rely on this
+    # propagation — _pulp_add_au links ausdk PRIVATE directly to the AU target,
+    # and the only public headers that pull AudioUnitSDK (au_v2_entry.hpp et al)
+    # are opt-in, compiled solely into an AU plugin entry point. Static-lib link
+    # propagation still pulls ausdk's objects into consumers that need them; only
+    # the stray include-dir is withheld. C++23 propagation is a separate PUBLIC
+    # compile-feature below, unaffected.
+    target_link_libraries(pulp-format PRIVATE ausdk)
     # AudioUnitSDK 1.4 headers `#include <expected>` (C++23). Apple clang
     # only exposes std::expected when the consuming TU is compiled with
     # -std=c++23. Set the standard explicitly (target_compile_features

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1345,8 +1345,12 @@ pulp_add_test_suite(pulp-test-midi-ci-pe LIBRARIES pulp::midi)
 # not linked on non-Apple lanes).
 if(APPLE AND NOT PULP_IOS AND PULP_HAS_AUSDK)
     add_executable(pulp-test-au-v2-effect test_au_v2_effect.cpp)
+    # Links ausdk directly: this test includes AudioUnitSDK headers, which
+    # pulp::format no longer exports (ausdk is PRIVATE on pulp-format to stop
+    # leaking those headers onto every consumer). AU-header access is opt-in
+    # via linking ausdk, same as _pulp_add_au does for real AU plugins.
     target_link_libraries(pulp-test-au-v2-effect PRIVATE
-        pulp::format pulp::midi Catch2::Catch2WithMain)
+        pulp::format pulp::midi ausdk Catch2::Catch2WithMain)
     # pulp::format on Apple compiles at C++23 (AudioUnitSDK 1.4 requires
     # std::expected). Match it here so the adapter header parses.
     set_target_properties(pulp-test-au-v2-effect PROPERTIES CXX_STANDARD 23)
@@ -1359,7 +1363,7 @@ if(APPLE AND NOT PULP_IOS AND PULP_HAS_AUSDK)
         test_au_v2_cocoa_ui.mm
         ${CMAKE_SOURCE_DIR}/core/format/src/au_v2_cocoa_view.mm)
     target_link_libraries(pulp-test-au-v2-cocoa-ui PRIVATE
-        pulp::format pulp::view Catch2::Catch2WithMain
+        pulp::format pulp::view ausdk Catch2::Catch2WithMain
         "-framework AppKit" "-framework AudioToolbox" "-framework QuartzCore")
     target_compile_definitions(pulp-test-au-v2-cocoa-ui PRIVATE
         PULP_AU_GUI=1 PULP_AU_COCOA_VIEW_CLASS=PulpAUCocoaViewFactory_Test)
@@ -2302,6 +2306,7 @@ if(APPLE AND PULP_HAS_AUSDK)
     )
     target_link_libraries(pulp-test-au-plugin-state PRIVATE
         pulp::format
+        ausdk
         Catch2::Catch2WithMain
         "-framework AudioToolbox"
         "-framework AVFoundation"

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "test/CMakeLists.txt",
-      "max_loc":     6245,
+      "max_loc":     6250,
       "note": "shared test registration hotspot; exact ceiling tracks current registered CMake test manifest"
     },
     {


### PR DESCRIPTION
## What
`core/format/CMakeLists.txt` linked `ausdk` **PUBLIC**, exporting `$<INSTALL_INTERFACE:external/AudioUnitSDK/include>` to every consumer of `pulp::format`. A foreign host embedding Pulp (JUCE plugin via pulp-view-embed → pulp-embed-juce) that vendors its **own**, differently-versioned AudioUnitSDK then resolved Pulp's headers for its own AU client → `no member named 'add'/'remove'/'foreach'`. **AU-format only.**

## Fix
`PUBLIC ausdk` → `PRIVATE ausdk`. Verified safe:
- pulp-format uses AudioUnitSDK only in its **own** AU v2 `.cpp` sources (PRIVATE = build-time includes).
- The only public headers pulling AudioUnitSDK (`au_v2_entry.hpp`, `au_v2_adapter.hpp`, `au_v2_instrument*.hpp`) are **opt-in**, compiled solely into an AU plugin entry point — never umbrella'd into a general consumer.
- Pulp's own AU plugins don't rely on the PUBLIC propagation: `_pulp_add_au` links `ausdk` PRIVATE directly to `${target}_AU` (PulpPluginFormats.cmake).
- Static-lib link propagation still pulls ausdk's objects into consumers that need them; only the stray include dir is withheld. C++23 propagation is a separate PUBLIC compile-feature, unaffected.

## Validation
- Regression (Pulp's own AU still builds): the CI matrix's AU-example build + AU adapter tests.
- Leak-closed proof: pulp-embed-juce's AU format build (currently excluded in its CI, documented there) goes green once a **new SDK is published** carrying this fix.

## ⚠️ Do not squash-merge / hold for release decision
Merge triggers the auto-release + SDK republish. Land via `shipyard pr` (applies the version bump) when you want the new SDK cut. Local build-validation was deferred to CI with the code-reading rationale above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link `AudioUnitSDK` as PRIVATE in `pulp::format` to stop exporting its include directory to dependents. This prevents AU header collisions in hosts that vendor their own SDK and ships in 0.549.3.

- **Bug Fixes**
  - Changed to `target_link_libraries(pulp-format PRIVATE ausdk)`; no public headers require it.
  - Updated AU tests to link `ausdk` directly and adjusted the test hotspot ceiling. Pulp’s AU builds remain green; the C++23 public compile feature is unchanged.

<sup>Written for commit dcf5a9c568875d0dd929ff3c5c9a6d8918ddf6e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

