### PR TITLE
docs(skill): pulp-web-demo — the player now implements file upload

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -112,17 +112,28 @@ Any implementation MUST satisfy all six rules. Each one, skipped, makes the zone
 6. **Keep the button.** Drop is a shortcut, not a replacement — and it is the *only* path on
    touch devices.
 
-**Testing gotcha (this one bites):** drive it with real `DragEvent`s and a real `DataTransfer`
-carrying a real `File`. The real browser order when the pointer crosses into a child is
-**`dragenter` on the new target, then `dragleave` on the old** — so a test that fires a bare
-`dragleave` will report a highlight-flicker bug **that does not exist**.
+**Two testing gotchas — both make a correct implementation look broken:**
 
-**Reference implementation:** `examples/web-demos/super-convolver-ui/ir-source.js` (drop zone at
-the bottom of `mountIrLoader()`; both traps written up in its comments). It also shows a related
-trap worth knowing: **`decodeAudioData` resamples, so the decoded buffer never carries the file's
-real sample rate** — parse the WAV/AIFF header (`sniffAudioHeader`) if you want to tell the user
-the truth about their file. That code currently lives in a demo and should be **upstreamed into
-the shared player**, not copied.
+- Drive it with real `DragEvent`s and a real `DataTransfer` carrying a real `File`. The real
+  browser order when the pointer crosses into a child is **`dragenter` on the new target, then
+  `dragleave` on the old** — so a test that fires a bare `dragleave` will report a
+  highlight-flicker bug **that does not exist**.
+- **`dropEffect` cannot be asserted from a synthetic drag.** The spec honours it only during a
+  real user-initiated drag, so on a synthetic `DataTransfer` `dropEffect = "copy"` silently
+  stays `"none"` — a browser-driven test will "fail" a line that is perfectly correct. Pin rule 4
+  in a DOM shim (where the assignment is observable) and do **not** "fix" the code to satisfy a
+  synthetic drag.
+
+**The player implements this** (`src/ui/file-upload.js` in `@danielraffel/web-player`): declare
+`fileUpload` and you get the zone, the button, and all six rules for free, on both ABIs. The
+player owns the *interaction*; the **encoding is yours** — only the plugin knows how its bytes
+want to look — so pass `onFile(file, api)` and use the `api.writeBlob()` you're handed, which
+preserves the plugin's params (loading a file must never reset the knobs). With no `onFile`, the
+player writes the file's raw bytes and lets the plugin decode them.
+
+One related trap worth knowing: **`decodeAudioData` resamples**, so the decoded buffer never
+carries the file's real sample rate. If you tell the user anything about their file, parse the
+WAV/AIFF header instead of trusting the decoded buffer.
 
 ## Gotchas (learned the hard way — do not re-derive)
 


### PR DESCRIPTION
Follow-up to #6097, which landed the drop zone + dialog in the shared player (`src/ui/file-upload.js`).

- The skill no longer says the mechanics "should be upstreamed" — they are in the player. Declare `fileUpload` and **both ABIs inherit all six rules**. The player owns the *interaction*; the **encoding stays with the plugin** (pass `onFile` and use the `api.writeBlob()` you are handed — it preserves params, so loading a file never resets the knobs).
- Records a **second testing gotcha**, found while testing the real implementation: **`dropEffect` cannot be asserted from a synthetic drag.** The spec honours it only during a real user-initiated drag, so on a synthetic `DataTransfer` `dropEffect = "copy"` silently stays `"none"` — a browser-driven test will "fail" a line that is perfectly correct. Pin rule 4 in a DOM shim; do **not** "fix" working code to satisfy it. Sibling of the bare-`dragleave` trap already recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 08:21 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update skill docs to reflect that the shared player (`@danielraffel/web-player`, `src/ui/file-upload.js`) now implements file upload (drop zone + button); declare `fileUpload` to get all six rules on both ABIs while plugins handle encoding via `onFile(file, api)` and `api.writeBlob()` preserves params. Add a testing note: `dropEffect` isn’t honored in synthetic drags (stays `none`), so pin rule 4 in a DOM shim; keep the bare-`dragleave` warning and note that `decodeAudioData` resamples.

<sup>Written for commit 39b386e1530510b5ff4e8b2bd8e52ff800070594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

