### PR TITLE
fix(skill): pulp-web-demo import-map resolution + mountDemo feature parity

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -73,6 +73,22 @@ player behavior outside the package, which is the whole thing this skill prevent
 - Regeneration is ownership-aware: the validator refuses to clobber a locally-edited owned file
   without reconciliation.
 
+## Gotchas (learned the hard way — do not re-derive)
+
+- **Never put a `?query` on the player's import specifier.** An import map keys on the *exact*
+  bare specifier, so `import … from "<pkg>?v=<hash>"` never matches the `"<pkg>"` key and the
+  module fails to resolve — the demo does not load at all. The cache-bust belongs on the
+  **mapped URL**. A versioned CDN pin is already its own cache key.
+- **A `midi-effect` demo without `synthUrls` is SILENT.** It renders fine and looks correct, but
+  a MIDI effect emits notes with nothing to play them. `synthUrls` chains it into a synth voice
+  pool. Always set it for `mode: "midi-effect"`.
+- **The WAM artifact set is three files, not two:** `wam-dsp.js`, `wam-processor.js`, **and
+  `wam-runtime.mjs`**. The worklet imports the runtime *relative to itself*
+  (`import … from "./wam-runtime.mjs"`), so it must be co-located with the processor. Miss it
+  and `audioWorklet.addModule()` fails with a bare `AbortError: Unable to load a worklet's module`.
+- **Cache-bust the main-thread entry only** — never the worklet/dsp URLs; both sides must resolve
+  to one processor name.
+
 ## Example
 
 `examples/example.config.json` is a copy-and-edit starting point: one plugin, WAM on GitHub

--- a/.agents/skills/pulp-web-demo/config.schema.json
+++ b/.agents/skills/pulp-web-demo/config.schema.json
@@ -154,10 +154,35 @@
           }
         },
         "paramOverrides": {
-          "description": "Widget/choices/initial overrides. Controls themselves come from getParameterInfo(); this only refines them.",
+          "description": "Initial param values by label. Controls themselves come from getParameterInfo(); this only refines them.",
           "type": "object"
         },
