### PR TITLE
feat(signal): add FftT::inverse_real() — real-valued inverse FFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.674.0
+    VERSION 0.675.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/signal/include/pulp/signal/fft.hpp
+++ b/core/signal/include/pulp/signal/fft.hpp
@@ -21,8 +21,9 @@ namespace pulp::signal {
 //
 // RT contract: construction/destruction allocate or release twiddle/vDSP
 // storage and are prepare/control-thread work. forward(), inverse(),
-// forward_real(), magnitude(), magnitude_db(), and size() are allocation-free
-// after construction when callers provide valid input/output buffers.
+// forward_real(), inverse_real(), magnitude(), magnitude_db(), and size()
+// are allocation-free after construction when callers provide valid
+// input/output buffers.
 template <typename SampleType = float>
 class FftT {
     static_assert(std::is_floating_point_v<SampleType>,
@@ -36,6 +37,7 @@ public:
 
     FftT(FftT&& other) noexcept
         : size_(other.size_), twiddles_(std::move(other.twiddles_))
+        , inverse_real_scratch_(std::move(other.inverse_real_scratch_))
 #if PULP_FFT_HAS_VDSP
         , log2n_(other.log2n_), vdsp_setup_(other.vdsp_setup_)
         , split_real_(std::move(other.split_real_)), split_imag_(std::move(other.split_imag_))
@@ -60,6 +62,7 @@ public:
             size_ = other.size_;
             other.size_ = 0;
             twiddles_ = std::move(other.twiddles_);
+            inverse_real_scratch_ = std::move(other.inverse_real_scratch_);
         }
         return *this;
     }
@@ -81,6 +84,11 @@ public:
             double angle = -2.0 * pi * i / size;
             twiddles_[i] = {std::cos(angle), std::sin(angle)};
         }
+        // Scratch for inverse_real_fallback() — allocated once here so
+        // inverse_real() stays allocation-free. The vDSP branch never touches it,
+        // so skip it where that branch always wins (Apple + float): a 65536-point
+        // FftT<float> would otherwise carry ~512 KB it can never use.
+        if constexpr (uses_inverse_real_fallback()) inverse_real_scratch_.resize(size);
     }
 
     ~FftT() {
@@ -130,6 +138,25 @@ public:
 #endif
     }
 
+    // Real-valued inverse FFT: conjugate-symmetric complex spectrum → real output.
+    // `input` must use the same N-length layout forward_real() produces (full
+    // conjugate-symmetric spectrum, i.e. input[N-k] == conj(input[k]), DC and
+    // Nyquist bins purely real). Normalization matches inverse(): forward_real()
+    // is unnormalized (same convention as forward()), and inverse_real() applies
+    // the compensating 1/N once, so inverse_real(forward_real(x)) == x (to float
+    // precision) with no extra scaling required by the caller.
+    void inverse_real(const std::complex<SampleType>* input, SampleType* output) const {
+#if PULP_FFT_HAS_VDSP
+        if constexpr (std::is_same_v<SampleType, float>) {
+            inverse_real_vdsp(input, output);
+        } else {
+            inverse_real_fallback(input, output);
+        }
+#else
+        inverse_real_fallback(input, output);
+#endif
+    }
+
     // Compute magnitude spectrum in dB
     void magnitude_db(const std::complex<SampleType>* freq,
                       SampleType* out,
@@ -151,9 +178,21 @@ public:
     }
 
 private:
+    /// True when inverse_real() resolves to inverse_real_fallback() — i.e. when the
+    /// vDSP branch isn't compiled in, or SampleType isn't the float it handles.
+    /// Mirrors inverse_real()'s own dispatch so the two can't drift apart.
+    static constexpr bool uses_inverse_real_fallback() {
+#if PULP_FFT_HAS_VDSP
+        return !std::is_same_v<SampleType, float>;
+#else
+        return true;
+#endif
+    }
+
     static constexpr double pi = 3.14159265358979323846;
     int size_ = 0;
     std::vector<std::complex<double>> twiddles_;
