### PR TITLE
fix(web-player): publish.sh cried wolf on a successful publish

### DIFF
--- a/packages/pulp-web-player/scripts/publish.sh
+++ b/packages/pulp-web-player/scripts/publish.sh
@@ -130,9 +130,17 @@ unset token
 
 npm publish --userconfig "$TMPNPMRC" --access public
 
-# ── 6. Verify the registry actually serves the new code. ────────────────────────
-sleep 5
-published="$(npm view "$PKG" version 2>/dev/null || echo '?')"
+# ── 6. Verify the registry actually serves the new version.
+#       `npm view` reads through a cache and the registry itself takes a moment to
+#       settle, so a single eager check right after publish reports the OLD version
+#       and cries wolf on a publish that in fact succeeded. Retry with backoff and
+#       read the registry directly rather than trusting the cache.
+for attempt in 1 2 3 4 5 6; do
+  published="$(curl -fsS "https://registry.npmjs.org/${PKG}" 2>/dev/null \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{console.log(JSON.parse(s)["dist-tags"].latest)}catch{console.log("?")}})')"
+  [[ "$published" == "$VERSION" ]] && break
+  sleep $(( attempt * 5 ))
+done
 [[ "$published" == "$VERSION" ]] \
-  || die "published, but the registry still reports $published — check npm"
+  || die "published, but after ~105s the registry still reports '$published' — check npm"
 printf '\n  ✓ %s@%s is live\n' "$PKG" "$VERSION"


### PR DESCRIPTION
Caught on the **first real run** of the script.

`0.2.1` published fine — and then the script said *"published, but the registry still reports 0.2.0"*.

The post-publish check read `npm view` five seconds after publishing. `npm view` reads through a **cache**, and the registry takes a moment to settle, so it saw the previous version and failed a publish that had **actually succeeded**. That's precisely the kind of false alarm that teaches people to ignore their release tooling.

Now it retries with backoff (~105s) and reads `registry.npmjs.org` **directly** rather than trusting the npm cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 16:53 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes post-publish verification in `packages/pulp-web-player/scripts/publish.sh` to stop false failures when npm cache lags after a successful publish. The script now reads `https://registry.npmjs.org/<pkg>` directly and retries with backoff (up to ~105s) until the new version appears.

<sup>Written for commit c9a72105c6c4d5be5e101f8820fec7c8b0a69277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

