### PR TITLE
fix(skill): pulp-web-demo example pins 0.2.1 (0.1.0 has no fileUpload)

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -149,6 +149,10 @@ WAV/AIFF header instead of trusting the decoded buffer.
   co-located with the processor. Miss it and `audioWorklet.addModule()` fails with a bare
   `AbortError: Unable to load a worklet's module`.
 - **Never invent a `tokensHref`.** A made-up relative path just 404s and silently drops the skin.
+- **Pin a player version that actually HAS the features you declare.** The config pins the
+  player, so declaring `fileUpload` against a version predating it yields a demo that silently
+  renders no zone. `fileUpload` needs **>= 0.2.0**. When the player gains a feature, bump the
+  pin in your config — the pin is what the generated page imports.
 - **Cache-bust the main-thread entry only** — never the worklet/dsp URLs; both sides must resolve
   to one processor name.
 

--- a/.agents/skills/pulp-web-demo/examples/example.config.json
+++ b/.agents/skills/pulp-web-demo/examples/example.config.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "player": {
     "package": "@danielraffel/web-player",
-    "version": "0.1.0"
+    "version": "0.2.1"
   },
   "theme": {
     "tokensHref": "./theme/tokens.css",
@@ -30,10 +30,14 @@
     "sourceLinkBase": "https://github.com/you/my-plugins/tree/main"
   },
   "gallery": {
-    "title": "My plugins — live web demos",
+    "title": "My plugins \u2014 live web demos",
     "layout": "grid",
     "crossLinks": [
-      { "label": "also runs as WCLAP →", "href": "https://my-plugins.pages.dev/my-plugins/", "abi": "wclap" }
+      {
+        "label": "also runs as WCLAP \u2192",
+        "href": "https://my-plugins.pages.dev/my-plugins/",
+        "abi": "wclap"
+      }
     ]
   },
   "plugins": [
@@ -42,7 +46,10 @@
       "title": "My Plugin",
       "subtitle": "One honest sentence about what it does.",
       "mode": "audio-effect",
-      "abis": ["wam", "wclap"]
+      "abis": [
+        "wam",
+        "wclap"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The skill documents `fileUpload`, but its example config pinned **0.1.0** — a player version that does not contain it. Anyone copying the example would declare a feature their pinned player cannot render. npm serves **0.2.1**.

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 17:23 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin pulp-web-demo to `@danielraffel/web-player` 0.2.1 so `fileUpload` works (0.1.0 lacked it). Add a SKILL.md note to pin versions with required features (`fileUpload` >= 0.2.0) and make minor JSON typography tweaks.

<sup>Written for commit 30dd94502114f4dfc22d0dd5b7a8c7f8f4c30225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