+    mutable std::vector<std::complex<SampleType>> inverse_real_scratch_;
 #if PULP_FFT_HAS_VDSP
     int log2n_ = 0;
     FFTSetup vdsp_setup_ = nullptr;
@@ -220,6 +259,41 @@ private:
             output[i] = {output[i].real() * scale, output[i].imag() * scale};
         }
     }
+
+    void inverse_real_vdsp(const std::complex<float>* input, float* output) const {
+        // Pack the conjugate-symmetric spectrum into vDSP_fft_zrip's split-complex
+        // layout — the inverse of forward_real_vdsp's unpack: DC into realp[0],
+        // Nyquist into imagp[0], and bins 1..half-1 as-is (upper half is redundant,
+        // implied by conjugate symmetry, so it is not read).
+        int half = size_ / 2;
+        split_real_[0] = input[0].real();     // DC
+        split_imag_[0] = input[half].real();  // Nyquist
+        for (int i = 1; i < half; ++i) {
+            split_real_[i] = input[i].real();
+            split_imag_[i] = input[i].imag();
+        }
+        DSPSplitComplex split = {split_real_.data(), split_imag_.data()};
+        vDSP_fft_zrip(vdsp_setup_, &split, 1, log2n_, kFFTDirection_Inverse);
+
+        // Scale derivation: forward_real_vdsp's raw (pre-0.5) zrip output is 2x
+        // the true unnormalized DFT (that's what its own 0.5 corrects). Feeding
+        // vDSP_fft_zrip's inverse the *true* (already 0.5-corrected) spectrum —
+        // as we do here — produces size_ times the original real signal, i.e.
+        // the same bare 1/N relationship inverse_vdsp() uses for the complex
+        // case (empirically verified: for input = forward_real_vdsp(x), the raw
+        // zrip inverse output equals size_ * x, independent of size_, so a
+        // single 1/size_ scale — not 1/(2*size_) — makes the round trip exact).
+        float scale = 1.0f / size_;
+        vDSP_vsmul(split_real_.data(), 1, &scale, split_real_.data(), 1, static_cast<vDSP_Length>(half));
+        vDSP_vsmul(split_imag_.data(), 1, &scale, split_imag_.data(), 1, static_cast<vDSP_Length>(half));
+
+        // Unpack split-complex back to interleaved real samples (inverse of
+        // forward_real_vdsp's even/odd pack)
+        for (int i = 0; i < half; ++i) {
+            output[2 * i] = split_real_[i];
+            output[2 * i + 1] = split_imag_[i];
+        }
+    }
 #endif
 
     void forward_fallback(std::complex<SampleType>* data) const {
@@ -251,6 +325,17 @@ private:
         for (int i = 0; i < size_; ++i)
             output[i] = {input[i], SampleType{0.0f}};
         forward(output);
+    }
+
+    void inverse_real_fallback(const std::complex<SampleType>* input,
+                               SampleType* output) const {
+        // inverse() is already normalized (1/N, see inverse_fallback()), so this
+        // is simply the complex inverse transform with the real part taken —
+        // obviously correct, and the reference the vDSP branch is checked against.
+        std::copy(input, input + size_, inverse_real_scratch_.begin());
+        inverse(inverse_real_scratch_.data());
+        for (int i = 0; i < size_; ++i)
+            output[i] = inverse_real_scratch_[i].real();
     }
 
     void bit_reverse(std::complex<SampleType>* data) const {

--- a/test/test_signal_rt_safety.cpp
+++ b/test/test_signal_rt_safety.cpp
@@ -482,6 +482,7 @@ TEST_CASE("FFT and simple convolver hot paths are allocation-free after setup",
         fft.forward(complex_samples.data());
         fft.inverse(complex_samples.data());
         fft.forward_real(real_samples.data(), complex_samples.data());
+        fft.inverse_real(complex_samples.data(), real_samples.data());
         fft.magnitude(complex_samples.data(), magnitudes.data(), static_cast<int>(magnitudes.size()));
         fft.magnitude_db(complex_samples.data(), magnitudes_db.data(), static_cast<int>(magnitudes_db.size()));
         (void)fft.size();

--- a/test/test_signal_spectral.cpp
+++ b/test/test_signal_spectral.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <random>
 #include <vector>
 
 using namespace pulp::signal;
@@ -331,6 +332,253 @@ TEST_CASE("FFT64 runs a double-precision round trip and real transform",
     std::vector<double> db(1, 0.0);
     fft.magnitude_db(bins.data(), db.data(), 1);
     REQUIRE_THAT(db[0], WithinAbs(-40.0, 1e-12));
+}
+
+// ── FFT inverse_real ─────────────────────────────────────────────────────────
+
+namespace {
+
+// Deterministic (fixed-seed) pseudo-random signal — no system randomness, so
+// runs are reproducible across machines and CI.
+std::vector<float> random_signal(int n, std::uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> x(static_cast<size_t>(n));
+    for (auto& v : x) v = dist(rng);
+    return x;
+}
+
+std::vector<float> impulse_signal(int n) {
+    std::vector<float> x(static_cast<size_t>(n), 0.0f);
+    x[0] = 1.0f;
+    return x;
+}
+
+std::vector<float> dc_signal(int n) {
+    return std::vector<float>(static_cast<size_t>(n), 0.37f);
+}
+
+std::vector<float> sine_signal(int n, int bin) {
+    std::vector<float> x(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i)
+        x[static_cast<size_t>(i)] =
+            std::sin(2.0f * 3.14159265358979323846f * static_cast<float>(bin) * i / n);
+    return x;
+}
+
+std::vector<float> multi_tone_signal(int n) {
+    std::vector<float> x(static_cast<size_t>(n), 0.0f);
+    for (int bin : {1, 3, 7, 11}) {
+        if (bin >= n / 2) continue;
+        for (int i = 0; i < n; ++i)
+            x[static_cast<size_t>(i)] +=
+                0.25f * std::sin(2.0f * 3.14159265358979323846f * bin * i / n);
+    }
+    return x;
+}
+
+// inverse_real(forward_real(x)) should reproduce x for every FftT instantiation
+// (this exercises whichever backend `Fft` resolves to — vdsp on Apple).
+void check_round_trip(int n, const std::vector<float>& signal, float tol) {
+    Fft fft(n);
+    std::vector<std::complex<float>> spectrum(static_cast<size_t>(n));
+    std::vector<float> recovered(static_cast<size_t>(n));
+
+    fft.forward_real(signal.data(), spectrum.data());
+    fft.inverse_real(spectrum.data(), recovered.data());
+
+    for (int i = 0; i < n; ++i) {
+        REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                     WithinAbs(signal[static_cast<size_t>(i)], tol));
+    }
+}
+
+} // namespace
+
+TEST_CASE("FFT inverse_real round-trip recovers forward_real input",
+          "[signal][fft][inverse_real]") {
+    for (int n : {64, 128, 256, 1024, 4096}) {
+        // Float32 error accumulates with transform size; scale tolerance accordingly.
+        const float tol = 5e-4f + 2e-7f * static_cast<float>(n);
+
+        check_round_trip(n, impulse_signal(n), tol);
+        check_round_trip(n, dc_signal(n), tol);
+        check_round_trip(n, sine_signal(n, 5), tol);
+        check_round_trip(n, multi_tone_signal(n), tol);
+        check_round_trip(n, random_signal(n, 0xF17700D5u), tol);
+    }
+}
+
+TEST_CASE("FFT inverse_real survives moving the FftT that owns its scratch",
+          "[signal][fft][inverse_real][move]") {
+    // FftT's move ctor/assignment enumerate their members explicitly, so a new
+    // owning member has to be transferred in both or the moved-to object is left
+    // with an empty (move-ctor) or wrong-sized (move-assign) scratch and
+    // inverse_real() writes out of bounds.
+    //
+    // Fft64 is deliberate, not incidental: inverse_real_scratch_ is only touched
+    // by inverse_real_fallback(), and FftT<float> takes the vDSP branch on Apple,
+    // so a float-only move test would pass whether or not the scratch is
+    // transferred. Fft64 never satisfies the vDSP gate, so it always drives the
+    // fallback and is the only variant here that can actually observe the bug.
+    constexpr int n = 256;
+    constexpr double tol = 1e-9;
+    std::vector<double> signal(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i)
+        signal[static_cast<size_t>(i)] =
+            std::sin(2.0 * 3.14159265358979323846 * 5.0 * i / n) +
+            0.5 * std::cos(2.0 * 3.14159265358979323846 * 11.0 * i / n);
+
+    std::vector<std::complex<double>> spectrum(static_cast<size_t>(n));
+    std::vector<double> recovered(static_cast<size_t>(n));
+
+    SECTION("move-constructed") {
+        Fft64 source(n);
+        Fft64 fft(std::move(source));
+        fft.forward_real(signal.data(), spectrum.data());
+        fft.inverse_real(spectrum.data(), recovered.data());
+        for (int i = 0; i < n; ++i)
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                         WithinAbs(signal[static_cast<size_t>(i)], tol));
+    }
+
+    SECTION("move-assigned over a smaller instance") {
+        Fft64 fft(64);  // its own scratch is too small for n
+        fft = Fft64(n);
+        fft.forward_real(signal.data(), spectrum.data());
+        fft.inverse_real(spectrum.data(), recovered.data());
+        for (int i = 0; i < n; ++i)
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                         WithinAbs(signal[static_cast<size_t>(i)], tol));
+    }
+
+    SECTION("move-constructed Fft (float) still round-trips") {
+        // Covers the vDSP branch's own moved members; does not exercise the
+        // scratch (see note above), but pins that moving doesn't break float.
+        const float ftol = 5e-4f + 2e-7f * static_cast<float>(n);
+        const std::vector<float> fsignal = multi_tone_signal(n);
+        std::vector<std::complex<float>> fspectrum(static_cast<size_t>(n));
+        std::vector<float> frecovered(static_cast<size_t>(n));
+
+        Fft source(n);
+        Fft fft(std::move(source));
+        fft.forward_real(fsignal.data(), fspectrum.data());
+        fft.inverse_real(fspectrum.data(), frecovered.data());
+        for (int i = 0; i < n; ++i)
+            REQUIRE_THAT(frecovered[static_cast<size_t>(i)],
+                         WithinAbs(fsignal[static_cast<size_t>(i)], ftol));
+    }
+}
+
+TEST_CASE("FFT64 inverse_real round-trip exercises the scalar fallback backend",
+          "[signal][fft][inverse_real][f64]") {
+    // Fft64 (double) never satisfies FftT's `is_same_v<SampleType, float>` vDSP
+    // gate, so this always drives inverse_real_fallback() -- the counterpart
+    // to the vdsp-backed Fft coverage above.
+    for (int n : {64, 256, 1024}) {
+        Fft64 fft(n);
+        std::vector<double> signal(static_cast<size_t>(n));
+        for (int i = 0; i < n; ++i)
+            signal[static_cast<size_t>(i)] =
+                std::sin(2.0 * 3.14159265358979323846 * 5.0 * i / n) +
+                0.5 * std::cos(2.0 * 3.14159265358979323846 * 11.0 * i / n);
+
+        std::vector<std::complex<double>> spectrum(static_cast<size_t>(n));
+        std::vector<double> recovered(static_cast<size_t>(n));
+        fft.forward_real(signal.data(), spectrum.data());
+        fft.inverse_real(spectrum.data(), recovered.data());
+
+        for (int i = 0; i < n; ++i) {
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                         WithinAbs(signal[static_cast<size_t>(i)], 1e-10));
+        }
+    }
+}
+
+TEST_CASE("FFT inverse_real matches hand-composed complex inverse() + real part",
+          "[signal][fft][inverse_real]") {
+    // Proves the dedicated real-optimized (vdsp zrip) path agrees with the
+    // generic route every consumer used before this function existed:
+    // forward_real() -> complex inverse() -> take the real part.
+    constexpr int N = 512;
+    Fft fft(N);
+
+    auto signal = multi_tone_signal(N);
+    std::vector<std::complex<float>> spectrum(N);
+    fft.forward_real(signal.data(), spectrum.data());
+
+    std::vector<float> via_inverse_real(N);
+    fft.inverse_real(spectrum.data(), via_inverse_real.data());
+
+    std::vector<std::complex<float>> hand_composed = spectrum;
+    fft.inverse(hand_composed.data());
+
+    for (int i = 0; i < N; ++i) {
+        REQUIRE_THAT(via_inverse_real[static_cast<size_t>(i)],
+                     WithinAbs(hand_composed[static_cast<size_t>(i)].real(), 1e-4f));
+        // The hand-composed route's imaginary part should be ~0 for a
+        // conjugate-symmetric spectrum -- confirms the input really was one.
+        REQUIRE_THAT(hand_composed[static_cast<size_t>(i)].imag(), WithinAbs(0.0f, 1e-3f));
+    }
+}
+
+TEST_CASE("FFT inverse_real reconstructs DC-only and Nyquist-only spectra",
+          "[signal][fft][inverse_real][issue-645]") {
+    // DC and Nyquist are the two bins folded into realp[0]/imagp[0] by the real
+    // FFT packing trick -- exactly where real-FFT bugs tend to hide.
+    constexpr int N = 32;
+    Fft fft(N);
+
+    SECTION("DC-only spectrum reconstructs a constant signal") {
+        constexpr float dc = 8.0f; // forward_real()'s unnormalized DC for a constant c is c*N
+        std::vector<std::complex<float>> spectrum(N, {0.0f, 0.0f});
+        spectrum[0] = {dc, 0.0f};
+
+        std::vector<float> recovered(N);
+        fft.inverse_real(spectrum.data(), recovered.data());
+
+        for (int i = 0; i < N; ++i) {
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                         WithinAbs(dc / static_cast<float>(N), 1e-4f));
+        }
+    }
+
+    SECTION("Nyquist-only spectrum reconstructs an alternating signal") {
+        constexpr float nyquist = 8.0f;
+        std::vector<std::complex<float>> spectrum(N, {0.0f, 0.0f});
+        spectrum[N / 2] = {nyquist, 0.0f};
+
+        std::vector<float> recovered(N);
+        fft.inverse_real(spectrum.data(), recovered.data());
+
+        const float expected_amplitude = nyquist / static_cast<float>(N);
+        for (int i = 0; i < N; ++i) {
+            const float expected = (i % 2 == 0 ? expected_amplitude : -expected_amplitude);
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)], WithinAbs(expected, 1e-4f));
+        }
+    }
+
+    SECTION("An alternating (+-A) input signal round-trips through the Nyquist bin") {
+        constexpr float amplitude = 0.75f;
+        std::vector<float> signal(N);
+        for (int i = 0; i < N; ++i)
+            signal[static_cast<size_t>(i)] = (i % 2 == 0 ? amplitude : -amplitude);
+
+        std::vector<std::complex<float>> spectrum(N);
+        fft.forward_real(signal.data(), spectrum.data());
+
+        // All energy should land in the Nyquist bin.
+        REQUIRE_THAT(spectrum[N / 2].real(), WithinAbs(amplitude * N, 1e-3f));
+        REQUIRE_THAT(spectrum[N / 2].imag(), WithinAbs(0.0f, 1e-4f));
+        REQUIRE_THAT(spectrum[0].real(), WithinAbs(0.0f, 1e-4f));
+
+        std::vector<float> recovered(N);
+        fft.inverse_real(spectrum.data(), recovered.data());
+        for (int i = 0; i < N; ++i) {
+            REQUIRE_THAT(recovered[static_cast<size_t>(i)],
+                         WithinAbs(signal[static_cast<size_t>(i)], 1e-4f));
+        }
+    }
 }
 
 // ── Convolver ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds `inverse_real()` to `pulp::signal::FftT`, mirroring the existing `forward_real()`.

