### PR TITLE
fix(skill): pulp-web-demo gallery.emit + optional theme; restore clobbered gotchas

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -73,6 +73,31 @@ player behavior outside the package, which is the whole thing this skill prevent
 - Regeneration is ownership-aware: the validator refuses to clobber a locally-edited owned file
   without reconciliation.
 
+## Gallery and theme (both optional)
+
+- **`gallery.emit`** — `"auto"` (default): emit the gallery landing page only when the catalog
+  has more than one plugin (a gallery is pointless for a single plugin). `true` / `false` force
+  it; use `false` to keep a hand-curated landing page of your own.
+- **`theme`** — omit it entirely and the player uses its **own bundled skin**. Only set
+  `tokensHref` / `fontHref` when you are actually supplying a token stylesheet.
+
+## Gotchas (learned the hard way — do not re-derive)
+
+- **Never put a `?query` on the player's import specifier.** An import map keys on the *exact*
+  bare specifier, so `import ... from "<pkg>?v=<hash>"` never matches the `"<pkg>"` key and the
+  module fails to resolve — the demo does not load at all. The cache-bust belongs on the
+  **mapped URL**. A versioned CDN pin is already its own cache key.
+- **A `midi-effect` demo without `synthUrls` is SILENT.** It renders fine and looks correct, but
+  a MIDI effect emits notes with nothing to play them. `synthUrls` chains it into a synth voice
+  pool. Always set it for `mode: "midi-effect"`.
+- **The WAM artifact set is three files, not two:** `wam-dsp.js`, `wam-processor.js`, **and
+  `wam-runtime.mjs`**. The worklet imports the runtime *relative to itself*, so it must be
+  co-located with the processor. Miss it and `audioWorklet.addModule()` fails with a bare
+  `AbortError: Unable to load a worklet's module`.
+- **Never invent a `tokensHref`.** A made-up relative path just 404s and silently drops the skin.
+- **Cache-bust the main-thread entry only** — never the worklet/dsp URLs; both sides must resolve
+  to one processor name.
+
 ## Example
 
 `examples/example.config.json` is a copy-and-edit starting point: one plugin, WAM on GitHub

--- a/.agents/skills/pulp-web-demo/config.schema.json
+++ b/.agents/skills/pulp-web-demo/config.schema.json
@@ -53,6 +53,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "emit": {
+          "description": "Whether to generate the gallery landing page. Default 'auto': emit when the catalog has more than one plugin (a gallery is pointless for a single plugin). Set false to keep a hand-curated gallery of your own.",
+          "type": ["boolean", "string"],
+          "enum": [true, false, "auto"],
+          "default": "auto"
+        },
         "title": { "type": "string" },
         "layout": { "type": "string", "enum": ["grid", "list", "single"], "default": "grid" },
         "crossLinks": {
@@ -154,10 +160,35 @@
           }
         },
         "paramOverrides": {
-          "description": "Widget/choices/initial overrides. Controls themselves come from getParameterInfo(); this only refines them.",
+          "description": "Initial param values by label. Controls themselves come from getParameterInfo(); this only refines them.",
           "type": "object"
         },
