### PR TITLE
docs(readme): add link-only min-OS FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ Pulp's CLI works with any AI coding agent. Skills (`.agents/skills/`) are auto-l
 
 Full breakdown of which agent gets what: [docs/agent-integrations.md](docs/agent-integrations.md). Plugin-specific setup details: [docs/guides/claude-code-plugin.md](docs/guides/claude-code-plugin.md).
 
+## FAQ
+
+<details>
+<summary><strong>How does Pulp handle minimum OS support (Windows, Linux, macOS)?</strong></summary>
+
+Depends on the platform and on whether you enable V8 (optional; default is QuickJS/JSC). We track the lowest OS the prebuilts support and occasionally sit a step above for toolchain reasons. Numbers live at the source, not here — your floor is the highest of whatever you link:
+
+| Floor | Where |
+|---|---|
+| Pulp, resolved (all platforms) | [`tools/deps/min_os.json`](tools/deps/min_os.json) |
+| Skia + Dawn (always linked) | [skia-builder](https://github.com/danielraffel/skia-builder#minimum-os-versions-deployment-targets) |
+| V8 (only with `PULP_JS_ENGINE=v8`) | [v8-builder](https://github.com/danielraffel/v8-builder#minimum-os-versions-deployment-targets--glibc-floor) |
+
+</details>
+
 ## Contributing
 
 Pulp is early and actively evolving — contributions and plugin-author


### PR DESCRIPTION
Collapsed FAQ entry linking the single resolved min-OS source (`tools/deps/min_os.json`) + the skia-builder and v8-builder fork repos. Restates no version numbers so the README never drifts. Replaces the stuck #5808 (rebuilt clean on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a collapsed README FAQ that explains how minimum OS support is determined and links to the live sources. It points to `tools/deps/min_os.json`, `skia-builder`, and `v8-builder` so version numbers aren’t duplicated in the docs.

<sup>Written for commit f216277c899bc999adc361ae57592c440db5a019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

