### PR TITLE
ci: fork-guard scheduled workflows so forks don't email owners on failed cron

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -155,6 +155,29 @@ tools/scripts/host_vitals.sh --json     # machine-readable
 
 ## GitHub workflow gotchas
 
+- **Every `on: schedule` workflow must carry the fork guard.** When someone forks
+  the repo, GitHub copies all workflows and runs the scheduled ones on the fork's
+  default branch — then emails the fork owner whenever one *fails*, which our
+  monitors reliably do on a fork (they probe this repo's state or use secrets the
+  fork lacks). So each entry job (a job with no `needs:` — dependents cascade-skip)
+  of a scheduled workflow gets:
+
+  ```yaml
+  jobs:
+    check:
+      if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
+  ```
+
+  compose it with an existing condition as
+  `if: (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (<existing>)`.
+  It only suppresses the **schedule** event on forks — `push` / `pull_request` /
+  `workflow_dispatch` are untouched, so PRs to this repo (which run in this repo's
+  context) and manual dispatches behave exactly as before. A workflow that
+  *should* run on forks' schedules opts out with a top-of-file
+  `# fork-guard-exempt: <reason>` comment. This is **enforced**:
+  `tools/scripts/scheduled_workflow_fork_guard_check.py` runs in `gates.sh`, the
+  pre-push hook, and `workflow-lint.yml`, so a new scheduled workflow missing the
+  guard fails the PR. Add the guard when you add the workflow.
 - **Codecov "total lines/files dropped" is usually upload starvation, not config drift.** Two distinct guard layers exist and they catch different things: `test_codecov_components.py` / `test_codecov_config.py` (PR-gate) guard the **codecov.yml mapping** (a subsystem matching no component → invisible); `coverage-upload-watchdog.yml` (hourly, main) guards the **outcome** — "main had a *successful* Coverage run in the last N hours." The watchdog exists because the dashboard degrades silently when fresh complete uploads stop arriving, from causes the config gate can't see: coverage runs cancelled by `stale-run-reaper.yml` when a CI dispatch throttle makes them queue past the cutoff (the 2026-06-28 incident — 8 consecutive main Coverage runs cancelled), an `llvm-cov -object`-set regression (a `libpulp-*.a` drops out → a whole subsystem vanishes while `lines-valid` stays > 0, which `verify_cobertura_xml.py`'s `lines-valid > 0` check cannot catch), or Codecov's `after_n_builds` waiting forever on a missing per-OS leg. When triaging a coverage-surface complaint: first check `gh run list --workflow coverage.yml --branch main` for recent **successful** runs (cancelled ≠ uploaded); only then suspect codecov.yml. Note the config gate is **advisory** (not in branch protection), so a fleet-auto-merged PR can land config drift despite a red gate — the watchdog is the main-branch backstop.
 - **`web-plugins.yml` is the headless-browser web lane (advisory).** It builds
   Pulp's WAMv2 (Emscripten) and WebCLAP (wasi-sdk) web plugin formats on a Linux

--- a/.github/workflows/coverage-staleness-check.yml
+++ b/.github/workflows/coverage-staleness-check.yml
@@ -56,6 +56,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Check coverage freshness on main
     env:

--- a/.github/workflows/coverage-upload-watchdog.yml
+++ b/.github/workflows/coverage-upload-watchdog.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     steps:
       - name: Scan main for a recent successful Coverage run

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -115,6 +115,7 @@ jobs:
   # graph/scene subsystems drifted onto main undetected until this job
   # existed. Keep it cheap and unconditional.
   codecov-config-validation:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +146,7 @@ jobs:
   # output, so a TS-only PR exits the macOS leg in <20 min instead of
   # ~45-60 min.
   changed-files:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     # dorny/paths-filter@v3 in PR mode requires pull-requests:read; without
     # it the action silently returns no changed files, which would defeat
@@ -196,6 +198,7 @@ jobs:
   # Namespace build variables because coverage/sanitizer/release lanes must
   # not spill onto the warm macOS gate pool.
   resolve-runners:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     outputs:
       linux_runs_on: ${{ steps.resolve.outputs.linux_runs_on }}
@@ -279,6 +282,7 @@ jobs:
   # as "native build required". See that script's module docstring +
   # tools/scripts/test_classify_changes.py.
   classify:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     outputs:
       # Force the full native matrix on `schedule` AND `workflow_dispatch`:
