### PR TITLE
fix(sdk): propagate min-OS floor to find_package(Pulp) consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.24)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.637.0
+    VERSION 0.638.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/cmake/cmake_smoke_tests.cmake
+++ b/test/cmake/cmake_smoke_tests.cmake
@@ -96,6 +96,20 @@ set_tests_properties(cmake-pulp-install-layout PROPERTIES
     # but pays a configure-amortised cost — pull it out of fast-CI.
     LABELS "cmake;binary-data;issue-905;slow"
     TIMEOUT 120)
+
+# Min-OS floor propagation to find_package(Pulp) consumers. PulpMinOs.cmake must
+# pin the consumer's deployment target when it runs AFTER project() (where the
+# target is a DEFINED-but-empty cache entry), not only when it runs before
+# Pulp's own project(). Without this, a plugin built against the installed SDK
+# silently inherits the build host's OS floor. Standalone `cmake -P` — no build
+# dir needed; asserts the correct per-host outcome (macOS deployment target /
+# Windows _WIN32_WINNT / Linux glibc floor).
+add_test(NAME cmake-pulp-minos-consumer-pin
+    COMMAND ${CMAKE_COMMAND}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_pulp_minos_consumer_pin.cmake)
+set_tests_properties(cmake-pulp-minos-consumer-pin PROPERTIES
+    LABELS "cmake;min-os"
+    TIMEOUT 60)
 # Install-layout regression for format helper sources used by
 # PulpAuv3.cmake / PulpPluginFormats.cmake from _PULP_FORMAT_SOURCE_DIR.
 # Without au_view_controller_mac.mm in the installed SDK, downstream

--- a/test/cmake/test_pulp_install_layout.cmake
+++ b/test/cmake/test_pulp_install_layout.cmake
@@ -111,6 +111,39 @@ if(NOT _installed_size EQUAL _source_size)
         "publishing a stale or different file.")
 endif()
 
+# Min-OS floor propagation: the SDK must ship PulpMinOs.cmake AND min_os.json
+# beside it, and PulpConfig.cmake must include PulpMinOs.cmake. Without all
+# three, a find_package(Pulp) consumer cannot resolve Pulp's floor and its
+# plugin silently inherits the build host's OS floor (e.g. a macOS-26 machine
+# ships a macOS-26-only plugin instead of Pulp's 13.3).
+set(_installed_minos "${_pulp_cmake_dir}/PulpMinOs.cmake")
+if(NOT EXISTS "${_installed_minos}")
+    message(FATAL_ERROR
+        "PulpMinOs.cmake not bundled with the installed Pulp SDK.\n"
+        "Expected: ${_installed_minos}\n"
+        "Consumers would not pin Pulp's min-OS floor and would ship plugins "
+        "targeting the build host's OS version.")
+endif()
+set(_installed_minos_json "${_pulp_cmake_dir}/min_os.json")
+if(NOT EXISTS "${_installed_minos_json}")
+    message(FATAL_ERROR
+        "min_os.json not bundled next to PulpMinOs.cmake in the installed SDK.\n"
+        "Expected: ${_installed_minos_json}\n"
+        "PulpMinOs.cmake finds no floor data and cannot pin the consumer.")
+endif()
+file(GLOB _pulp_config LIST_DIRECTORIES false
+    "${_pulp_cmake_dir}/PulpConfig.cmake")
+if(_pulp_config)
+    list(GET _pulp_config 0 _pulp_config)
+    file(READ "${_pulp_config}" _installed_config_text)
+    if(NOT _installed_config_text MATCHES "PulpMinOs\\.cmake")
+        message(FATAL_ERROR
+            "Installed PulpConfig.cmake does not include PulpMinOs.cmake — the "
+            "min-OS floor would not be pinned for find_package(Pulp) consumers.")
+    endif()
+endif()
+
 message(STATUS
     "Install layout: PulpUtils.cmake at ${_pulp_utils}, encoder at "
-    "${_installed_encoder} (${_installed_size} bytes). All present.")
+    "${_installed_encoder} (${_installed_size} bytes), PulpMinOs.cmake + "
+    "min_os.json bundled and wired into PulpConfig.cmake. All present.")

