### PR TITLE
feat(skill): pulp-web-demo file upload — config + drop-zone contract

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -81,6 +81,49 @@ player behavior outside the package, which is the whole thing this skill prevent
 - **`theme`** — omit it entirely and the player uses its **own bundled skin**. Only set
   `tokensHref` / `fontHref` when you are actually supplying a token stylesheet.
 
+## File upload (dialog **and** drag-and-drop)
+
+If a plugin takes a user-supplied file (a convolver's impulse response, a sample, a preset),
+declare it with the per-plugin **`fileUpload`** config (`accept`, `label`, `hint`). The demo must
+then offer **both** a file-dialog button **and** a drop zone — people drag files onto anything
+that looks like a target.
+
+**This is a PLAYER behavior, not a per-demo one.** Like every other UX invariant, the drop-zone
+mechanics belong in the shared player so both ABIs inherit them. Re-implementing a drop zone in
+one demo page is exactly the drift this skill exists to prevent — its WCLAP twin would then need
+its own copy, and the two would diverge.
+
+Any implementation MUST satisfy all six rules. Each one, skipped, makes the zone feel broken:
+
+1. **Swallow drops on the whole `document`.** The browser's default action for a file dropped
+   anywhere on the page is to **navigate to it**, destroying the running demo — audio context,
+   loaded state, knob positions. Add `document` listeners for `dragover` and `drop` that call
+   `preventDefault()` and nothing else, so a ten-pixel miss is inert rather than session-ending.
+   That is a brutal punishment for a gesture you invited. **Unbind them in `destroy()`.**
+2. **Count `dragenter`/`dragleave` depth — do not toggle.** `dragleave` bubbles from the zone's
+   own children, so dragging across a button *inside* the zone fires it and the highlight
+   strobes. Keep a depth counter; clear the highlight only at zero.
+3. **Scope the highlight to the drop zone**, never the whole plugin — the highlight is the thing
+   that tells someone where the target is.
+4. **Set `dataTransfer.dropEffect = "copy"`** on `dragover`, so the cursor shows a copy badge
+   rather than a "no entry" sign.
+5. **Handle the empty drop.** `dataTransfer.files[0]` can be `undefined` (dragged text, a URL).
+   Say so; don't throw.
+6. **Keep the button.** Drop is a shortcut, not a replacement — and it is the *only* path on
+   touch devices.
+
+**Testing gotcha (this one bites):** drive it with real `DragEvent`s and a real `DataTransfer`
+carrying a real `File`. The real browser order when the pointer crosses into a child is
+**`dragenter` on the new target, then `dragleave` on the old** — so a test that fires a bare
+`dragleave` will report a highlight-flicker bug **that does not exist**.
+
+**Reference implementation:** `examples/web-demos/super-convolver-ui/ir-source.js` (drop zone at
+the bottom of `mountIrLoader()`; both traps written up in its comments). It also shows a related
+trap worth knowing: **`decodeAudioData` resamples, so the decoded buffer never carries the file's
+real sample rate** — parse the WAV/AIFF header (`sniffAudioHeader`) if you want to tell the user
+the truth about their file. That code currently lives in a demo and should be **upstreamed into
+the shared player**, not copied.
+
 ## Gotchas (learned the hard way — do not re-derive)
 
 - **Never put a `?query` on the player's import specifier.** An import map keys on the *exact*

--- a/.agents/skills/pulp-web-demo/config.schema.json
+++ b/.agents/skills/pulp-web-demo/config.schema.json
@@ -187,6 +187,20 @@
           "type": "object"
         },
         "inputGain": { "type": "number", "description": "Linear source trim in front of an effect." },