@@ -1167,7 +1171,7 @@ jobs:
     # validates PRs, but it must not be the only main upload for a SHA whose
     # native Coverage run was superseded before any OS legs uploaded.
     name: Coverage report (@pulp/react, Vitest)
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (github.event_name != 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -51,6 +51,7 @@ jobs:
   # ctest filters. GitHub-hosted ubuntu-latest only.
   linux:
     name: Linux build + test
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -132,6 +133,7 @@ jobs:
   # windows-latest only.
   windows:
     name: Windows build + test
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: windows-latest
     timeout-minutes: 60
     env:
@@ -211,6 +213,7 @@ jobs:
   # runners, see android.yml #487) and needs a KVM-capable runner.
   android:
     name: Android NDK build
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   audit:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Audit dependency pins and notices
 

--- a/.github/workflows/deps-drift-check.yml
+++ b/.github/workflows/deps-drift-check.yml
@@ -52,6 +52,7 @@ permissions:
 
 jobs:
   drift:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Audit dependency upstream drift
 

--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   freshness:
     name: Check package freshness
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -59,7 +60,7 @@ jobs:
   # Tier 2: Full build validation (monthly or on-demand)
   build-validation:
     name: Build validation (${{ matrix.package }}) — ${{ matrix.os }}
-    if: inputs.tier == '2'
+    if: (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (inputs.tier == '2')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/host-quirks-staleness.yml
+++ b/.github/workflows/host-quirks-staleness.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   staleness:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Report stale host-quirk catalog entries
     steps:

--- a/.github/workflows/nightly-full-build.yml
+++ b/.github/workflows/nightly-full-build.yml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   full-build:
     name: Full build (examples + all tests)
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: macos-15
 
     outputs:

--- a/.github/workflows/orphan-branch-sweep.yml
+++ b/.github/workflows/orphan-branch-sweep.yml
@@ -50,6 +50,7 @@ permissions:
 
 jobs:
   sweep:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Identify and report orphan branches
 

--- a/.github/workflows/post-merge-review-sweep.yml
+++ b/.github/workflows/post-merge-review-sweep.yml
@@ -44,6 +44,7 @@ permissions:
 
 jobs:
   sweep:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Scan merged PRs for unresolved bot comments
 

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -50,6 +50,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Check bumps-vs-tags invariant
 

--- a/.github/workflows/release-draft-stuck-check.yml
+++ b/.github/workflows/release-draft-stuck-check.yml
@@ -59,6 +59,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Check tag-vs-published-release invariant
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   dry-run:
     name: Release dry-run (darwin-arm64, no publish)
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   catch-failure:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     runs-on: ubuntu-latest
     name: Open issue on release-cli failure
     steps:
@@ -83,7 +83,7 @@ jobs:
               --label ci
 
   catch-missing-release:
-    if: ${{ github.event_name != 'workflow_run' }}
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (github.event_name != 'workflow_run') }}
     runs-on: ubuntu-latest
     name: Detect tag-without-release
     steps:

--- a/.github/workflows/release-health.yml
+++ b/.github/workflows/release-health.yml
@@ -45,6 +45,7 @@ env:
 
 jobs:
   release-health:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history + tags)

--- a/.github/workflows/ruleset-drift-check.yml
+++ b/.github/workflows/ruleset-drift-check.yml
@@ -53,6 +53,7 @@ permissions:
 
 jobs:
   diff:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Diff checked-in ruleset against live GitHub ruleset
 

--- a/.github/workflows/stale-run-reaper.yml
+++ b/.github/workflows/stale-run-reaper.yml
@@ -65,6 +65,7 @@ concurrency:
 
 jobs:
   reap:
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-latest
     name: Cancel stuck workflow runs
 

--- a/.github/workflows/watchdog-reaper.yml
+++ b/.github/workflows/watchdog-reaper.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   reap:
     name: Close stale release-watchdog trackers
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
     runs-on: ubuntu-24.04
     steps:
       - name: Reap superseded/released trackers

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -85,6 +85,18 @@ jobs:
           print(f"structural parse OK across {sum(1 for _ in pathlib.Path('.github/workflows').rglob('*.y*ml'))} files")
           PY
 
