### PR TITLE
chore(web-player): 0.2.0 — file upload (dialog + drag-and-drop)

### DIFF
--- a/packages/pulp-web-player/package.json
+++ b/packages/pulp-web-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielraffel/web-player",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Reusable, skinnable, host-agnostic web player for Pulp audio plugins (WAMv2 today, WebCLAP next) \u2014 the overlay/lifecycle shell, auto-generated parameter grid, on-screen + computer keyboard + WebMIDI, oscilloscope/meter, safety limiter, PLST state container, MIDI visualisers and canvas widget set, driven through a small host-adapter interface.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps the shared player to **0.2.0** so #6097's `mountDemo({ fileUpload })` can be published to npm.

Generated demos import the **pinned** package from esm.sh, so they remain on 0.1.0 (no drop zone) until a config pins 0.2.0. Publishing is the step that makes `fileUpload` actually function.

Verified before publish: the tarball contains `src/ui/file-upload.js` (7.5kB), and the package's full suite is green on this commit (adapter seam, WebCLAP adapter, custom-UI, file-upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 16:12 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@danielraffel/web-player` to 0.2.0 to ship file upload support (file dialog + drag-and-drop) from #6097. This enables `mountDemo({ fileUpload })` in generated demos when they pin 0.2.0; demos pinned to 0.1.0 keep the old behavior.

- **Migration**
  - Pin `@danielraffel/web-player@0.2.0` in generated demo configs (esm.sh) to enable file upload.

<sup>Written for commit 64cd686efca5b0286f9ee8d4e84fae8daf868cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

