### PR TITLE
fix(skill): pulp-web-demo — og:image must exist AND be a real PNG (a 200 can lie)

### DIFF
--- a/.agents/skills/pulp-web-demo/SKILL.md
+++ b/.agents/skills/pulp-web-demo/SKILL.md
@@ -69,7 +69,62 @@ player behavior outside the package, which is the whole thing this skill prevent
   never the worklet/dsp URLs (both sides must resolve one processor name).
 - **Cross-origin isolation must cover the real deployed path** (e.g. `/my-plugins/`), and
   every worklet/wasm dependency must be isolation-compatible — validated, not assumed.
-- **OG/metadata generation + checks are blocking** (never `continue-on-error`).
+- **OG/metadata checks are blocking** (never `continue-on-error`). The generator emits the
+  `og:image` **tag** but does not **render** the image (rendering needs a browser; the generator
+  is offline + deterministic). So with `ogImageStrategy: "screenshot"` your pipeline MUST render
+  the images *before* `validate.mjs --check-metadata` runs — the validator fails if the tag points
+  at a file that isn't there, **or isn't really a PNG**. Do not settle for an HTTP 200: a static
+  host (Cloudflare Pages) will serve a missing asset as 200 and cheerfully confirm an image that
+  does not exist. Check the bytes. Use `ogImageStrategy: "text"` if you don't render images.
+- Regeneration is ownership-aware: the validator refuses to clobber a locally-edited owned file
+  without reconciliation.
+
+## File upload (dialog **and** drag-and-drop)
+
+If a plugin takes a user-supplied file (a convolver's impulse response, a sample, a preset),
+declare it with the per-plugin **`fileUpload`** config (`accept`, `label`, `hint`). The demo must
+then offer **both** a file-dialog button **and** a drop zone — people drag files onto anything
+that looks like a target.
+
+**This is a PLAYER behavior, not a per-demo one.** Like every other UX invariant, the drop-zone
+mechanics belong in the shared player so both ABIs inherit them. Re-implementing a drop zone in
+one demo page is exactly the drift this skill exists to prevent — its WCLAP twin would then need
+its own copy, and the two would diverge.
+
+**Put it INSIDE the plugin, directly under the controls.** Placement is not cosmetics here. A
+loader parked below the plugin panel — in the page chrome, past the scope and the meter — reads
+as page furniture rather than part of the instrument, and people simply do not find it: it is
+the one control the demo is *asking* them to use, and it is the one sitting outside the box
+everything else lives in. It belongs in the panel, immediately under the last row of controls,
+with the gap between them tight enough that they read as one unit. The player exposes a slot for
+exactly this (chrome the plugin owns, rendered inside the panel); use it rather than appending to
+the page.
+
+Any implementation MUST satisfy all six rules. Each one, skipped, makes the zone feel broken:
+
+1. **Swallow drops on the whole `document`.** The browser's default action for a file dropped
+   anywhere on the page is to **navigate to it**, destroying the running demo — audio context,
+   loaded state, knob positions. Add `document` listeners for `dragover` and `drop` that call
+   `preventDefault()` and nothing else, so a ten-pixel miss is inert rather than session-ending.
+   That is a brutal punishment for a gesture you invited. **Unbind them in `destroy()`.**
+2. **Count `dragenter`/`dragleave` depth — do not toggle.** `dragleave` bubbles from the zone's
+   own children, so dragging across a button *inside* the zone fires it and the highlight
+   strobes. Keep a depth counter; clear the highlight only at zero.
+3. **Scope the highlight to the drop zone**, never the whole plugin — the highlight is the thing
+   that tells someone where the target is.
+4. **Set `dataTransfer.dropEffect = "copy"`** on `dragover`, so the cursor shows a copy badge
+   rather than a "no entry" sign.
+5. **Handle the empty drop.** `dataTransfer.files[0]` can be `undefined` (dragged text, a URL).
+   Say so; don't throw.
+6. **Keep the button.** Drop is a shortcut, not a replacement — and it is the *only* path on
+   touch devices.
+
+**Two testing gotchas — both make a correct implementation look broken:**
+
+- Drive it with real `DragEvent`s and a real `DataTransfer` carrying a real `File`. The real
+  browser order when the pointer crosses into a child is **`dragenter` on the new target, then
+  `dragleave` on the old** — so a test that fires a bare `dragleave` will report a
+  highlight-flicker bug **that does not exist**.
 - Regeneration is ownership-aware: the validator refuses to clobber a locally-edited owned file
   without reconciliation.
 

--- a/.agents/skills/pulp-web-demo/validate.mjs
+++ b/.agents/skills/pulp-web-demo/validate.mjs
@@ -6,11 +6,11 @@
 //   node validate.mjs --site <dir> --check-metadata   # OG/unfurl tags present (blocking)
 //   node validate.mjs --site <dir> --check-ownership  # owned files unmodified since generation
 //
-// The headline risk (Codex): isolation must cover the REAL base path (e.g. /my-plugins/),
+// The headline risk (Codex): isolation must cover the REAL base path (e.g. /example-plugins/),
 // not "/", or the page loads and only threaded init fails.
 
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname } from "node:path";
 import { createHash } from "node:crypto";
 
 const args = process.argv.slice(2);
