### PR TITLE
test(wam): repair test_wam_adapter for the planar process() signature

### DIFF
--- a/test/test_wam_adapter.cpp
+++ b/test/test_wam_adapter.cpp
@@ -80,9 +80,12 @@ TEST_CASE("WAM bridge clamps oversized blocks instead of overrunning", "[wam][rt
     WamProcessorBridge bridge(pulp::examples::create_pulp_gain);
     REQUIRE(bridge.initialize(48000.0, 128)); // planar buffers sized to 128
 
+    // Planar buffers: channel 0 = [0,256), channel 1 = [256,512).
     std::vector<float> in(2 * 256, 0.25f), out(2 * 256, -99.0f);
-    REQUIRE_NOTHROW(bridge.process(in.data(), out.data(), 2, 256)); // 256 > 128
-    REQUIRE_NOTHROW(bridge.process(in.data(), out.data(), 2, 0));   // <= 0 guard
+    const float* in_ch[] = {in.data(), in.data() + 256};
+    float* out_ch[] = {out.data(), out.data() + 256};
+    REQUIRE_NOTHROW(bridge.process(in_ch, out_ch, 2, 256)); // 256 > 128
+    REQUIRE_NOTHROW(bridge.process(in_ch, out_ch, 2, 0));   // <= 0 guard
 
     for (int i = 0; i < 2 * 128; ++i) REQUIRE(std::isfinite(out[i]));
 }
@@ -128,18 +131,21 @@ TEST_CASE("WAM bridge gain parameter and state round-trip", "[wam]") {
     REQUIRE(bridge.initialize(48000.0, 128));
 
     constexpr int CH = 2, FR = 128, N = CH * FR;
+    // Planar layout: channel 0 = [0,FR), channel 1 = [FR,2*FR).
     std::vector<float> in(N), out(N, 0.0f);
-    for (int f = 0; f < FR; ++f) { in[f * CH] = 0.5f; in[f * CH + 1] = -0.5f; }
+    for (int f = 0; f < FR; ++f) { in[f] = 0.5f; in[FR + f] = -0.5f; }
+    const float* in_ch[] = {in.data(), in.data() + FR};
+    float* out_ch[] = {out.data(), out.data() + FR};
 
     // Default 0 dB in/out -> unity passthrough, distinct L/R preserved.
-    bridge.process(in.data(), out.data(), CH, FR);
+    bridge.process(in_ch, out_ch, CH, FR);
     REQUIRE(rms(out, N) == Catch::Approx(0.5f).margin(0.01f));
-    REQUIRE(out[0] == Catch::Approx(0.5f).margin(0.01f));   // L
-    REQUIRE(out[1] == Catch::Approx(-0.5f).margin(0.01f));  // R
+    REQUIRE(out[0] == Catch::Approx(0.5f).margin(0.01f));    // L, ch0 first sample
+    REQUIRE(out[FR] == Catch::Approx(-0.5f).margin(0.01f));  // R, ch1 first sample
 
     // Output gain +6 dB (~2x). PulpGain ids: "1" input, "2" output, "3" bypass.
     bridge.set_parameter_value("2", 6.0f);
-    bridge.process(in.data(), out.data(), CH, FR);
+    bridge.process(in_ch, out_ch, CH, FR);
     REQUIRE(rms(out, N) == Catch::Approx(1.0f).margin(0.03f));
 
     // Parameter read-back.
@@ -160,15 +166,18 @@ TEST_CASE("WAM bridge delivers scheduled MIDI to the processor", "[wam]") {
     REQUIRE(bridge.initialize(48000.0, 128));
 
     constexpr int CH = 2, FR = 128, N = CH * FR;
+    // Planar layout: channel 0 = [0,FR), channel 1 = [FR,2*FR).
     std::vector<float> in(N, 0.0f), out(N, -1.0f);
+    const float* in_ch[] = {in.data(), in.data() + FR};
+    float* out_ch[] = {out.data(), out.data() + FR};
 
     // No MIDI yet -> the probe outputs silence.
-    bridge.process(in.data(), out.data(), CH, FR);
+    bridge.process(in_ch, out_ch, CH, FR);
     REQUIRE(out[0] == Catch::Approx(0.0f).margin(1e-6f));
 
     // Schedule a note-on; the bridge must route it into the processor's midi_in,
     // which the probe reflects by driving its output high.
     bridge.schedule_midi(0x90, 60, 100, 0);
-    bridge.process(in.data(), out.data(), CH, FR);
+    bridge.process(in_ch, out_ch, CH, FR);
     REQUIRE(out[0] == Catch::Approx(1.0f).margin(1e-6f));
 }


### PR DESCRIPTION
Fixes a **main build break** introduced by #5958 (WAM planar end-to-end): `WamProcessorBridge::process` became planar (`const float* const*`) but `test/test_wam_adapter.cpp` still passed interleaved `float*` and asserted interleaved output — so it no longer compiles, redding the native full-build / diff-cover CI job on main and blocking `shipyard pr` validation for downstream PRs (SF-1, MF-7).

Converts the three affected cases to planar (channel-pointer arrays, planar fill, R-channel assertion at `out[FR]`). **Test-only, no production change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update WAM adapter tests to the planar `process(const float* const* inputs, float* const* outputs, int channels, int frames)` signature to fix the main build break from #5958 and restore CI.

- **Bug Fixes**
  - Converted three cases in `test/test_wam_adapter.cpp` from interleaved to planar using channel-pointer arrays; updated planar input fill and output assertions (R at `out[FR]`).
  - Test-only change; no production code modified.

<sup>Written for commit 5b3ec059727f0770b1e07ebd48927bc060d66af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

