### PR TITLE
refactor(view): expose HotReloader::should_reload_for_modified_file so it links on MSVC

### DIFF
--- a/core/view/include/pulp/view/hot_reload.hpp
+++ b/core/view/include/pulp/view/hot_reload.hpp
@@ -65,6 +65,18 @@ public:
     // How many reloads have occurred
     uint32_t reload_count() const { return reload_count_.load(); }
 
+    // Content-addressed reload gate: returns true only when `path` is a readable
+    // .js/.mjs whose content hash differs from the last observed hash (a
+    // save-without-edit or an editor's atomic-rename touch does not reload).
+    // Updates the observed-hash map as a side effect. Public because it is
+    // exercised directly by the unit tests: a private definition that is
+    // referenced from only one in-library call site is elided by MSVC (a private
+    // method cannot be referenced across a translation unit), so a test reaching
+    // it via `#define private public` links on Clang/GCC but fails on MSVC with
+    // an unresolved external. Exposing it guarantees an out-of-line symbol on
+    // every toolchain.
+    bool should_reload_for_modified_file(const std::filesystem::path& path);
+
 private:
     std::filesystem::path watched_path_;
     std::string entry_file_;
@@ -85,7 +97,6 @@ private:
     std::optional<std::string> try_read_file(const std::filesystem::path& path);
     std::string read_file(const std::filesystem::path& path);
     void seed_observed_content_hashes();
-    bool should_reload_for_modified_file(const std::filesystem::path& path);
     static std::uint64_t content_hash(std::string_view content);
 };
 


### PR DESCRIPTION
## Problem

`pulp-test-hot-reload` fails to link on the **Windows** lane:

```
error LNK2019: unresolved external symbol
  "public: bool __cdecl pulp::view::HotReloader::should_reload_for_modified_file(...)"
error LNK1120: 1 unresolved externals [pulp-test-hot-reload.vcxproj]
```

Introduced by #5216. It is **only** Windows and **only** this one symbol —
every other `HotReloader` method and every sibling view-script test links fine.

## Root cause

`should_reload_for_modified_file` was a **private** member called from exactly one
in-library site (`on_file_changed`). MSVC elides the out-of-line copy of a private
method — nothing can legally reference it across a translation unit — so when the
test reaches it via `#define private public`, the symbol resolves on Clang/GCC
(which always emit the out-of-line copy) but is missing on MSVC. Not a platform
guard, not a missing source: the definition is unguarded and present; MSVC simply
never emitted the standalone symbol.

## Fix

Make the method **public**. It is a legitimately unit-tested pure decision query
(content-hash reload gate; 4 assertions in `test_hot_reload.cpp`), so exposing it
is honest and guarantees an out-of-line symbol on every toolchain. Pure
access-specifier move — the definition is unchanged, internal callers are
unaffected, and object layout is untouched (method access doesn't affect layout).

## Validation

- **macOS (local):** `pulp-test-hot-reload` builds clean and **all 23 hot-reload
  tests pass** — no regression on the toolchains that already worked.
- **Windows advisory lane on this PR** is the cross-toolchain proof that the
  symbol now links.

Non-user-facing build-linkage fix (`refactor:`); Windows is a compile-verified,
advisory lane with no SDK release consumers, so no release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVa51RbTDgDCnLCoFfvUZc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `pulp::view::HotReloader::should_reload_for_modified_file` as public so MSVC emits the symbol, fixing the Windows link failure in `pulp-test-hot-reload` (LNK2019/LNK1120). Pure access move; no runtime or layout changes.

<sup>Written for commit 5f64e7a720fa7b86b0454862ec8c0fd2bd6bc025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