+        "fileUpload": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Declare that this plugin accepts a user-supplied file (e.g. a convolver's impulse response). The player must then offer BOTH a file-dialog button AND a drag-and-drop zone — drop is a shortcut, not a replacement, and the button is the only path on touch devices. The drop-zone mechanics are a PLAYER behavior (see SKILL.md 'File upload'); never re-implement them per demo.",
+          "properties": {
+            "accept": {
+              "type": "string",
+              "description": "Input accept list, e.g. \"audio/*,.wav,.aif,.aiff,.flac,.mp3,.ogg\"."
+            },
+            "label": { "type": "string", "description": "Button label, e.g. \"Load impulse response…\"." },
+            "hint": { "type": "string", "description": "Short line shown in the drop zone, e.g. \"or drop a file here\"." },
+            "revertLabel": { "type": "string", "description": "Optional label for a 'back to the built-in' control." }
+          }
+        },
         "controllers": { "type": "boolean", "description": "Expose the controller/preset surface." },
         "stateMemo": { "type": "boolean", "description": "Enable the state-memo surface." }
       }

--- a/.agents/skills/pulp-web-demo/generate.mjs
+++ b/.agents/skills/pulp-web-demo/generate.mjs
@@ -112,6 +112,7 @@ for (const p of cfg.plugins) {
     ["widgets", p.widgets],
     ["choices", p.choices],
     ["inputGain", p.inputGain],
+    ["fileUpload", p.fileUpload],
     ["controllers", p.controllers],
     ["stateMemo", p.stateMemo],
   ].filter(([, v]) => v !== undefined && v !== null);

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.337.6",
+      "version": "0.338.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.337.6"
+  "version": "0.338.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.337.6",
+  "version": "0.338.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",


### PR DESCRIPTION
Adds file-upload support to the **pulp-web-demo** skill: a per-plugin **`fileUpload`** config (`accept`, `label`, `hint`, `revertLabel`) for plugins that take a user-supplied file (a convolver IR, a sample, a preset). The demo must then offer **both** a file-dialog button **and** a drag-and-drop zone — people drag files onto anything that looks like a target, and the button is the only path on touch devices.

### The drop zone is a PLAYER behavior, not a per-demo one
Re-implementing a zone in a single demo page is exactly the drift this skill exists to prevent — that demo's WCLAP twin would need its own copy and the two would diverge. So the skill **declares** the capability and **owns the contract**; the mechanics belong in the shared player. (Reference implementation currently lives in `examples/web-demos/super-convolver-ui/ir-source.js` and should be upstreamed — tracked separately.)

### The six rules, now binding in SKILL.md
Each one, skipped, makes the zone feel broken:

1. **Swallow drops on the whole `document`.** The browser's default action for a file dropped anywhere on the page is to **navigate to it**, destroying the running demo (audio context, loaded state, knob positions). A ten-pixel miss ending someone's session is a brutal punishment for a gesture we invited. Unbind in `destroy()`.
2. **Count `dragenter`/`dragleave` depth — don't toggle.** `dragleave` bubbles from the zone's own children, so dragging across a button inside it strobes the highlight.
3. **Scope the highlight to the zone**, never the whole plugin.
4. **`dataTransfer.dropEffect = "copy"`** on `dragover`.
5. **Handle the empty drop** — `files[0]` can be `undefined` (dragged text, a URL).
6. **Keep the button.** Drop is a shortcut, not a replacement.

### Testing gotcha (recorded, because it bites)
The real browser order when the pointer crosses into a child is **`dragenter` on the new target, then `dragleave` on the old** — so a test firing a bare `dragleave` will report a highlight-flicker bug **that does not exist**.

Also notes the related trap that `decodeAudioData` **resamples**, so the decoded buffer never carries the file's real sample rate — sniff the WAV/AIFF header if you want to tell the user the truth about their file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file-upload support to `pulp-web-demo` via a per-plugin `fileUpload` config and a player-level drag-and-drop contract. Requires both a file-dialog button and a drop zone to keep UX consistent across demos and ABIs.

- **New Features**
  - `config.schema.json`: adds `fileUpload` with `accept`, `label`, `hint`, `revertLabel`.
  - `generate.mjs`: passes `fileUpload` through to generated output.
  - `SKILL.md`: defines the player-owned drop-zone contract (document-level guards, depth-counted enter/leave, scoped highlight, copy cursor, empty-drop handling, keep the button) and records the drag event-order testing gotcha.

- **Dependencies**
  - Bump `.claude-plugin` version to `0.338.0` (`plugin.json`, `marketplace.json`) to ship the new skill feature.

<sup>Written for commit 0ec835d4d21b3deddd2e93d33734d1f32f4559b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

