### PR TITLE
chore: bump versions (v0.634.0 — ship Linux SDK at glibc 2.34)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.24)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.633.0
+    VERSION 0.634.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
Cut v0.634.0 to release the first Linux SDK built in the ubuntu:22.04 container (merged in 3083589cd / PR #5821), so the shipped Linux SDK lands at **glibc 2.34** — matching the declared floor. v0.633.0 and earlier were built before that change and still carry the ubuntu-24.04 host's glibc 2.39.

Validated on release-cli run 29015489854: `[glibc-floor] OK — build/pulp floor 2.34 <= 2.34`.

Version-only change; on merge, auto-release tags v0.634.0 and the release lane rebuilds all platforms — macOS 13.3, Windows 10, Linux glibc 2.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.634.0 to ship the Linux SDK built on `ubuntu:22.04` with glibc 2.34, matching the declared floor. Version-only change; merging triggers the release pipeline to tag v0.634.0 and rebuild all platforms (macOS 13.3, Windows 10, Linux glibc 2.34).

<sup>Written for commit 27826c0724b889bfe0dcfceecfadf3ac4b5dc1ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

