### PR TITLE
chore(web-player): 0.2.1 — publish the corrected README

### DIFF
--- a/packages/pulp-web-player/package.json
+++ b/packages/pulp-web-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielraffel/web-player",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reusable, skinnable, host-agnostic web player for Pulp audio plugins (WAMv2 today, WebCLAP next) \u2014 the overlay/lifecycle shell, auto-generated parameter grid, on-screen + computer keyboard + WebMIDI, oscilloscope/meter, safety limiter, PLST state container, MIDI visualisers and canvas widget set, driven through a small host-adapter interface.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
npm serves the README **from the published tarball**, so npmjs.com still shows the pre-#6108 text — which claims `"private": true` and that publishing is a *pending owner-gated step*, on a package that is published. A patch release is the only way to fix what people actually read on the package page.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 16:50 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `@danielraffel/web-player` 0.2.1 to update the README shown on npm. No code changes—just a version bump so npm serves the corrected README instead of the stale one claiming the package is private or unpublished.

<sup>Written for commit 1aa0442e4f28de55936ae17af52f018a3eda8240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

