### PR TITLE
fix(view): include host_frame_pump outside PULP_HAS_SKIA (mac build break)

### DIFF
--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -39,11 +39,16 @@
 // view_is_in_tree, modifiers_from_ns_flags) — same pulp-view-core lib.
 #include "window_host_mac_internal.hpp"
 
+// The host frame pump drives BOTH the Core Graphics and the Skia paths (the CG
+// host owns a HostFramePump member and calls should_dispatch_host_frame /
+// begin_host_frame / advance_host_frame), so these must not sit behind
+// PULP_HAS_SKIA — a non-Skia build would not see the type.
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/host_frame_pump.hpp>
+
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
-#include <pulp/view/frame_clock.hpp>
-#include <pulp/view/host_frame_pump.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/ui_components.hpp>
 #include "window_host_mac_capture.h"  // mac_capture::encode_rgba_to_png


### PR DESCRIPTION
**`core/view` does not compile on main without `PULP_HAS_SKIA`** — 8 errors in `plugin_view_host_mac.mm`.

`frame_clock.hpp` and `host_frame_pump.hpp` are included **inside** the `#ifdef PULP_HAS_SKIA` block, but the shared **Core Graphics** path uses them outside any Skia guard: the CG host owns a `HostFramePump frame_pump_` member and calls `should_dispatch_host_frame` / `begin_host_frame` / `advance_host_frame`. Without Skia the type is invisible → `unknown type name 'HostFramePump'`, `no member named 'should_dispatch_host_frame' in namespace 'pulp::view'`, plus cascading `PluginViewHost` conversion errors.

Came in with the frame-delta work (#6072). It persists on main because the build is **not a required check** — and it blocks Shipyard's pre-push diff-cover build, so `shipyard pr` currently fails for *any* PR (that's how I hit it).

Fix: hoist those two headers out of the guard. Both are plain view utilities with no Skia dependency; Skia builds are unaffected (they already included them).

**Verified:** `cmake --build … --target pulp-view-core` goes from 8 errors → `[100%] Built target pulp-view-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS non-Skia build by moving `frame_clock.hpp` and `host_frame_pump.hpp` outside the `PULP_HAS_SKIA` guard in `plugin_view_host_mac.mm`. The Core Graphics path now sees `HostFramePump` and compiles cleanly.

- **Bug Fixes**
  - Hoisted `pulp/view/frame_clock.hpp` and `pulp/view/host_frame_pump.hpp` above the Skia guard and added a comment noting both CG and Skia paths use them.
  - Verified macOS non-Skia build compiles; Skia builds unchanged.

<sup>Written for commit 6ad0b43ba4812af70ac72b95e16d819bf50ff1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