--- a/test/cmake/test_pulp_minos_consumer_pin.cmake
+++ b/test/cmake/test_pulp_minos_consumer_pin.cmake
@@ -1,0 +1,93 @@
+#[[
+Behavioral test: PulpMinOs.cmake pins the min-OS floor for a find_package(Pulp)
+CONSUMER, i.e. when it runs AFTER the consumer's project() rather than before
+Pulp's own.
+
+The subtlety this guards: before project() the deployment target is genuinely
+NOT DEFINED; after project() CMake has already DEFINED it as the empty string.
+The consumer path must treat empty as "unset → pin", not fall through. If this
+regresses, plugins built against the installed SDK silently inherit the build
+host's OS floor instead of Pulp's.
+
+Run standalone via `cmake -P`. Asserts the correct per-host outcome:
+  * macOS   — CMAKE_OSX_DEPLOYMENT_TARGET pinned to the macos-arm64 floor
+  * Windows — CMAKE_CXX_FLAGS carries _WIN32_WINNT from the windows-x64 floor
+  * Linux   — PULP_LINUX_GLIBC_FLOOR exposed from the linux-x64 floor
+]]
+
+cmake_minimum_required(VERSION 3.24)
+
+get_filename_component(_repo_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(PULP_MIN_OS_JSON "${_repo_root}/tools/deps/min_os.json")
+if(NOT EXISTS "${PULP_MIN_OS_JSON}")
+    message(FATAL_ERROR "min_os.json not found at ${PULP_MIN_OS_JSON}")
+endif()
+file(READ "${PULP_MIN_OS_JSON}" _json)
+
+execute_process(COMMAND uname -s
+                OUTPUT_VARIABLE _uname OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+if(_uname STREQUAL "Darwin")
+    # Reproduce the post-project() consumer state: the target is a DEFINED-but-
+    # empty CACHE entry (that is exactly what project() leaves when the developer
+    # passed no -DCMAKE_OSX_DEPLOYMENT_TARGET). Using a cache entry — not a normal
+    # variable — matters: PulpMinOs re-pins via `set(... CACHE ... FORCE)`, and a
+    # normal variable of the same name would shadow that write and mask the fix.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "simulated consumer (unset)" FORCE)
+    set(CMAKE_OSX_SYSROOT "")
+
+    # Expected floor = max(measured) over skia/dawn/libcxx (V8 only under v8 engine).
+    set(_expected "")
+    foreach(_dep skia dawn libcxx)
+        string(JSON _m ERROR_VARIABLE _e GET "${_json}" platforms macos-arm64 deps ${_dep} measured)
+        if(_e STREQUAL "NOTFOUND" AND _m AND NOT _m STREQUAL "null")
+            if(_expected STREQUAL "" OR _m VERSION_GREATER _expected)
+                set(_expected "${_m}")
+            endif()
+        endif()
+    endforeach()
+
+    include("${_repo_root}/tools/cmake/PulpMinOs.cmake")
+
+    if(CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+        message(FATAL_ERROR
+            "Consumer pin regressed: CMAKE_OSX_DEPLOYMENT_TARGET is still empty "
+            "after including PulpMinOs.cmake. A find_package(Pulp) consumer would "
+            "ship a plugin targeting the build host's OS, not Pulp's floor.")
+    endif()
+    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "${_expected}")
+        message(FATAL_ERROR
+            "Consumer pin wrong: expected ${_expected} (min_os.json macos-arm64 "
+            "floor) but PulpMinOs pinned ${CMAKE_OSX_DEPLOYMENT_TARGET}.")
+    endif()
+    message(STATUS
+        "min-OS consumer pin (macOS): empty target → ${CMAKE_OSX_DEPLOYMENT_TARGET} "
+        "(floor ${_expected}). OK.")
+
+elseif(CMAKE_HOST_WIN32)
+    string(JSON _winnt ERROR_VARIABLE _e GET "${_json}" platforms windows-x64 win32_winnt)
+    include("${_repo_root}/tools/cmake/PulpMinOs.cmake")
+    if(NOT CMAKE_CXX_FLAGS MATCHES "_WIN32_WINNT")
+        message(FATAL_ERROR
+            "Consumer pin regressed (Windows): CMAKE_CXX_FLAGS has no _WIN32_WINNT "
+            "after including PulpMinOs.cmake; a consumer would compile against the "
+            "Windows SDK default API level, not Pulp's floor.")
+    endif()
+    message(STATUS "min-OS consumer pin (Windows): _WIN32_WINNT=${_winnt} present in flags. OK.")
+
+else()
+    # Linux (and any other host): no compile-time pin — the module exposes the
+    # declared glibc floor for CI/packaging; the artifact is verified post-link.
+    string(JSON _floor ERROR_VARIABLE _e GET "${_json}" platforms linux-x64 floor)
+    include("${_repo_root}/tools/cmake/PulpMinOs.cmake")
+    if(NOT DEFINED PULP_LINUX_GLIBC_FLOOR OR PULP_LINUX_GLIBC_FLOOR STREQUAL "")
+        message(FATAL_ERROR
+            "Consumer note regressed (Linux): PULP_LINUX_GLIBC_FLOOR not exposed "
+            "after including PulpMinOs.cmake.")
+    endif()
+    if(NOT PULP_LINUX_GLIBC_FLOOR STREQUAL "${_floor}")
+        message(FATAL_ERROR
+            "Linux floor wrong: expected ${_floor} but got ${PULP_LINUX_GLIBC_FLOOR}.")
+    endif()
+    message(STATUS "min-OS consumer note (Linux): glibc floor ${PULP_LINUX_GLIBC_FLOOR}. OK.")
+endif()

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -30,6 +30,16 @@ set(PULP_IOS_AUV3_TEMPLATE_DIR "${PULP_SDK_DIR}/templates/ios-auv3")
 # Platform detection → PULP_APPLE / PULP_LINUX / PULP_WINDOWS / etc.
 include("${CMAKE_CURRENT_LIST_DIR}/PulpPlatformConfig.cmake")
 
+# Propagate Pulp's minimum-OS floor to the consumer. Without this, a plugin
+# built against the installed SDK inherits the BUILD HOST's OS floor (e.g. a
+# macOS-26 machine ships a macOS-26-only plugin) instead of the floor Pulp's own
+# libraries were compiled at. PulpMinOs.cmake reads the min_os.json shipped
+# beside it and pins the consumer's macOS deployment target / Windows
+# _WIN32_WINNT (override-wins if the consumer set a higher value) and exposes the
+# Linux glibc floor. find_package(Pulp) must precede the consumer's plugin
+# targets for the macOS/Windows pin to take effect — the normal ordering.
+include("${CMAKE_CURRENT_LIST_DIR}/PulpMinOs.cmake")
+
 # Linux PkgConfig::* IMPORTED target recreation. No-op on non-Linux.
 include("${CMAKE_CURRENT_LIST_DIR}/PulpPkgConfigImports.cmake")
 

--- a/tools/cmake/PulpInstallRules.cmake
+++ b/tools/cmake/PulpInstallRules.cmake
@@ -252,6 +252,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpAppTargets.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPlugin.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPlatformConfig.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPkgConfigImports.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpSdkGuards.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpWebGpuImportedTarget.cmake"
@@ -259,6 +260,15 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInfoPlist.aax.in"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInfoPlist.au.in"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInfoPlist.vst3.in"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Pulp
+)
+
+# Ship the min-OS floor data next to PulpMinOs.cmake so a find_package(Pulp)
+# consumer resolves the SAME floor Pulp's own build did. Without this file the
+# consumer-side PulpMinOs.cmake finds no min_os.json and cannot pin, so the
+# plugin would silently inherit the build host's OS floor.
+install(FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/deps/min_os.json"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Pulp
 )
 

--- a/tools/cmake/PulpMinOs.cmake
+++ b/tools/cmake/PulpMinOs.cmake
@@ -26,7 +26,16 @@
 #                                 what the toolchain/deps support)
 
 if(NOT DEFINED PULP_MIN_OS_JSON)
-  set(PULP_MIN_OS_JSON "${CMAKE_CURRENT_LIST_DIR}/../deps/min_os.json")
+  # Two layouts carry this module:
+  #   * source tree  — tools/cmake/PulpMinOs.cmake → tools/deps/min_os.json
+  #   * installed SDK — lib/cmake/Pulp/PulpMinOs.cmake → lib/cmake/Pulp/min_os.json
+  #     (PulpInstallRules.cmake ships min_os.json next to this module so a
+  #     find_package(Pulp) consumer inherits the same floor as Pulp itself).
+  if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../deps/min_os.json")
+    set(PULP_MIN_OS_JSON "${CMAKE_CURRENT_LIST_DIR}/../deps/min_os.json")
+  else()
+    set(PULP_MIN_OS_JSON "${CMAKE_CURRENT_LIST_DIR}/min_os.json")
+  endif()
 endif()
 
 # A min_os.json edit is a data change CMake would not otherwise treat as a
@@ -74,8 +83,16 @@ function(_pulp_min_os_pin_macos)
   endif()
 
   # Decide whether to (re)pin per the override policy documented above.
+  #
+  # "unset" has two forms depending on when this runs. Included BEFORE project()
+  # (Pulp's own build) the variable is genuinely NOT DEFINED. Included from
+  # PulpConfig.cmake at find_package() time (an installed-SDK consumer) it runs
+  # AFTER the consumer's project(), where CMake has already DEFINED it as the
+  # empty string. Both mean "the developer did not choose a target" → pin
+  # silently to the floor; only a non-empty value BELOW the floor is a real
+  # (warn-worthy) below-floor request.
   set(_apply FALSE)
-  if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+  if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
     set(_apply TRUE)
   elseif(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS _floor)
     set(_apply TRUE)


### PR DESCRIPTION
## The bug (found by the SDK-consumer sweep against v0.634.0)

The min-OS floor is pinned only when building **Pulp itself** — `PulpMinOs.cmake` runs before Pulp's own `project()`. A downstream plugin built against the **installed SDK** never saw it: `PulpConfig.cmake` didn't include `PulpMinOs.cmake`, and the SDK didn't even ship `min_os.json`. So a consumer inherited the **build host's** OS floor.

**Measured on the shipped v0.634.0 macOS SDK:** `pulp-example-plugins`' `Gain.clap` came out **minos 26.0** (the build host) instead of Pulp's **13.3** — a plugin built on a new Mac silently required that new macOS, defeating the whole floor.

## The fix — make the single source propagate

- Ship `min_os.json` + `PulpMinOs.cmake` in the SDK (`lib/cmake/Pulp/`); include `PulpMinOs.cmake` from `PulpConfig.cmake` so `find_package(Pulp)` pins the consumer's floor (override-wins if the consumer set a higher target).
- Make `PulpMinOs.cmake` dual-use: resolve `min_os.json` in the installed layout, and treat a **DEFINED-but-empty** `CMAKE_OSX_DEPLOYMENT_TARGET` as "unset → pin" (the form `project()` leaves for a consumer; the old `NOT DEFINED`-only check missed it).

## Per-platform (validated they land what they imply)
- **macOS:** pins `CMAKE_OSX_DEPLOYMENT_TARGET`. **Proven end-to-end** — consumer built against the fixed SDK with no `-D` now measures **minos 13.3** (was 26.0); explicit higher target still respected.
- **Windows:** pins `_WIN32_WINNT`/`WINVER` (compile-time API floor). The PE subsystem measured by `measure_min_os.py` is a separate loader-side value.
- **Linux:** exposes `PULP_LINUX_GLIBC_FLOOR`; no compile-time pin (glibc floor is a build-base property) — consumers build on a `<=floor` base and verify post-link.

## Tests
- `cmake-pulp-minos-consumer-pin` — asserts the post-`project()` pin fires per host.
- Extended `cmake-pulp-install-layout` — asserts `min_os.json` + `PulpMinOs.cmake` ship and `PulpConfig.cmake` wires them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates Pulp’s minimum OS floor to SDK consumers so plugins built with `find_package(Pulp)` target Pulp’s floor instead of the build host. Shipped in SDK 0.638.0; fixes incorrect macOS deployment targets, Windows API level, and exposes the Linux glibc floor.

- **Bug Fixes**
  - Ship `min_os.json` and `PulpMinOs.cmake` in the SDK and include it from `PulpConfig.cmake` so `find_package(Pulp)` pins the consumer’s floor (higher user target still wins).
  - Make `PulpMinOs.cmake` work in source and installed layouts and treat an empty `CMAKE_OSX_DEPLOYMENT_TARGET` as unset.
  - macOS: pins `CMAKE_OSX_DEPLOYMENT_TARGET`; Windows: sets `_WIN32_WINNT`/`WINVER`; Linux: exposes `PULP_LINUX_GLIBC_FLOOR`.
  - Add `cmake-pulp-minos-consumer-pin` test and extend install-layout tests to assert files ship and wiring is present.

<sup>Written for commit 4b8af97962b0a42b663a076098dfc292612cb775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/5851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