## The gap

`fft.hpp` has `forward_real()` (vDSP branch + scalar fallback) but no real-valued inverse. Any caller doing real-signal spectral work — analyse a real block, modify the spectrum, resynthesise — has to hand-compose `forward_real()` → complex `inverse()` → take the real part at every call site. That's a round trip the library can do better, and it's easy to get the normalization wrong in caller code.

## What it does

A straight mirror of `forward_real`'s structure:

- `inverse_real_vdsp()` under `PULP_FFT_HAS_VDSP` for float — `vDSP_fft_zrip` with `kFFTDirection_Inverse`, packing DC/Nyquist back into `realp[0]`/`imagp[0]` (the inverse of the forward unpack), then unpacking to interleaved real samples.
- `inverse_real_fallback()` — complex `inverse()`, take the real part.
- Header-only, no new deps, no existing function changes.

**Normalization** follows the existing convention: `forward()`/`forward_real()` are unnormalized, `inverse()` applies `1/N` once — so `inverse_real(forward_real(x)) == x` with no caller-side scaling.

**Scaling derivation.** Web sources conflicted, so I measured it against real `vDSP_fft_zrip` (N=16, random real signal): the raw forward zrip output is 2× the true DFT (which is what `forward_real_vdsp`'s existing `0.5` corrects), and feeding the corrected spectrum into the raw inverse yields exactly `size × x` — so a plain `1/size_`, matching `inverse_vdsp()`'s complex case, not the `1/(2·size_)` some summaries suggest. The derivation and the empirical check are in the code comment.

**RT contract preserved.** The class comment promises allocation-free-after-construction, so the fallback's scratch is allocated once in the constructor (mirroring `twiddles_`) — and only where the fallback can actually be reached, so `FftT<float>` on Apple carries nothing. `inverse_real()` is wired into the existing allocation-free probe in `test_signal_rt_safety.cpp`.

## Tests

In `test_signal_spectral.cpp` (not `test_fft_backends.cpp` — `MultiBackendFft` only exposes the complex transforms, and the existing `forward_real` coverage lives in spectral):

- round-trip identity across sizes {64,128,256,1024,4096} × {impulse, DC, sine, multi-tone, seeded random}
- the same round-trip via `Fft64` to force the fallback branch (the `if constexpr` gate means `FftT<float>` always takes vDSP on Apple, so a float-only test can't observe the fallback at all)
- `inverse_real` vs the hand-composed `inverse()`+real-part, proving the vDSP branch matches the fallback's semantics — an independent oracle for the scale factor, since the vDSP path can't be turned off at runtime
- DC-only / Nyquist-only reconstruction and an alternating-signal round trip — that's where real-FFT packing bugs live
- move-constructed / move-assigned coverage, using `Fft64` deliberately: the scratch is only touched by the fallback, so a float move test would pass whether or not it's transferred

`pulp-test-signal-spectral` 31,839 assertions / 27 cases pass; `pulp-test-signal-rt-safety` passes; `pulp-test-fft-backends` unaffected.

Version bumped 0.668.0 → 0.669.0 per the public-header minor rule, in its own `chore: bump versions` commit.