-        "midiViz": { "type": "string", "enum": ["transpose", "mpe", "inspector", "sysex"] }
+        "midiViz": { "type": "string", "enum": ["transpose", "mpe", "inspector", "sysex"] },
+        "paramRows": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rows to reserve in the param grid before params arrive, so the panel doesn't jump on start."
+        },
+        "synthUrls": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Chain this plugin into a synth voice pool so a MIDI effect is AUDIBLE. Required for midi-effect demos — without it they render but produce no sound.",
+          "properties": {
+            "dsp": { "type": "string" },
+            "processor": { "type": "string" }
+          }
+        },
+        "widgets": {
+          "description": "Widget-kind overrides by param id or label, e.g. { \"Gain\": \"fader\" }. Values: knob|fader|toggle|combo.",
+          "type": "object"
+        },
+        "choices": {
+          "description": "Names for a stepped int param, e.g. { \"Waveform\": [\"Saw\", \"Square\"] }.",
+          "type": "object"
+        },
+        "inputGain": { "type": "number", "description": "Linear source trim in front of an effect." },
+        "controllers": { "type": "boolean", "description": "Expose the controller/preset surface." },
+        "stateMemo": { "type": "boolean", "description": "Enable the state-memo surface." }
       }
     },
     "abiArtifacts": {

--- a/.agents/skills/pulp-web-demo/generate.mjs
+++ b/.agents/skills/pulp-web-demo/generate.mjs
@@ -42,13 +42,24 @@ console.error(`pulp-web-demo: config OK → ${configPath}`);
 // ---- derived, deterministic ----
 const player = cfg.player;
 const playerHash = sha8(`${player.package}@${player.version}`);            // cache-bust, deterministic
+// Query-free base — used to build asset paths under the player (e.g. the WCLAP processor).
+const playerBaseUrl = player.importBase || `https://esm.sh/${player.package}@${player.version}`;
+// The URL the import map points at. A versioned CDN pin IS its own cache key; a self-hosted
+// importBase may be unversioned, so carry the deterministic hash there. The cache-bust must
+// live on the mapped URL — a bare specifier with a ?query never matches the import-map key.
 const playerUrl = player.importBase
-  ? player.importBase
-  : `https://esm.sh/${player.package}@${player.version}`;                  // COEP-friendly CDN, pinned
+  ? `${playerBaseUrl}${playerBaseUrl.includes("?") ? "&" : "?"}v=${playerHash}`
+  : playerBaseUrl;
+// Theme is OPTIONAL. Unset ⇒ the player uses its own bundled skin; we must not invent a
+// tokensHref (a made-up relative path just 404s and drops the skin entirely).
 const theme = cfg.theme || {};
-const tokensHref = theme.tokensHref || "./theme/tokens.css";
-const fontsHref = theme.fontHref || "./theme/fonts.css";
+const tokensHref = theme.tokensHref || null;
+const fontsHref = theme.fontHref || null;
 const themeMode = theme.mode || "auto";
+const themeLinks = [
+  tokensHref ? `<link rel="stylesheet" href="${tokensHref}" />` : null,
+  fontsHref ? `<link rel="stylesheet" href="${fontsHref}" />` : null,
+].filter(Boolean).join("\n");
 const meta = cfg.metadata || {};
 const siteBase = (meta.siteBase || "").replace(/\/$/, "");
 
@@ -75,7 +86,7 @@ function artifactsFor(plugin, abi) {
   if (explicit?.dspUrl && explicit?.processorUrl) return explicit;
   if (abi === "wam") return { dspUrl: "./wam-dsp.js", processorUrl: "./wam-processor.js" };
   // wclap: the plugin's threaded .wasm + the player-provided worklet CLAP host
-  return { dspUrl: `./${plugin.id}.wasm`, processorUrl: `${playerUrl.replace(/\/$/, "")}/vendor/pulp-wasm/wclap-processor.js` };
+  return { dspUrl: `./${plugin.id}.wasm`, processorUrl: `${playerBaseUrl.replace(/\/$/, "")}/vendor/pulp-wasm/wclap-processor.js` };
 }
 
 const ogTag = (url) => meta.ogImageStrategy === "text" ? "" : `<meta property="og:image" content="${url}og.png" />`;
@@ -89,8 +100,22 @@ const cards = [];
 for (const p of cfg.plugins) {
   const abis = p.abis || ["wam", "wclap"];
   const modeLine = p.mode ? `mode: ${JSON.stringify(p.mode)},` : "";
-  const paramBlock = p.paramOverrides ? `,\n    initialParams: ${JSON.stringify(p.paramOverrides)}` : "";
-  const midiBlock = p.midiViz ? `,\n    midiViz: ${JSON.stringify(p.midiViz)}` : "";
+  // Optional mountDemo passthroughs, emitted only when present. `synthUrls` is what makes a
+  // midi-effect demo audible (it chains into a synth voice pool) — omitting it yields silence.
+  const extras = [
+    ["tokensHref", tokensHref],
+    ["fontHref", fontsHref],
+    ["initialParams", p.paramOverrides],
+    ["midiViz", p.midiViz],
+    ["paramRows", p.paramRows],
+    ["synthUrls", p.synthUrls],
+    ["widgets", p.widgets],
+    ["choices", p.choices],
+    ["inputGain", p.inputGain],
+    ["controllers", p.controllers],
+    ["stateMemo", p.stateMemo],
+  ].filter(([, v]) => v !== undefined && v !== null);
+  const extrasBlock = extras.map(([k, v]) => `,\n    ${k}: ${JSON.stringify(v)}`).join("");
   const cardAbis = [];
 
   for (const abi of abis) {
@@ -109,12 +134,11 @@ for (const p of cfg.plugins) {
       TITLE_JSON: JSON.stringify(p.title), SUBTITLE_JSON: JSON.stringify(p.subtitle || ""),
       MODE_LINE: modeLine, PAGE_URL: pageUrl, SOURCE_URL: sourceUrl,
       OG_IMAGE_TAG: ogTag(pageUrl),
-      TOKENS_HREF: tokensHref, FONTS_HREF: fontsHref,
-      TOKENS_HREF_JSON: JSON.stringify(tokensHref), FONTS_HREF_JSON: JSON.stringify(fontsHref),
+      THEME_LINKS: themeLinks,
       THEME_MODE_JSON: JSON.stringify(themeMode),
       PLAYER_PACKAGE: player.package, PLAYER_URL: playerUrl, PLAYER_HASH: playerHash,
       BASE_PATH: basePath,
-      PARAM_OVERRIDES_BLOCK: paramBlock, MIDI_VIZ_BLOCK: midiBlock,
+      EXTRA_OPTS_BLOCK: extrasBlock,
     };
 
     if (abi === "wam") {
@@ -144,13 +168,19 @@ for (const p of cfg.plugins) {
 }
 
 // ---- gallery landing page ----
+// `gallery.emit`: true | false | "auto" (default). Auto emits only when the catalog has more
+// than one plugin — a gallery is pointless for a single plugin, and `false` lets a consumer
+// keep a hand-curated landing page of their own.
 const gallery = cfg.gallery || {};
+const emitGallery = gallery.emit === undefined || gallery.emit === "auto"
+  ? cfg.plugins.length > 1
+  : gallery.emit === true;
 const crossLinks = (gallery.crossLinks || []).map((c) => `<a href="${c.href}">${c.label}</a>`).join(" · ");
-emit("index.html", fill(T("gallery.index.html.tmpl"), {
+if (emitGallery) emit("index.html", fill(T("gallery.index.html.tmpl"), {
   GENERATOR_VERSION,
   GALLERY_TITLE: gallery.title || "Pulp web demos",
   GALLERY_URL: (cfg.deploy?.wam?.publicUrl || `${siteBase}${(cfg.deploy?.wam?.basePath) || "/"}`).replace(/\/+$/, "") + "/",
-  TOKENS_HREF: tokensHref, FONTS_HREF: fontsHref,
+  THEME_LINKS: themeLinks,
   LAYOUT_CLASS: `layout-${gallery.layout || "grid"}`,
   CROSS_LINKS: crossLinks, PLUGIN_CARDS: cards.join("\n"),
 }));

--- a/.agents/skills/pulp-web-demo/templates/gallery.index.html.tmpl
+++ b/.agents/skills/pulp-web-demo/templates/gallery.index.html.tmpl
@@ -8,8 +8,7 @@
 <meta property="og:title" content="{{GALLERY_TITLE}}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{GALLERY_URL}}" />
-<link rel="stylesheet" href="{{TOKENS_HREF}}" />
-<link rel="stylesheet" href="{{FONTS_HREF}}" />
+{{THEME_LINKS}}
 <style>
   body { font-family: var(--font-family-native, system-ui); color: var(--text-primary, #111);
          background: var(--bg-primary, #fff); margin: 0; padding: 2rem; }

--- a/.agents/skills/pulp-web-demo/templates/wam.index.html.tmpl
+++ b/.agents/skills/pulp-web-demo/templates/wam.index.html.tmpl
@@ -16,8 +16,7 @@
 <meta name="pulp:source" content="{{SOURCE_URL}}" />
 
 <!-- Your skin: 19 color tokens + 1 font var. The player is 100% token-driven. -->
-<link rel="stylesheet" href="{{TOKENS_HREF}}" />
-<link rel="stylesheet" href="{{FONTS_HREF}}" />
+{{THEME_LINKS}}
 
 <!-- Pinned shared player — imported, never vendored. -->
 <script type="importmap">
@@ -27,9 +26,10 @@
 <body>
 <div id="app"></div>
 <script type="module">
-// Cache-bust the MAIN-THREAD entry only (?v=<hash>); NEVER the worklet/dsp URLs —
-// both sides must hash to one processor name.
-import { mountDemo } from "{{PLAYER_PACKAGE}}?v={{PLAYER_HASH}}";
+// The pinned player resolves through the import map above. The cache-bust lives on the
+// MAPPED URL (a bare specifier with a ?query would not match the import-map key), and
+// NEVER on the worklet/dsp URLs — both sides must hash to one processor name.
+import { mountDemo } from "{{PLAYER_PACKAGE}}";
 
 mountDemo({
   root: document.getElementById("app"),
@@ -39,9 +39,7 @@ mountDemo({
   {{MODE_LINE}}
   dspUrl: {{WAM_DSP_URL_JSON}},
   processorUrl: {{WAM_PROCESSOR_URL_JSON}},
-  tokensHref: {{TOKENS_HREF_JSON}},
-  fontHref: {{FONTS_HREF_JSON}},
-  theme: {{THEME_MODE_JSON}}{{PARAM_OVERRIDES_BLOCK}}{{MIDI_VIZ_BLOCK}}
+  theme: {{THEME_MODE_JSON}}{{EXTRA_OPTS_BLOCK}}
 });
 </script>
 </body>

--- a/.agents/skills/pulp-web-demo/templates/wclap.index.html.tmpl
+++ b/.agents/skills/pulp-web-demo/templates/wclap.index.html.tmpl
@@ -19,8 +19,7 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="pulp:source" content="{{SOURCE_URL}}" />
 
-<link rel="stylesheet" href="{{TOKENS_HREF}}" />
-<link rel="stylesheet" href="{{FONTS_HREF}}" />
+{{THEME_LINKS}}
 
 <script type="importmap">
 { "imports": { "{{PLAYER_PACKAGE}}": "{{PLAYER_URL}}" } }
@@ -29,7 +28,9 @@
 <body>
 <div id="app"></div>
 <script type="module">
-import { mountShell, createWclapAdapter } from "{{PLAYER_PACKAGE}}?v={{PLAYER_HASH}}";
+// Pinned player resolves via the import map; the cache-bust lives on the MAPPED URL
+// (a bare specifier with a ?query would not match the import-map key).
+import { mountShell, createWclapAdapter } from "{{PLAYER_PACKAGE}}";
 {{ADAPTER_IMPORT_LINE}}
 
 if (!self.crossOriginIsolated) {
@@ -47,9 +48,7 @@ if (!self.crossOriginIsolated) {
     dspUrl: {{WCLAP_DSP_URL_JSON}},
     processorUrl: {{WCLAP_PROCESSOR_URL_JSON}},
     createAdapter: {{ADAPTER_FACTORY}},
-    tokensHref: {{TOKENS_HREF_JSON}},
-    fontHref: {{FONTS_HREF_JSON}},
-    theme: {{THEME_MODE_JSON}}{{PARAM_OVERRIDES_BLOCK}}{{MIDI_VIZ_BLOCK}}
+    theme: {{THEME_MODE_JSON}}{{EXTRA_OPTS_BLOCK}}
   });
 }
 </script>


### PR DESCRIPTION
Two generator improvements found while preparing a real consumer migration, plus a restore.

**`gallery.emit`** — `true` | `false` | `"auto"` (default). Auto emits the gallery landing page only when the catalog has **more than one plugin** (a gallery is pointless for a single plugin); `false` lets a consumer keep a hand-curated landing page of their own.

**Theme is now optional.** The generator defaulted `tokensHref` to `./theme/tokens.css` — which simply **404s and silently drops the skin**. The real demo pages pass no theme at all and rely on the player's *bundled* skin. Unset now means exactly that; the `<link>` tags and `mountDemo` opts are omitted.

**Restores the Gotchas section.** #6080 added it; **#6082 silently reverted it** — that PR was a ParamInfo/GCC change based on a pre-#6080 `main`, so its squash carried an old `SKILL.md` and removed 16 unrelated lines (`0 added, 16 removed`). Worth flagging as a stale-base clobber pattern.

Validation for first real use is tracked in #6084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `gallery.emit` controls and make the demo theme optional in the `pulp-web-demo` generator to prevent broken skins and allow custom landing pages. Also restores the “Gotchas” section in `SKILL.md` that was accidentally removed.

- **New Features**
  - `gallery.emit`: `true` | `false` | `"auto"` (default). `"auto"` emits the gallery only when there’s more than one plugin; `false` keeps your own landing page.
  - Optional theme: when `theme` is unset we omit `<link>` tags and do not pass `tokensHref`/`fontHref`; the player uses its bundled skin.
  - Pass-through demo opts: exposes new optional fields in `config.schema.json` and forwards them when present (e.g., `synthUrls` for audible MIDI-effect demos).

- **Bug Fixes**
  - Restores the “Gotchas” section in `SKILL.md` lost in a stale-base merge, documenting pitfalls like keeping cache-busting on the mapped URL and not on the bare import specifier.

<sup>Written for commit 65fe904107b3996317c1e643d19a80c6fe2b2c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