@@ -80,6 +80,23 @@ function checkIsolation(cfg, site) {
 }
 
 // ---- metadata / OG (blocking) ----
+//
+// The generator EMITS an og:image tag; it does not RENDER the image (rendering needs a
+// browser, and the generator is deliberately offline + deterministic). So the tag can
+// point at nothing. Worse: a static host will happily serve a missing asset as HTTP 200
+// (Cloudflare Pages does), so a status-code probe would confirm an image that isn't there.
+// The only honest check is the bytes: the file must exist AND start with the PNG magic.
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+function ogImageIsReal(site, pageRel, imgUrl) {
+  // og:image is absolute (siteBase + basePath + id + "/og.png"); resolve it to the page dir
+  const name = imgUrl.split("/").pop();
+  const f = join(site, dirname(pageRel), name);
+  if (!existsSync(f)) return { ok: false, why: `missing: ${dirname(pageRel)}/${name}` };
+  const head = readFileSync(f).subarray(0, 8);
+  if (!head.equals(PNG_MAGIC)) return { ok: false, why: `${dirname(pageRel)}/${name} is not a PNG (a host would still serve it 200)` };
+  return { ok: true };
+}
+
 function checkMetadata(cfg, site) {
   const strategy = cfg.metadata?.ogImageStrategy || "screenshot";
   const pages = [];
@@ -93,7 +110,14 @@ function checkMetadata(cfg, site) {
     if (strategy === "screenshot" && !/property="og:image"/.test(h) && !/index\.html$/.test(rel) === false && !rel.startsWith("index")) {
       // gallery root may omit a per-plugin image; plugin pages must have one under screenshot strategy
     }
-    if (strategy === "screenshot" && /\/index\.html$/.test("/" + rel) && rel !== "index.html" && !/property="og:image"/.test(h)) bad(`${rel}: screenshot strategy requires og:image`);
+    if (strategy === "screenshot" && rel !== "index.html") {
+      const m = h.match(/property="og:image" content="([^"]+)"/);
+      if (!m) { bad(`${rel}: screenshot strategy requires og:image`); }
+      else {
+        const v = ogImageIsReal(site, rel, m[1]);
+        if (!v.ok) bad(`${rel}: og:image ${v.why}`);
+      }
+    }
   }
   if (pages.length) ok(`metadata present on ${pages.length} pages (strategy: ${strategy})`);
 }


### PR DESCRIPTION
Closes the OG-image gap tracked in #6084.

The generator emits the `og:image` **tag** but never **renders** the image (rendering needs a browser; the generator is offline + deterministic). So the tag could point at nothing and nobody would notice until a social card came up blank.

**The obvious check is wrong.** A static host serves a *missing* asset as **HTTP 200** — Cloudflare Pages does — so a status-code probe would cheerfully confirm an image that isn't there. The only honest check is the **bytes**: the file must exist *and* start with the PNG magic. (Caught in practice while deploying the WCLAP demos.)

`--check-metadata` now fails on a tag pointing at a missing or non-PNG image, which turns `ogImageStrategy: "screenshot"` into an actual contract: **render your images before validating.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["claude", "m5", "w1", "XX ✳ Check m3 server…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `w1`  ·  **Tab** `XX ✳ Check m3 server for wedged processes`  
**Session** `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Resume** `claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea`  
**Restore URL** https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj  
**Jump to this tab** `cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
**Relaunch (any agent)** `cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431`  
<sub>stamped 2026-07-13 22:01 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify that every `og:image` in the pulp web demo actually exists and is a real PNG by checking file bytes on disk. Prevents blank social cards and makes `ogImageStrategy: "screenshot"` an enforceable contract.

- **Bug Fixes**
  - In `validate.mjs`, when `ogImageStrategy: "screenshot"`, parse each page’s `og:image`, resolve the file next to the page, and validate the PNG magic bytes.
  - Fail `--check-metadata` if the image is missing or not PNG; avoids false positives from static hosts returning 200.

- **Migration**
  - Render screenshots before running `validate.mjs --check-metadata`. If you aren’t rendering images, use `ogImageStrategy: "text"`.

<sup>Written for commit a6b442318dbecbcd181e2dbf0955c5ef56f9524c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