-        "midiViz": { "type": "string", "enum": ["transpose", "mpe", "inspector", "sysex"] }
+        "midiViz": { "type": "string", "enum": ["transpose", "mpe", "inspector", "sysex"] },
+        "paramRows": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rows to reserve in the param grid before params arrive, so the panel doesn't jump on start."
+        },
+        "synthUrls": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Chain this plugin into a synth voice pool so a MIDI effect is AUDIBLE. Required for midi-effect demos — without it they render but produce no sound.",
+          "properties": {
+            "dsp": { "type": "string" },
+            "processor": { "type": "string" }
+          }
+        },
+        "widgets": {
+          "description": "Widget-kind overrides by param id or label, e.g. { \"Gain\": \"fader\" }. Values: knob|fader|toggle|combo.",
+          "type": "object"
+        },
+        "choices": {
+          "description": "Names for a stepped int param, e.g. { \"Waveform\": [\"Saw\", \"Square\"] }.",
+          "type": "object"
+        },
+        "inputGain": { "type": "number", "description": "Linear source trim in front of an effect." },
+        "controllers": { "type": "boolean", "description": "Expose the controller/preset surface." },
+        "stateMemo": { "type": "boolean", "description": "Enable the state-memo surface." }
       }
     },
     "abiArtifacts": {

--- a/.agents/skills/pulp-web-demo/generate.mjs
+++ b/.agents/skills/pulp-web-demo/generate.mjs
@@ -42,9 +42,14 @@ console.error(`pulp-web-demo: config OK → ${configPath}`);
 // ---- derived, deterministic ----
 const player = cfg.player;
 const playerHash = sha8(`${player.package}@${player.version}`);            // cache-bust, deterministic
+// Query-free base — used to build asset paths under the player (e.g. the WCLAP processor).
+const playerBaseUrl = player.importBase || `https://esm.sh/${player.package}@${player.version}`;
+// The URL the import map points at. A versioned CDN pin IS its own cache key; a self-hosted
+// importBase may be unversioned, so carry the deterministic hash there. The cache-bust must
+// live on the mapped URL — a bare specifier with a ?query never matches the import-map key.
 const playerUrl = player.importBase
-  ? player.importBase
-  : `https://esm.sh/${player.package}@${player.version}`;                  // COEP-friendly CDN, pinned
+  ? `${playerBaseUrl}${playerBaseUrl.includes("?") ? "&" : "?"}v=${playerHash}`
+  : playerBaseUrl;
 const theme = cfg.theme || {};
 const tokensHref = theme.tokensHref || "./theme/tokens.css";
 const fontsHref = theme.fontHref || "./theme/fonts.css";
@@ -75,7 +80,7 @@ function artifactsFor(plugin, abi) {
   if (explicit?.dspUrl && explicit?.processorUrl) return explicit;
   if (abi === "wam") return { dspUrl: "./wam-dsp.js", processorUrl: "./wam-processor.js" };
   // wclap: the plugin's threaded .wasm + the player-provided worklet CLAP host
-  return { dspUrl: `./${plugin.id}.wasm`, processorUrl: `${playerUrl.replace(/\/$/, "")}/vendor/pulp-wasm/wclap-processor.js` };
+  return { dspUrl: `./${plugin.id}.wasm`, processorUrl: `${playerBaseUrl.replace(/\/$/, "")}/vendor/pulp-wasm/wclap-processor.js` };
 }
 
 const ogTag = (url) => meta.ogImageStrategy === "text" ? "" : `<meta property="og:image" content="${url}og.png" />`;
@@ -89,8 +94,20 @@ const cards = [];
 for (const p of cfg.plugins) {
   const abis = p.abis || ["wam", "wclap"];
   const modeLine = p.mode ? `mode: ${JSON.stringify(p.mode)},` : "";
-  const paramBlock = p.paramOverrides ? `,\n    initialParams: ${JSON.stringify(p.paramOverrides)}` : "";
-  const midiBlock = p.midiViz ? `,\n    midiViz: ${JSON.stringify(p.midiViz)}` : "";
+  // Optional mountDemo passthroughs, emitted only when present. `synthUrls` is what makes a
+  // midi-effect demo audible (it chains into a synth voice pool) — omitting it yields silence.
+  const extras = [
+    ["initialParams", p.paramOverrides],
+    ["midiViz", p.midiViz],
+    ["paramRows", p.paramRows],
+    ["synthUrls", p.synthUrls],
+    ["widgets", p.widgets],
+    ["choices", p.choices],
+    ["inputGain", p.inputGain],
+    ["controllers", p.controllers],
+    ["stateMemo", p.stateMemo],
+  ].filter(([, v]) => v !== undefined && v !== null);
+  const extrasBlock = extras.map(([k, v]) => `,\n    ${k}: ${JSON.stringify(v)}`).join("");
   const cardAbis = [];
 
   for (const abi of abis) {
@@ -114,7 +131,7 @@ for (const p of cfg.plugins) {
       THEME_MODE_JSON: JSON.stringify(themeMode),
       PLAYER_PACKAGE: player.package, PLAYER_URL: playerUrl, PLAYER_HASH: playerHash,
       BASE_PATH: basePath,
-      PARAM_OVERRIDES_BLOCK: paramBlock, MIDI_VIZ_BLOCK: midiBlock,
+      EXTRA_OPTS_BLOCK: extrasBlock,
     };
 
     if (abi === "wam") {

--- a/.agents/skills/pulp-web-demo/templates/wam.index.html.tmpl
+++ b/.agents/skills/pulp-web-demo/templates/wam.index.html.tmpl
@@ -27,9 +27,10 @@
 <body>
 <div id="app"></div>
 <script type="module">
-// Cache-bust the MAIN-THREAD entry only (?v=<hash>); NEVER the worklet/dsp URLs —
-// both sides must hash to one processor name.
-import { mountDemo } from "{{PLAYER_PACKAGE}}?v={{PLAYER_HASH}}";
+// The pinned player resolves through the import map above. The cache-bust lives on the
+// MAPPED URL (a bare specifier with a ?query would not match the import-map key), and
+// NEVER on the worklet/dsp URLs — both sides must hash to one processor name.
+import { mountDemo } from "{{PLAYER_PACKAGE}}";
 
 mountDemo({
   root: document.getElementById("app"),
@@ -41,7 +42,7 @@ mountDemo({
   processorUrl: {{WAM_PROCESSOR_URL_JSON}},
   tokensHref: {{TOKENS_HREF_JSON}},
   fontHref: {{FONTS_HREF_JSON}},
-  theme: {{THEME_MODE_JSON}}{{PARAM_OVERRIDES_BLOCK}}{{MIDI_VIZ_BLOCK}}
+  theme: {{THEME_MODE_JSON}}{{EXTRA_OPTS_BLOCK}}
 });
 </script>
 </body>

--- a/.agents/skills/pulp-web-demo/templates/wclap.index.html.tmpl
+++ b/.agents/skills/pulp-web-demo/templates/wclap.index.html.tmpl
@@ -29,7 +29,9 @@
 <body>
 <div id="app"></div>
 <script type="module">
-import { mountShell, createWclapAdapter } from "{{PLAYER_PACKAGE}}?v={{PLAYER_HASH}}";
+// Pinned player resolves via the import map; the cache-bust lives on the MAPPED URL
+// (a bare specifier with a ?query would not match the import-map key).
+import { mountShell, createWclapAdapter } from "{{PLAYER_PACKAGE}}";
 {{ADAPTER_IMPORT_LINE}}
 
 if (!self.crossOriginIsolated) {
@@ -49,7 +51,7 @@ if (!self.crossOriginIsolated) {
     createAdapter: {{ADAPTER_FACTORY}},
     tokensHref: {{TOKENS_HREF_JSON}},
     fontHref: {{FONTS_HREF_JSON}},
-    theme: {{THEME_MODE_JSON}}{{PARAM_OVERRIDES_BLOCK}}{{MIDI_VIZ_BLOCK}}
+    theme: {{THEME_MODE_JSON}}{{EXTRA_OPTS_BLOCK}}
   });
 }
 </script>


### PR DESCRIPTION
Two **real defects** in the skill added by #6078, found by actually driving a generated page in a browser against real built plugin artifacts (not by inspection).

**1. Import-map resolution — the generated demo did not load at all.**
Templates imported the player as `"<pkg>?v=<hash>"`. An import map keys on the *exact* bare specifier, so a specifier carrying a `?query` never matches its key:
```
Uncaught TypeError: Failed to resolve module specifier "@danielraffel/web-player?v=2c4a11d0"
```
The cache-bust now lives on the **mapped URL**. A versioned CDN pin is already its own cache key, so the hash is only appended for a self-hosted (possibly unversioned) `importBase`.

**2. Feature gap — a generated midi-effect demo would be SILENT.**
Real demo pages pass `mountDemo` options the generator never emitted: `paramRows` (every page), `synthUrls` (3 pages), `widgets`, `choices`, `controllers`, `stateMemo`, `inputGain`. `synthUrls` is what chains a MIDI effect into a synth voice pool — without it the demo renders but makes no sound. All are now declarative per-plugin config fields, emitted only when present.

**Verified end-to-end:** a generated page mounting the pinned `@danielraffel/web-player` from esm.sh loads the real WAM artifacts (`wam-dsp.js` + `wam-processor.js` + `wam-runtime.mjs`), starts audio, renders params from `getParameterInfo()`, and draws all 8 widgets — zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes import-map resolution so generated web demos load reliably, and adds missing `mountDemo` options so MIDI-effect demos produce sound.

- **Bug Fixes**
  - Import map: stop importing `"<pkg>?v=<hash>"`. Keep the bare specifier and move the cache-bust to the mapped URL. CDN pins stay versioned; self-hosted `importBase` gets `?v=<hash>`. Worklet/DSP and WCLAP processor URLs now use a query-free `playerBaseUrl`.
  - Feature parity: pass through optional `mountDemo` options from config — `paramRows`, `synthUrls`, `widgets`, `choices`, `controllers`, `stateMemo`, `inputGain`. Schema updated to include these. `synthUrls` ensures MIDI-effect demos are audible.

<sup>Written for commit a0321fc0b02cf6369459db0e0111a710203b0855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