+      - name: Scheduled-workflow fork guard
+        # Every `on: schedule` workflow's entry jobs must carry the fork guard
+        # (`github.event_name != 'schedule' || github.repository == '<repo>'`) so
+        # a fork's copy doesn't cron-run our monitors and email the fork owner on
+        # every failure. The check also runs in gates.sh and the pre-push hook.
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet 'pyyaml>=6'
+          python3 tools/scripts/test_scheduled_workflow_fork_guard_check.py
+          python3 tools/scripts/scheduled_workflow_fork_guard_check.py
+
       - name: Release-pipeline regression tests (#720, #1962, #2467)
         # Regression coverage for silent CI-pipeline failures:
         #

--- a/tools/scripts/gates.sh
+++ b/tools/scripts/gates.sh
@@ -69,6 +69,7 @@ CODECOV_CFG_TEST="$ROOT/tools/scripts/test_codecov_config.py"
 CODECOV_COMP_TEST="$ROOT/tools/scripts/test_codecov_components.py"
 TERMS_LINT="$ROOT/tools/scripts/processing_model_terms_lint.py"
 SINGLE_BACKEND_GUARD="$ROOT/tools/scripts/single_backend_guard.py"
+FORK_GUARD="$ROOT/tools/scripts/scheduled_workflow_fork_guard_check.py"
 
 if [ ! -f "$VBC" ] || [ ! -f "$SSC" ] || [ ! -f "$CFG" ]; then
     echo "gates.sh: gate scripts not found (expected at tools/scripts/)" >&2
@@ -235,6 +236,17 @@ if [ -f "$IMPORT_PROV" ] && [ -n "${PULP_IMPORT_PROVENANCE_DIRS:-}" ]; then
     echo "▸ import-provenance check" >&2
     # shellcheck disable=SC2086
     if ! "$PYTHON" "$IMPORT_PROV" $PULP_IMPORT_PROVENANCE_DIRS; then
+        fail=1
+    fi
+fi
+
+# ── 11. scheduled-workflow fork guard ──────────────────────────────────────
+# Every `on: schedule` workflow's entry jobs must carry the fork guard so a
+# fork's copy doesn't cron-run our monitors and email the fork owner on failure.
+if [ -f "$FORK_GUARD" ]; then
+    echo "" >&2
+    echo "▸ scheduled-workflow fork-guard check" >&2
+    if ! "$PYTHON" "$FORK_GUARD"; then
         fail=1
     fi
 fi

--- a/tools/scripts/scheduled_workflow_fork_guard_check.py
+++ b/tools/scripts/scheduled_workflow_fork_guard_check.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Enforce the fork-guard on scheduled GitHub Actions workflows.
+
+When someone forks this repo, GitHub copies every workflow and runs the
+``on: schedule`` ones on the fork's default branch — then emails the fork owner
+whenever one *fails* (and our monitors WILL fail on a fork: they probe this
+repo's state or use secrets the fork lacks). The fix is a per-job guard so a
+scheduled run no-ops on a fork:
+
+    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
+
+This lint keeps that guard in place as new scheduled workflows land. For every
+workflow with an ``on: schedule`` trigger, each *entry* job (one with no
+``needs:`` — the roots that a scheduled run actually dispatches; dependents
+cascade-skip when their roots skip) must carry an ``if:`` that references
+``github.repository`` (the guard, optionally composed with the job's own
+condition). Non-scheduled workflows and dependent jobs are ignored.
+
+The guard only suppresses the *schedule* event on forks — ``push`` /
+``pull_request`` / ``workflow_dispatch`` are untouched, so a contributor's PR to
+this repo (which runs in this repo's context) and a fork owner's manual dispatch
+both behave exactly as before.
+
+Escape hatch: a workflow that legitimately should run on forks' schedules can
+opt out with a top-of-file ``# fork-guard-exempt: <reason>`` comment.
+
+Usage:
+    scheduled_workflow_fork_guard_check.py            # scan .github/workflows
+    scheduled_workflow_fork_guard_check.py --list     # list scheduled workflows + status
+    scheduled_workflow_fork_guard_check.py <files...>  # scan specific files
+
+Exit codes: 0 = all guarded (or exempt), 1 = one or more violations.
+"""
+from __future__ import annotations
+
+import glob
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("scheduled_workflow_fork_guard_check: PyYAML not available", file=sys.stderr)
+    sys.exit(2)
+
+CANONICAL = "github.repository"
+EXEMPT_MARKER = "# fork-guard-exempt"
+
+
+def _on_block(doc):
+    # YAML parses the bare key `on:` as the boolean True, so check both.
+    if not isinstance(doc, dict):
+        return None
+    return doc.get("on", doc.get(True))
+
+
+def is_scheduled(doc) -> bool:
+    on = _on_block(doc)
+    return isinstance(on, dict) and "schedule" in on
+
+
+def entry_jobs(doc):
+    jobs = doc.get("jobs", {}) if isinstance(doc, dict) else {}
+    return {
+        name: job
+        for name, job in jobs.items()
+        if isinstance(job, dict) and "needs" not in job
+    }
+
+
+def job_is_guarded(job) -> bool:
+    cond = job.get("if")
+    return isinstance(cond, str) and CANONICAL in cond
+
+
+def check_file(path: str):
+    """Return a list of violation strings for one workflow file."""
+    raw = open(path, encoding="utf-8").read()
+    if EXEMPT_MARKER in raw:
+        return []
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        return [f"{path}: YAML parse error: {exc}"]
+    if not is_scheduled(doc):
+        return []
+    violations = []
+    for name, job in entry_jobs(doc).items():
+        if not job_is_guarded(job):
+            violations.append(f"{path}: job '{name}' runs on schedule but lacks the fork guard")
+    return violations
+
+
+def main(argv):
+    args = [a for a in argv if not a.startswith("--")]
+    list_mode = "--list" in argv
+    files = args or sorted(glob.glob(".github/workflows/*.yml") + glob.glob(".github/workflows/*.yaml"))
+
+    all_violations = []
+    for path in files:
+        raw = open(path, encoding="utf-8").read()
+        try:
+            doc = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            doc = None
+        if list_mode and is_scheduled(doc):
+            status = "EXEMPT" if EXEMPT_MARKER in raw else ("OK" if not check_file(path) else "MISSING GUARD")
+            print(f"  {status:13} {path}")
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("scheduled-workflow-fork-guard: violations found:", file=sys.stderr)
+        for v in all_violations:
+            print(f"  ✗ {v}", file=sys.stderr)
+        print(
+            "\nAdd the guard to each flagged entry job (a job with no `needs:`):\n"
+            "    if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'\n"
+            "compose it with an existing condition as\n"
+            "    if: (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (<existing>)\n"
+            "or, if the workflow SHOULD run on forks' schedules, add a top-of-file\n"
+            "    # fork-guard-exempt: <reason>\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not list_mode:
+        print("scheduled-workflow-fork-guard: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -94,6 +94,8 @@
         "tools/scripts/hotspot_size_guard.json",
         "tools/scripts/test_hotspot_size_guard.py",
         "tools/scripts/gates.sh",
+        "tools/scripts/scheduled_workflow_fork_guard_check.py",
+        "tools/scripts/test_scheduled_workflow_fork_guard_check.py",
         "tools/scripts/host_vitals.sh",
         "tools/scripts/test_host_vitals.sh",
         "tools/scripts/host_vitals_sensor.sh",

--- a/tools/scripts/test_scheduled_workflow_fork_guard_check.py
+++ b/tools/scripts/test_scheduled_workflow_fork_guard_check.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tests for scheduled_workflow_fork_guard_check.py."""
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "scheduled_workflow_fork_guard_check.py")
+
+GUARD = "github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'"
+
+GUARDED = f"""\
+name: monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+jobs:
+  check:
+    if: {GUARD}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+UNGUARDED = """\
+name: monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+COMPOSED = f"""\
+name: monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+jobs:
+  check:
+    if: (github.event_name != 'schedule' || github.repository == 'danielraffel/pulp') && (github.event_name != 'pull_request')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+NON_SCHEDULED = """\
+name: on-pr
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+DEPENDENT_OK = f"""\
+name: monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  root:
+    if: {GUARD}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  child:
+    needs: root
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+EXEMPT = """\
+# fork-guard-exempt: this monitor is meant to run on forks too
+name: monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+
+def run(*files):
+    return subprocess.run(
+        [sys.executable, SCRIPT, *files],
+        capture_output=True, text=True,
+    )
+
+
+def write(d, name, content):
+    p = os.path.join(d, name)
+    open(p, "w").write(content)
+    return p
+
+
+def main():
+    passed = failed = 0
+
+    def check(name, content, expect_ok):
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as d:
+            p = write(d, "wf.yml", content)
+            r = run(p)
+            ok = (r.returncode == 0)
+            if ok == expect_ok:
+                passed += 1
+                print(f"  [PASS] {name}")
+            else:
+                failed += 1
+                print(f"  [FAIL] {name}: rc={r.returncode} want_ok={expect_ok}\n{r.stderr}")
+
+    print("== scheduled_workflow_fork_guard_check ==")
+    check("guarded scheduled workflow passes", GUARDED, True)
+    check("unguarded scheduled workflow fails", UNGUARDED, False)
+    check("composed guard passes", COMPOSED, True)
+    check("non-scheduled workflow ignored", NON_SCHEDULED, True)
+    check("dependent job needs no guard (root guarded)", DEPENDENT_OK, True)
+    check("exempt marker skips the check", EXEMPT, True)
+
+    # Multi-file: one bad among good -> overall fail, and the bad file is named.
+    with tempfile.TemporaryDirectory() as d:
+        good = write(d, "good.yml", GUARDED)
+        bad = write(d, "bad.yml", UNGUARDED)
+        r = run(good, bad)
+        if r.returncode == 1 and "bad.yml" in r.stderr and "good.yml" not in r.stderr:
+            passed += 1
+            print("  [PASS] multi-file names only the offender")
+        else:
+            failed += 1
+            print(f"  [FAIL] multi-file: rc={r.returncode}\n{r.stderr}")
+
+    print(f"\nscheduled_workflow_fork_guard_check: {passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

When someone forks the repo, GitHub copies every workflow and runs the
`on: schedule` ones on the fork's default branch — then **emails the fork owner
whenever one fails**, which our monitors reliably do on a fork (they probe this
repo's state or use secrets the fork lacks). A contributor hit exactly this
("[matthewfudge/pulp] Coverage upload watchdog … failed").

## What

Add a per-entry-job guard to **all 19 scheduled workflows**:

```yaml
if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'
```

(composed with any pre-existing `if:`). It suppresses **only** the `schedule`
event on forks — `push` / `pull_request` / `workflow_dispatch` are untouched, so
a PR to this repo (which runs in this repo's context) and a manual dispatch
behave exactly as before. A fork's cron now no-ops instead of failing + emailing.
Only *entry* jobs (no `needs:`) are guarded; dependents cascade-skip.

## Enforced going forward

`tools/scripts/scheduled_workflow_fork_guard_check.py` (7 hermetic tests)
requires the guard on every scheduled workflow's entry jobs, and runs in
**`gates.sh`, the pre-push hook, and `workflow-lint.yml`** — a new scheduled
workflow missing the guard fails the PR. Escape hatch: a top-of-file
`# fork-guard-exempt: <reason>` for a workflow that legitimately should run on
forks' schedules. The `ci` skill documents the convention.

Verified: lint tests pass, the lint reports the repo clean after the guards,
all changed workflows parse + actionlint-clean (only pre-existing shellcheck
style warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVa51RbTDgDCnLCoFfvUZc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops forks from running our scheduled workflows and emailing owners on failures by gating cron jobs to run only in `danielraffel/pulp`. Adds an enforcement script so new scheduled workflows must include this guard.

- **Bug Fixes**
  - Added job-level guard to all 19 scheduled workflows: `if: github.event_name != 'schedule' || github.repository == 'danielraffel/pulp'`.
  - Only suppresses `schedule` on forks; `push`, `pull_request`, and `workflow_dispatch` are unchanged.
  - Applied to entry jobs only; downstream jobs auto-skip via `needs:`.

- **Migration**
  - New scheduled workflows must add the guard to each entry job; compose with existing `if` when needed.
  - To run on forks’ schedules, add `# fork-guard-exempt: <reason>` at the top of the workflow.
  - Enforced by `tools/scripts/scheduled_workflow_fork_guard_check.py` in `gates.sh` and `workflow-lint.yml`.

<sup>Written for commit 7ab82a8dada5950c20900115ec3954f9567266da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

