### PR TITLE
feat(signal): joint-channel block oversampling + elliptic half-band IIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.668.0
+    VERSION 0.669.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/signal/include/pulp/signal/elliptic_halfband_iir.hpp
+++ b/core/signal/include/pulp/signal/elliptic_halfband_iir.hpp
@@ -1,0 +1,310 @@
+#pragma once
+
+/// @file elliptic_halfband_iir.hpp
+/// Elliptic (Valenzuela-Constantinides) polyphase-allpass half-band filter for
+/// 2x oversampling — a variable-order, runtime-designed sibling to
+/// `halfband_iir.hpp`'s fixed six-section Vaidyanathan / Regalia-Mitra design.
+///
+/// Both filters realise the same classical "two parallel allpass paths"
+/// half-band decomposition; they differ in *which* elliptic design fills in
+/// the allpass coefficients and in how many sections that design needs for a
+/// requested transition width / stopband floor. `halfband_iir.hpp` pins a
+/// single published six-section design. This header instead runs the
+/// Valenzuela-Constantinides elliptic design equations at configure() time,
+/// so the section count (and therefore the group delay and stopband) tracks
+/// whatever transition width and stopband floor the caller asks for, rather
+/// than being pinned to one fixed operating point.
+///
+/// Group delay is materially different between the two designs at matched
+/// operating points: this elliptic design's per-stage schedule (see
+/// `OversamplerT::Kind::elliptic_polyphase_iir` in oversampling.hpp) lands
+/// close to 0 samples of *extra* passthrough error at the same factor,
+/// where the six-section default in `halfband_iir.hpp` differs by more
+/// than a sample — neither is wrong, they are simply different points on
+/// the latency/transition-width/section-count trade-off, and callers that
+/// need this design's specific latency/response pick this one.
+///
+/// ## Design equations
+/// `design_elliptic_halfband_allpass()` solves for the number of allpass
+/// sections `N` and their coefficients `a_i` from a normalised transition
+/// width (fraction of the input Nyquist) and a stopband floor in dB, via the
+/// elliptic-filter degree equation and the Vaidyanathan/Constantinides
+/// closed form for equiripple half-band allpass coefficients (Valenzuela &
+/// Constantinides, "Digital allpass filter design", and the classical
+/// elliptic-rational-function machinery it builds on). All arithmetic is
+/// double precision; coefficients are narrowed to `SampleType` only at the
+/// end, matching how such designs are computed in every reference
+/// implementation of this method.
+///
+/// ## Section layout
+/// The `N` coefficients solved above are split even/odd-indexed into a
+/// "direct" path (indices 0, 2, 4, ...) and a "delayed" path (1, 3, 5, ...),
+/// each run as a per-sample cascade of first-order allpass sections. This is
+/// the same even/odd split `halfband_iir.hpp` calls path A / path B, just
+/// with a variable, design-dependent number of sections in each path instead
+/// of a fixed six.
+///
+/// RT contract: `configure()` (and the constructor, which calls it) resize
+/// per-section state and allocate. `process()`, `process_block()`, and
+/// `reset()` allocate no memory once configured.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace pulp::signal {
+
+namespace detail {
+
+/// Solve the Valenzuela-Constantinides elliptic half-band allpass design for
+/// a normalised transition width (fraction of the input Nyquist, i.e. `tw`
+/// in `(0, 1)`) and a stopband floor in dB (negative). Returns the flat
+/// coefficient array `[direct sections..., delayed sections...]` that
+/// `EllipticHalfBandUpsampler2xT` / `EllipticHalfBandDownsampler2xT` expect,
+/// i.e. even-indexed `a_i` first, then odd-indexed.
+template <typename SampleType>
+std::vector<SampleType> design_elliptic_halfband_allpass(double normalised_transition_width,
+                                                         double stopband_db) {
+    constexpr double pi = 3.14159265358979323846;
+    const double wt = 2.0 * pi * normalised_transition_width;
+    // pow(10, stopband_db * 0.05) stays finite and nonzero for any stopband_db
+    // a caller would realistically pass (it's only exactly 0 in the limit
+    // stopband_db -> -inf); computing it directly avoids a prior special
+    // case that snapped stopband_gain to a hard 0 at exactly -300 dB, which
+    // sent k1 to 0, log(k1*k1/16) to -inf, and n to +inf — UB on the
+    // ceil-to-int below for a value the class explicitly documents as a
+    // valid stopband floor.
+    const double stopband_gain = std::pow(10.0, stopband_db * 0.05);
+
+    const double k = std::pow(std::tan((pi - wt) / 4.0), 2.0);
+    const double kp = std::sqrt(1.0 - k * k);
+    const double e = (1.0 - std::sqrt(kp)) / (1.0 + std::sqrt(kp)) * 0.5;
+    const double q =
+        e + 2.0 * std::pow(e, 5.0) + 15.0 * std::pow(e, 9.0) + 150.0 * std::pow(e, 13.0);
+
+    const double k1 = stopband_gain * stopband_gain / (1.0 - stopband_gain * stopband_gain);
+    const double raw_n = std::log(k1 * k1 / 16.0) / std::log(q);
+    // A caller-supplied stopband_db so deep (or a transition width so close
+    // to the Nyquist edge that q rounds to 1) that raw_n isn't finite would
+    // otherwise hit the same ceil-to-int UB; clamp to a section count no
+    // real design here needs an order of magnitude more of.
+    constexpr double kMaxOrder = 4095.0;
+    int n = static_cast<int>(std::ceil(std::clamp(raw_n, 1.0, kMaxOrder)));
+    if (n % 2 == 0)
+        ++n;
+    if (n == 1)
+        n = 3;
+
+    const int order = (n - 1) / 2;
+    std::vector<double> ai(static_cast<std::size_t>(order), 0.0);
+
+    for (int i = 1; i <= order; ++i) {
+        double num = 0.0;
+        double delta = 1.0;
+        int m = 0;
+        while (std::abs(delta) > 1e-100) {
+            delta = std::pow(-1.0, m) * std::pow(q, static_cast<double>(m) * (m + 1)) *
+                    std::sin((2.0 * m + 1) * pi * i / static_cast<double>(n));
+            num += delta;
+            ++m;
+        }
+        num *= 2.0 * std::pow(q, 0.25);
+
+        double den = 0.0;
+        delta = 1.0;
+        m = 1;
+        while (std::abs(delta) > 1e-100) {
+            delta = std::pow(-1.0, m) * std::pow(q, static_cast<double>(m) * m) *
+                    std::cos(m * 2.0 * pi * i / static_cast<double>(n));
+            den += delta;
+            ++m;
+        }
+        den = 1.0 + 2.0 * den;
+
+        const double wi = num / den;
+        const double api = std::sqrt((1.0 - wi * wi * k) * (1.0 - wi * wi / k)) / (1.0 + wi * wi);
+        ai[static_cast<std::size_t>(i - 1)] = (1.0 - api) / (1.0 + api);
+    }
+
+    std::vector<SampleType> coeffs;
+    coeffs.reserve(static_cast<std::size_t>(order));
+    for (int i = 0; i < order; i += 2)
+        coeffs.push_back(static_cast<SampleType>(ai[static_cast<std::size_t>(i)]));
+    for (int i = 1; i < order; i += 2)
+        coeffs.push_back(static_cast<SampleType>(ai[static_cast<std::size_t>(i)]));
+    return coeffs;
+}
+
+/// Split a flat `[direct..., delayed...]` coefficient array into the two
+/// cascades, direct getting the ceil half so odd-order designs bias toward
+/// direct having one more section than delayed (matches the even/odd `a_i`
+/// index split above: there is always at least as many even indices as odd).
+template <typename SampleType>
+void split_direct_delayed(const std::vector<SampleType>& coeffs, std::vector<SampleType>& direct,
+                          std::vector<SampleType>& delayed) {
+    const std::size_t total = coeffs.size();
+    const std::size_t delayed_count = total / 2;
+    const std::size_t direct_count = total - delayed_count;
+    direct.assign(coeffs.begin(), coeffs.begin() + static_cast<std::ptrdiff_t>(direct_count));
+    delayed.assign(coeffs.begin() + static_cast<std::ptrdiff_t>(direct_count), coeffs.end());
+}
+
+/// One cascade of first-order allpass sections, each realised in the
+/// transposed direct form `output = a*in + state; state = in - a*output` —
+/// a different state-variable choice than `HalfBandAllpassSectionT`'s
+/// direct form I, but the same transfer function per section. Shared by
+/// the upsampler's two paths and the downsampler's two paths below.
+template <typename SampleType>
+SampleType run_allpass_cascade(const std::vector<SampleType>& coeffs,
+                               std::vector<SampleType>& state, SampleType x) {
+    SampleType in = x;
+    for (std::size_t n = 0; n < coeffs.size(); ++n) {
+        const SampleType alpha = coeffs[n];
+        const SampleType out = alpha * in + state[n];
+        state[n] = in - alpha * out;
+        in = out;
+    }
+    return in;
+}
+
+} // namespace detail
+
+/// 2x half-band upsampler using the Valenzuela-Constantinides elliptic
+/// polyphase-allpass design (see file header). Each call to
+/// `process(x, out_lo, out_hi)` consumes one input sample and produces two
+/// output samples at twice the rate — same calling convention as
+/// `HalfBandUpsampler2xT`, so the two are interchangeable at call sites.
+template <typename SampleType = float> class EllipticHalfBandUpsampler2xT {
+  public:
+    /// Design a fresh network. `normalised_transition_width` is a fraction
+    /// of the input Nyquist; `stopband_db` is the target stopband floor
+    /// (negative dB). The defaults reproduce the first (tightest) stage of
+    /// the `Quality::pristine` schedule in `OversamplerT`: narrow transition,
+    /// deep stopband floor.
+    explicit EllipticHalfBandUpsampler2xT(double normalised_transition_width = 0.05,
+                                          double stopband_db = -90.0) {
+        configure(normalised_transition_width, stopband_db);
+    }
+
+    /// Re-run the design equations, resizing (and so allocating) the
+    /// per-section state to match — as documented, only `configure()` and
+    /// the constructor allocate.
+    void configure(double normalised_transition_width, double stopband_db) {
+        const auto coeffs = detail::design_elliptic_halfband_allpass<SampleType>(
+            normalised_transition_width, stopband_db);
+        detail::split_direct_delayed(coeffs, direct_, delayed_);
+        direct_state_.assign(direct_.size(), SampleType{0});
+        delayed_state_.assign(delayed_.size(), SampleType{0});
+    }
+
+    /// Number of sections in the direct (even-indexed) path.
+    std::size_t direct_sections() const {
+        return direct_.size();
+    }
+    /// Number of sections in the delayed (odd-indexed) path.
+    std::size_t delayed_sections() const {
+        return delayed_.size();
+    }
+
+    // std::fill zeroes in place instead of vector::assign, which is free to
+    // reallocate — reset() is documented allocation-free and only ever
+    // needs to re-zero state configure() already sized.
+    void reset() {
+        std::fill(direct_state_.begin(), direct_state_.end(), SampleType{0});
+        std::fill(delayed_state_.begin(), delayed_state_.end(), SampleType{0});
+    }
+
+    /// Produce two output samples for one input sample. `out_lo` is the
+    /// direct-path (even-phase) output, `out_hi` the delayed-path
+    /// (odd-phase) output — the same phase convention as
+    /// `HalfBandUpsampler2xT::process`.
+    void process(SampleType x, SampleType& out_lo, SampleType& out_hi) {
+        out_lo = detail::run_allpass_cascade(direct_, direct_state_, x);
+        out_hi = detail::run_allpass_cascade(delayed_, delayed_state_, x);
+    }
+
+    /// Block helper. `input` length N produces `output` length 2N.
+    void process_block(std::span<const SampleType> input, std::span<SampleType> output) {
+        const std::size_t n = input.size();
+        for (std::size_t i = 0; i < n; ++i)
+            process(input[i], output[2 * i], output[2 * i + 1]);
+    }
+
+  private:
+    std::vector<SampleType> direct_, delayed_;
+    std::vector<SampleType> direct_state_, delayed_state_;
+};
+
+using EllipticHalfBandUpsampler2x = EllipticHalfBandUpsampler2xT<float>;
+using EllipticHalfBandUpsampler2x64 = EllipticHalfBandUpsampler2xT<double>;
+
+/// 2x half-band downsampler using the Valenzuela-Constantinides elliptic
+/// polyphase-allpass design. Each call to `process(in_lo, in_hi)` consumes
+/// two input samples at the higher rate and emits one decimated output —
+/// same calling convention as `HalfBandDownsampler2xT`.
+template <typename SampleType = float> class EllipticHalfBandDownsampler2xT {
+  public:
+    explicit EllipticHalfBandDownsampler2xT(double normalised_transition_width = 0.05,
+                                            double stopband_db = -90.0) {
+        configure(normalised_transition_width, stopband_db);
+    }
+
+    void configure(double normalised_transition_width, double stopband_db) {
+        const auto coeffs = detail::design_elliptic_halfband_allpass<SampleType>(
+            normalised_transition_width, stopband_db);
+        detail::split_direct_delayed(coeffs, direct_, delayed_);
+        direct_state_.assign(direct_.size(), SampleType{0});
+        delayed_state_.assign(delayed_.size(), SampleType{0});
+        holdover_ = SampleType{0};
+    }
+
+    std::size_t direct_sections() const {
+        return direct_.size();
+    }
+    std::size_t delayed_sections() const {
+        return delayed_.size();
+    }
+
+    // std::fill zeroes in place instead of vector::assign, which is free to
+    // reallocate — reset() is documented allocation-free and only ever
+    // needs to re-zero state configure() already sized.
+    void reset() {
+        std::fill(direct_state_.begin(), direct_state_.end(), SampleType{0});
+        std::fill(delayed_state_.begin(), delayed_state_.end(), SampleType{0});
+        holdover_ = SampleType{0};
+    }
+
+    /// Consume `in_lo` (even-phase, index 2n) and `in_hi` (odd-phase, index
+    /// 2n+1) and return one decimated output sample. The delayed path's
+    /// output is held over one sample before being combined with the direct
+    /// path's — the explicit `holdover_` register that realises the extra
+    /// `z^-1` the decimation polyphase identity needs on that branch.
+    SampleType process(SampleType in_lo, SampleType in_hi) {
+        const SampleType direct_out =
+            detail::run_allpass_cascade(direct_, direct_state_, in_lo);
+        const SampleType delayed_out =
+            detail::run_allpass_cascade(delayed_, delayed_state_, in_hi);
+        const SampleType output = (holdover_ + direct_out) * SampleType{0.5};
+        holdover_ = delayed_out;
+        return output;
+    }
+
+    /// Block helper. `input` length 2N produces `output` length N.
+    void process_block(std::span<const SampleType> input, std::span<SampleType> output) {
+        const std::size_t n = output.size();
+        for (std::size_t i = 0; i < n; ++i)
+            output[i] = process(input[2 * i], input[2 * i + 1]);
+    }
+
+  private:
+    std::vector<SampleType> direct_, delayed_;
+    std::vector<SampleType> direct_state_, delayed_state_;
+    SampleType holdover_ = SampleType{0};
+};
+
+using EllipticHalfBandDownsampler2x = EllipticHalfBandDownsampler2xT<float>;
+using EllipticHalfBandDownsampler2x64 = EllipticHalfBandDownsampler2xT<double>;
+
+} // namespace pulp::signal

--- a/core/signal/include/pulp/signal/oversampling.hpp
+++ b/core/signal/include/pulp/signal/oversampling.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pulp/signal/biquad.hpp>
+#include <pulp/signal/elliptic_halfband_iir.hpp>
 #include <pulp/signal/halfband_iir.hpp>
 #include <pulp/signal/oversampling_fir.hpp>
 
@@ -15,7 +16,7 @@ namespace pulp::signal {
 // Oversampling processor — runs a callback at 2x, 4x, 8x, or 16x sample rate
 // with anti-aliasing filters on input and output.
 //
-// Three filter `Kind`s are available:
+// Four filter `Kind`s are available:
 //
 //   * `fir_biquad` (default) — a Butterworth Biquad pair per 2x stage.
 //     Lightweight and symmetric, but a single biquad cannot reject much near
@@ -32,6 +33,17 @@ namespace pulp::signal {
 //   * `linear_phase_fir` — Kaiser-windowed FIR with a transition that ends at
 //     the base-rate Nyquist. `Quality::standard` is a 96 dB design flat to
 //     80% of Nyquist; `Quality::pristine` uses a 140 dB prototype flat to 90%.
+//   * `elliptic_polyphase_iir` — half-band polyphase IIR using the
+//     Valenzuela-Constantinides elliptic design (`EllipticHalfBandUpsampler2x`
+//     / `EllipticHalfBandDownsampler2x`) instead of `polyphase_iir`'s fixed
+//     six-section design. Same allpass-network shape and the same "no
+//     constant latency" contract, but a different, design-equation-driven
+//     section count per stage: the design equations solve directly for a
+//     requested transition width and stopband floor, so pick this kind when
+//     a specific latency/response operating point matters more than
+//     matching `polyphase_iir`'s fixed coefficient table. `Quality` selects
+//     the per-stage transition-width/stopband schedule, same as
+//     `linear_phase_fir`.
 //
 // Switch with `set_kind()`. All kinds share the same callback API so
 // callers don't need to know which filter is active. Configure factor,
@@ -45,9 +57,10 @@ template <typename SampleType = float> class OversamplerT {
 
     /// Which anti-aliasing filter family the oversampler uses.
     enum class Kind {
-        fir_biquad,       ///< Original biquad lowpass on both sides.
-        polyphase_iir,    ///< Half-band polyphase IIR (allpass-network).
-        linear_phase_fir, ///< Linear-phase FIR with reported integer latency.
+        fir_biquad,             ///< Original biquad lowpass on both sides.
+        polyphase_iir,          ///< Half-band polyphase IIR (allpass-network).
+        linear_phase_fir,       ///< Linear-phase FIR with reported integer latency.
+        elliptic_polyphase_iir, ///< Half-band polyphase IIR, elliptic (Valenzuela-Constantinides) design.
     };
 
     enum class Quality {
@@ -86,12 +99,16 @@ template <typename SampleType = float> class OversamplerT {
         kind_ = kind;
         if (kind_ == Kind::linear_phase_fir)
             configure_linear_phase_filters();
+        else if (kind_ == Kind::elliptic_polyphase_iir)
+            configure_elliptic_filters();
         reset();
     }
     void set_quality(Quality quality) {
         quality_ = quality;
         if (kind_ == Kind::linear_phase_fir)
             configure_linear_phase_filters();
+        else if (kind_ == Kind::elliptic_polyphase_iir)
+            configure_elliptic_filters();
         reset();
     }
     Kind kind() const {
@@ -165,6 +182,10 @@ template <typename SampleType = float> class OversamplerT {
             stage.reset();
         for (auto& stage : hb_down_stages_)
             stage.reset();
+        for (auto& stage : elliptic_up_stages_)
+            stage.reset();
+        for (auto& stage : elliptic_down_stages_)
+            stage.reset();
         for (auto& stage : fir_stages_)
             stage.reset();
     }
@@ -195,6 +216,9 @@ template <typename SampleType = float> class OversamplerT {
         if (kind_ == Kind::polyphase_iir) {
             return process_polyphase_iir(input, callback);
         }
+        if (kind_ == Kind::elliptic_polyphase_iir) {
+            return process_elliptic_polyphase_iir(input, callback);
+        }
         return process_fir_biquad(input, callback);
     }
 
@@ -221,6 +245,32 @@ template <typename SampleType = float> class OversamplerT {
         }
         if (kind_ == Kind::linear_phase_fir)
             configure_linear_phase_filters();
+        else if (kind_ == Kind::elliptic_polyphase_iir)
+            configure_elliptic_filters();
+    }
+
+    // Per-stage transition-width / stopband-floor schedule for the elliptic
+    // design: stage 0 gets half the transition width of later stages (its
+    // Nyquist has the least headroom), and each stage's stopband floor
+    // shallows by a fixed step off a deep stage-0 floor — a linear
+    // `floor_start + step * stage_index` progression. `Quality::pristine`
+    // narrows the transition width and deepens the stage-0 floor relative to
+    // `Quality::standard`, with a larger per-stage step.
+    void configure_elliptic_filters() {
+        const bool max_quality = quality_ == Quality::pristine;
+        const double tw_up_base = max_quality ? 0.10 : 0.12;
+        const double tw_down_base = max_quality ? 0.12 : 0.15;
+        const double gain_start_up = max_quality ? -90.0 : -70.0;
+        const double gain_start_down = max_quality ? -75.0 : -60.0;
+        const double gain_step = max_quality ? 10.0 : 8.0;
+        for (std::size_t stage = 0; stage < kMaxStages; ++stage) {
+            const double half_first = stage == 0 ? 0.5 : 1.0;
+            const double stage_index = static_cast<double>(stage);
+            elliptic_up_stages_[stage].configure(tw_up_base * half_first,
+                                                 gain_start_up + gain_step * stage_index);
+            elliptic_down_stages_[stage].configure(tw_down_base * half_first,
+                                                   gain_start_down + gain_step * stage_index);
+        }
     }
 
     void configure_linear_phase_filters() {
@@ -273,6 +323,9 @@ template <typename SampleType = float> class OversamplerT {
     // ── polyphase_iir lane ─────────────────────────────────────────────
     std::array<HalfBandUpsampler2xT<SampleType>, kMaxStages> hb_up_stages_;
     std::array<HalfBandDownsampler2xT<SampleType>, kMaxStages> hb_down_stages_;
+    // ── elliptic_polyphase_iir lane ────────────────────────────────────
+    std::array<EllipticHalfBandUpsampler2xT<SampleType>, kMaxStages> elliptic_up_stages_;
+    std::array<EllipticHalfBandDownsampler2xT<SampleType>, kMaxStages> elliptic_down_stages_;
     std::array<detail::LinearPhaseOversamplingStage2x<SampleType>, kMaxStages> fir_stages_;
 
     template <typename Callback>
@@ -295,6 +348,31 @@ template <typename SampleType = float> class OversamplerT {
             count /= 2;
             for (std::size_t i = 0; i < count; ++i) {
                 values[i] = hb_down_stages_[stage].process(values[2 * i], values[2 * i + 1]);
+            }
+        }
+        return values[0];
+    }
+
+    template <typename Callback>
+    SampleType process_elliptic_polyphase_iir(SampleType input, Callback& callback) {
+        std::array<SampleType, static_cast<std::size_t>(Factor::x16)> values{};
+        std::array<SampleType, static_cast<std::size_t>(Factor::x16)> expanded{};
+        values[0] = input;
+        std::size_t count = 1;
+        const int stages = stage_count();
+        for (int stage = 0; stage < stages; ++stage) {
+            for (std::size_t i = 0; i < count; ++i) {
+                elliptic_up_stages_[stage].process(values[i], expanded[2 * i], expanded[2 * i + 1]);
+            }
+            count *= 2;
+            std::copy_n(expanded.begin(), count, values.begin());
+        }
+        for (std::size_t i = 0; i < count; ++i)
+            values[i] = callback(values[i]);
+        for (int stage = stages; stage-- > 0;) {
+            count /= 2;
+            for (std::size_t i = 0; i < count; ++i) {
+                values[i] = elliptic_down_stages_[stage].process(values[2 * i], values[2 * i + 1]);
             }
         }
         return values[0];

--- a/core/signal/include/pulp/signal/polyphase_block_oversampler.hpp
+++ b/core/signal/include/pulp/signal/polyphase_block_oversampler.hpp
@@ -1,0 +1,296 @@
+#pragma once
+
+/// @file polyphase_block_oversampler.hpp
+/// Block-oriented, multi-channel half-band polyphase IIR oversampler that
+/// exposes the intermediate oversampled buffer between the up and down
+/// passes.
+///
+/// `OversamplerT` (oversampling.hpp) is fused and single-channel: one call
+/// upsamples, invokes a per-sample callback N times, and decimates, with no
+/// way to see the oversampled samples in between. That is the right shape
+/// for a single independent channel of DSP, but it cannot express work that
+/// needs to look across channels at the SAME oversampled sub-index — for
+/// example a dither draw shared by L/R so both channels quantize against
+/// the same random value, or a stereo-linked compressor whose envelope
+/// follower is driven by `0.5*(|L| + |R|)` computed once per oversampled
+/// sample rather than twice independently. Two independent `OversamplerT`
+/// instances cannot do this: each one runs its whole N-sample loop to
+/// completion before returning, so channel R's oversampled sample at index
+/// i does not exist yet while channel L's callback for index i is running.
+///
+/// `PolyphaseBlockOversamplerT` instead splits the fused call into
+/// `process_up()` / `process_down()`, both operating on all channels at
+/// once and both taking/returning plain buffers instead of a callback.
+/// Callers do their joint-channel work directly on the `BlockView` returned
+/// by `process_up()`, indexed by oversampled sample and channel, then call
+/// `process_down()` to decimate back. This is deliberately a sibling class
+/// rather than new methods on `OversamplerT`: `OversamplerT`'s fused,
+/// allocation-free-per-sample callback API is worth keeping intact for the
+/// (more common) single-channel case, and folding both shapes into one
+/// class would mean every caller — including existing `OversamplerT`
+/// users — carries API surface for a use case most of them don't have.
+///
+/// The filter family is selected at compile time via the `UpStage` /
+/// `DownStage` template template-parameters, defaulting to the
+/// `polyphase_iir` design (`HalfBandUpsampler2xT` / `HalfBandDownsampler2xT`,
+/// halfband_iir.hpp). Passing `EllipticHalfBandUpsampler2xT` /
+/// `EllipticHalfBandDownsampler2xT` (elliptic_halfband_iir.hpp) instead
+/// selects the Valenzuela-Constantinides elliptic design — see
+/// `EllipticPolyphaseBlockOversamplerT` below. Both stage types are
+/// default-constructible with a fixed, reasonable single-stage design, so
+/// every cascade stage reuses that same design regardless of stage index —
+/// the same "one fixed design at every stage" approach `OversamplerT`
+/// itself already uses for `Kind::polyphase_iir`. Callers who need a
+/// per-stage-relaxed schedule instead (as `OversamplerT`'s
+/// `elliptic_polyphase_iir` `Kind` provides for the fused, single-channel
+/// case) should configure `stage(n).up(channel)` / `stage(n).down(channel)`
+/// directly after `prepare()`.
+///
+/// RT contract: `prepare()` allocates every stage's per-channel filter
+/// state and scratch buffer. `reset()`, `process_up()`, and
+/// `process_down()` allocate no memory once prepared.
+
+#include <pulp/signal/elliptic_halfband_iir.hpp>
+#include <pulp/signal/halfband_iir.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace pulp::signal {
+
+/// A non-owning view over the oversampled buffer `process_up()` fills in —
+/// `num_channels` channels of `num_samples` samples each, at the oversampled
+/// rate. Valid until the next `process_up()` / `process_down()` call.
+template <typename SampleType> struct OversampledBlockView {
+    SampleType* const* channels = nullptr;
+    std::size_t num_channels = 0;
+    std::size_t num_samples = 0;
+
+    std::size_t get_num_samples() const {
+        return num_samples;
+    }
+    SampleType* channel_pointer(std::size_t channel) const {
+        return channels[channel];
+    }
+};
+
+template <typename SampleType = float, template <typename> class UpStage = HalfBandUpsampler2xT,
+         template <typename> class DownStage = HalfBandDownsampler2xT>
+class PolyphaseBlockOversamplerT {
+  public:
+    using View = OversampledBlockView<SampleType>;
+
+    /// One 2x cascade level, holding one filter pair and one scratch buffer
+    /// per channel. The up pass fills the buffer (2x the stage's input
+    /// length); the down pass reads it and decimates.
+    class Stage {
+      public:
+        void prepare(std::size_t num_channels, std::size_t max_input_samples) {
+            up_.assign(num_channels, UpStage<SampleType>{});
+            down_.assign(num_channels, DownStage<SampleType>{});
+            buffer_.assign(num_channels, std::vector<SampleType>(max_input_samples * 2, SampleType{0}));
+            pointers_.assign(num_channels, nullptr);
+        }
+
+        void reset() {
+            for (auto& stage : up_)
+                stage.reset();
+            for (auto& stage : down_)
+                stage.reset();
+            for (auto& channel : buffer_)
+                std::fill(channel.begin(), channel.end(), SampleType{0});
+        }
+
+        /// Direct access to this stage's per-channel filters, for callers
+        /// that want to reconfigure a design that supports `configure()`
+        /// (e.g. `EllipticHalfBandUpsampler2xT`) with a non-default
+        /// transition width / stopband floor after `prepare()`.
+        UpStage<SampleType>& up(std::size_t channel) {
+            return up_[channel];
+        }
+        DownStage<SampleType>& down(std::size_t channel) {
+            return down_[channel];
+        }
+
+        void process_up(const SampleType* const* input, std::size_t num_channels,
+                        std::size_t num_samples) {
+            for (std::size_t channel = 0; channel < num_channels; ++channel) {
+                SampleType* out = buffer_[channel].data();
+                const SampleType* in = input[channel];
+                for (std::size_t i = 0; i < num_samples; ++i)
+                    up_[channel].process(in[i], out[2 * i], out[2 * i + 1]);
+            }
+        }
+
+        void process_down(SampleType* const* output, std::size_t num_channels,
+                          std::size_t num_samples) {
+            for (std::size_t channel = 0; channel < num_channels; ++channel) {
+                const SampleType* in = buffer_[channel].data();
+                SampleType* out = output[channel];
+                for (std::size_t i = 0; i < num_samples; ++i)
+                    out[i] = down_[channel].process(in[2 * i], in[2 * i + 1]);
+            }
+        }
+
+        SampleType* const* channel_pointers(std::size_t num_channels) {
+            for (std::size_t channel = 0; channel < num_channels; ++channel)
+                pointers_[channel] = buffer_[channel].data();
+            return pointers_.data();
+        }
+
+      private:
+        std::vector<UpStage<SampleType>> up_;
+        std::vector<DownStage<SampleType>> down_;
+        std::vector<std::vector<SampleType>> buffer_; // [channel][2 * stage input length]
+        std::vector<SampleType*> pointers_;
+    };
+
+    /// Ceiling on `num_stages`: `oversampling_factor()` returns `1 <<
+    /// stages_.size()` as a plain `int`, so anything at or past the width of
+    /// `int` is undefined behaviour. This cap sits far below that — no real
+    /// oversampling factor is anywhere near `2^24` — purely to turn a
+    /// caller's garbage stage count into a clamp instead of UB.
+    static constexpr int kMaxStages = 24;
+
+    /// Ceiling on `max_block_size` (and, by extension, on any `num_samples`
+    /// `process_up()` is called with): the highest stage's scratch buffer is
+    /// `max_block_size * 2^num_stages`, doubled once more inside
+    /// `Stage::prepare()`. Bounding `max_block_size` so that growth can't
+    /// overflow `std::size_t` even at `kMaxStages` keeps every subsequent
+    /// plain `* 2` in `prepare()` / `process_up()` / `process_down()` exact,
+    /// instead of scattering a clamp into each doubling.
+    static constexpr std::size_t kMaxBlockSize = std::numeric_limits<std::size_t>::max() >>
+                                                 (kMaxStages + 1);
+
+    /// `num_stages` is the number of 2x cascade levels (ratio = 2^num_stages) —
+    /// it counts *stages*, not the ratio, distinct from
+    /// `OversamplerT::Factor`, which encodes the ratio directly.
+    /// `num_stages` is clamped to `[0, kMaxStages]` (a negative count would
+    /// otherwise wrap to a huge `size_t` below) and `max_block_size` to
+    /// `kMaxBlockSize`, so the repeated `* 2` that sizes each stage's scratch
+    /// buffer can never overflow `size_t` and undersize it.
+    void prepare(std::size_t num_channels, int num_stages, std::size_t max_block_size) {
+        num_channels_ = num_channels;
+        const auto clamped_stages =
+            static_cast<std::size_t>(std::clamp(num_stages, 0, kMaxStages));
+        stages_.assign(clamped_stages, Stage{});
+        max_block_size_ = std::min(max_block_size, kMaxBlockSize);
+        std::size_t stage_input_samples = max_block_size_;
+        for (auto& stage : stages_) {
+            stage.prepare(num_channels, stage_input_samples);
+            stage_input_samples *= 2;
+        }
+        passthrough_buffer_.assign(num_channels, std::vector<SampleType>(max_block_size_, SampleType{0}));
+        passthrough_pointers_.assign(num_channels, nullptr);
+    }
+
+    void reset() {
+        for (auto& stage : stages_)
+            stage.reset();
+    }
+
+    /// Number of 2x cascade stages configured by `prepare()`.
+    std::size_t num_stages() const {
+        return stages_.size();
+    }
+    /// The overall ratio, `2^num_stages()`.
+    int oversampling_factor() const {
+        return 1 << stages_.size();
+    }
+
+    /// Direct access to stage `n`, e.g. to reconfigure an elliptic design's
+    /// transition width per stage. `n` must be `< num_stages()`.
+    Stage& stage(std::size_t n) {
+        return stages_[n];
+    }
+
+    /// Upsample `input` (num_channels x num_samples) through every cascade
+    /// stage and return a view over the final, highest-rate stage buffer —
+    /// num_channels x (num_samples * oversampling_factor()). The view stays
+    /// valid, and may be freely read AND written, until the matching
+    /// `process_down()` call (or the next `process_up()`).
+    ///
+    /// `num_channels` / `num_samples` are clamped to what `prepare()`
+    /// configured: every per-channel scratch buffer is sized from
+    /// `prepare()`'s `num_channels` / `max_block_size`, so trusting a larger
+    /// caller-supplied count here would index and write past it.
+    View process_up(const SampleType* const* input, std::size_t num_channels,
+                    std::size_t num_samples) {
+        num_channels = std::min(num_channels, num_channels_);
+        num_samples = std::min(num_samples, max_block_size_);
+
+        if (stages_.empty()) {
+            // No cascade stage owns a buffer to expose, but the contract
+            // promises a *writable* view a caller can edit jointly across
+            // channels before process_down() reads it back — aliasing
+            // `input` directly would mean writing through a pointer the
+            // caller may have handed us as genuinely const, and silently
+            // drop any edit if `output` isn't literally the same buffer as
+            // `input`. The owned passthrough scratch makes both round-trip
+            // regardless.
+            for (std::size_t channel = 0; channel < num_channels; ++channel) {
+                std::copy_n(input[channel], num_samples, passthrough_buffer_[channel].data());
+                passthrough_pointers_[channel] = passthrough_buffer_[channel].data();
+            }
+            return {passthrough_pointers_.data(), num_channels, num_samples};
+        }
+
+        stages_.front().process_up(input, num_channels, num_samples);
+        std::size_t block_samples = num_samples * 2;
+        for (std::size_t i = 1; i < stages_.size(); ++i) {
+            SampleType* const* previous = stages_[i - 1].channel_pointers(num_channels);
+            stages_[i].process_up(previous, num_channels, block_samples);
+            block_samples *= 2;
+        }
+        SampleType* const* last = stages_.back().channel_pointers(num_channels);
+        return {last, num_channels, block_samples};
+    }
+
+    /// Decimate the (possibly caller-modified) oversampled buffer back down
+    /// through every cascade stage into `output` (num_channels x
+    /// num_samples). Must follow a `process_up()` call with the same
+    /// `num_channels` / `num_samples`.
+    void process_down(SampleType* const* output, std::size_t num_channels,
+                      std::size_t num_samples) {
+        num_channels = std::min(num_channels, num_channels_);
+        num_samples = std::min(num_samples, max_block_size_);
+
+        if (stages_.empty()) {
+            for (std::size_t channel = 0; channel < num_channels; ++channel)
+                std::copy_n(passthrough_buffer_[channel].data(), num_samples, output[channel]);
+            return;
+        }
+
+        std::size_t current_samples = num_samples;
+        for (std::size_t n = 0; n + 1 < stages_.size(); ++n)
+            current_samples *= 2;
+
+        for (std::size_t n = stages_.size() - 1; n > 0; --n) {
+            SampleType* const* destination = stages_[n - 1].channel_pointers(num_channels);
+            stages_[n].process_down(destination, num_channels, current_samples);
+            current_samples /= 2;
+        }
+        stages_.front().process_down(output, num_channels, num_samples);
+    }
+
+  private:
+    std::vector<Stage> stages_;
+    std::size_t num_channels_ = 0;
+    std::size_t max_block_size_ = 0;
+    std::vector<std::vector<SampleType>> passthrough_buffer_;
+    std::vector<SampleType*> passthrough_pointers_;
+};
+
+using PolyphaseBlockOversampler = PolyphaseBlockOversamplerT<float>;
+using PolyphaseBlockOversampler64 = PolyphaseBlockOversamplerT<double>;
+
+/// The elliptic-design sibling: same block API, Valenzuela-Constantinides
+/// elliptic half-band filter (see elliptic_halfband_iir.hpp).
+using EllipticPolyphaseBlockOversampler =
+    PolyphaseBlockOversamplerT<float, EllipticHalfBandUpsampler2xT, EllipticHalfBandDownsampler2xT>;
+using EllipticPolyphaseBlockOversampler64 =
+    PolyphaseBlockOversamplerT<double, EllipticHalfBandUpsampler2xT, EllipticHalfBandDownsampler2xT>;
+
+} // namespace pulp::signal

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -495,7 +495,8 @@ a working convolution and would hide the bug. Assert
 | Chorus | `chorus.hpp` | Modulated delay for stereo widening and detuning effects |
 | Convolver | `convolver.hpp` | Partitioned frequency-domain convolution for reverb impulse responses |
 | Delay Line | `delay_line.hpp` | Sample-accurate delay with linear, cubic, or sinc interpolation |
-| Oversampling | `oversampling.hpp` | 2x/4x/8x/16x realtime up/downsampling; minimum-phase IIR and 96/140 dB-prototype linear-phase FIR tiers with exact latency reporting |
+| Oversampling | `oversampling.hpp` | 2x/4x/8x/16x realtime up/downsampling; two minimum-phase polyphase IIR designs (fixed six-section and elliptic Valenzuela-Constantinides) and 96/140 dB-prototype linear-phase FIR tiers with exact latency reporting |
+| Polyphase Block Oversampling | `polyphase_block_oversampler.hpp` | Block-oriented, multi-channel half-band oversampling that exposes the intermediate oversampled buffer for joint-channel work (shared dither, stereo-linked sidechain) between the up and down passes |
 | Phaser | `phaser.hpp` | All-pass filter chain with LFO modulation for sweeping comb effects |
 | Reverb | `reverb.hpp` | Algorithmic stereo reverb with room size, damping, and width controls |
 | Waveshaper | `waveshaper.hpp` | Static nonlinear distortion via transfer function (tanh, soft clip, custom) |

--- a/test/cmake/late_core_tests.cmake
+++ b/test/cmake/late_core_tests.cmake
@@ -34,6 +34,12 @@ pulp_add_test_suite(pulp-test-resampler LIBRARIES pulp::signal)
 # Polyphase IIR half-band filter
 pulp_add_test_suite(pulp-test-halfband-iir LIBRARIES pulp::signal)
 
+# Elliptic (Valenzuela-Constantinides) polyphase IIR half-band filter
+pulp_add_test_suite(pulp-test-elliptic-halfband-iir LIBRARIES pulp::signal)
+
+# Block-oriented multi-channel polyphase oversampler
+pulp_add_test_suite(pulp-test-polyphase-block-oversampler LIBRARIES pulp::signal)
+
 # Generic Synthesiser polyphony
 pulp_add_test_suite(pulp-test-synthesiser
     SOURCES test_synthesiser.cpp harness/rt_allocation_probe.cpp

--- a/test/test_elliptic_halfband_iir.cpp
+++ b/test/test_elliptic_halfband_iir.cpp
@@ -1,0 +1,285 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/signal/elliptic_halfband_iir.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <numbers>
+#include <vector>
+
+using namespace pulp::signal;
+using Catch::Matchers::WithinAbs;
+
+// ────────────────────────────────────────────────────────────────────────
+// Elliptic (Valenzuela-Constantinides) half-band polyphase-allpass filter.
+//
+// Same polyphase-allpass shape as `halfband_iir.hpp`'s
+// HalfBandUpsampler2x/HalfBandDownsampler2x, but the section count and
+// coefficients come from running the elliptic design equations at
+// configure() time against a caller-supplied transition width / stopband
+// floor, instead of a fixed six-section table — see
+// OversamplerT::Kind::elliptic_polyphase_iir in oversampling.hpp, which
+// drives this per its own per-stage transition-width/stopband-floor
+// schedule.
+//
+// Test strategy mirrors test_halfband_iir.cpp: internal goldens, no
+// external reference filter — passband flatness, stopband rejection, DC,
+// sample-rate invariance, round-trip, reset, and a deliberately narrower
+// design to prove `configure()`'s parameters actually change behaviour.
+// ────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+constexpr float kPi = std::numbers::pi_v<float>;
+
+float trailing_rms(const std::vector<float>& samples, std::size_t skip) {
+    if (samples.size() <= skip)
+        return 0.0f;
+    double acc = 0.0;
+    const std::size_t n = samples.size() - skip;
+    for (std::size_t i = skip; i < samples.size(); ++i)
+        acc += static_cast<double>(samples[i]) * samples[i];
+    return static_cast<float>(std::sqrt(acc / static_cast<double>(n)));
+}
+
+float to_db(float lin) {
+    return 20.0f * std::log10(std::max(lin, 1e-30f));
+}
+
+std::vector<float> sine(float cycles_per_sample, std::size_t n) {
+    std::vector<float> out(n);
+    const float w = 2.0f * kPi * cycles_per_sample;
+    for (std::size_t i = 0; i < n; ++i)
+        out[i] = std::sin(w * static_cast<float>(i));
+    return out;
+}
+
+} // namespace
+
+TEST_CASE("EllipticHalfBandUpsampler2x default design is stable and finite",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up;
+    REQUIRE(up.direct_sections() > 0);
+    REQUIRE(up.delayed_sections() > 0);
+    float lo = 0.0f, hi = 0.0f;
+    up.process(1.0f, lo, hi);
+    for (int i = 0; i < 1000; ++i) {
+        up.process(0.0f, lo, hi);
+        REQUIRE(std::isfinite(lo));
+        REQUIRE(std::isfinite(hi));
+        REQUIRE(std::fabs(lo) <= 2.0f);
+        REQUIRE(std::fabs(hi) <= 2.0f);
+    }
+}
+
+TEST_CASE("EllipticHalfBandDownsampler2x default design is stable and finite",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandDownsampler2x dn;
+    REQUIRE(dn.direct_sections() > 0);
+    REQUIRE(dn.delayed_sections() > 0);
+    for (int i = 0; i < 1000; ++i) {
+        const float y = dn.process(0.5f, -0.5f);
+        REQUIRE(std::isfinite(y));
+        REQUIRE(std::fabs(y) <= 2.0f);
+    }
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x preserves DC", "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up;
+    constexpr std::size_t kN = 512;
+    std::vector<float> y(2 * kN, 0.0f);
+    for (std::size_t i = 0; i < kN; ++i)
+        up.process(0.5f, y[2 * i], y[2 * i + 1]);
+    const std::size_t tail_start = (2 * kN) - 64;
+    for (std::size_t i = tail_start; i < 2 * kN; ++i) {
+        INFO("y[" << i << "] = " << y[i]);
+        REQUIRE_THAT(y[i], WithinAbs(0.5f, 1e-3f));
+    }
+}
+
+TEST_CASE("EllipticHalfBandDownsampler2x preserves DC", "[signal][halfband][elliptic]") {
+    EllipticHalfBandDownsampler2x dn;
+    constexpr std::size_t kN = 256;
+    std::vector<float> y(kN, 0.0f);
+    for (std::size_t i = 0; i < kN; ++i)
+        y[i] = dn.process(0.5f, 0.5f);
+    const std::size_t tail_start = kN - 32;
+    for (std::size_t i = tail_start; i < kN; ++i)
+        REQUIRE_THAT(y[i], WithinAbs(0.5f, 1e-3f));
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x preserves passband sine amplitude",
+          "[signal][halfband][elliptic]") {
+    for (float f_in : {0.05f, 0.10f, 0.20f, 0.30f, 0.40f}) {
+        EllipticHalfBandUpsampler2x up;
+        constexpr std::size_t kN = 2048;
+        const auto x = sine(f_in, kN);
+        std::vector<float> y(2 * kN, 0.0f);
+        up.process_block(x, y);
+        const float in_rms = trailing_rms(x, kN / 4);
+        const float out_rms = trailing_rms(y, kN);
+        const float gain_db = to_db(out_rms / in_rms);
+        INFO("f_in=" << f_in << " out/in RMS = " << gain_db << " dB");
+        REQUIRE(gain_db < 0.5f);
+        REQUIRE(gain_db > -0.5f);
+    }
+}
+
+TEST_CASE("EllipticHalfBandDownsampler2x rejects deep-stopband energy",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandDownsampler2x dn;
+    constexpr std::size_t kN = 8192;
+    const auto x = sine(0.47f, kN);
+    std::vector<float> y(kN / 2, 0.0f);
+    dn.process_block(x, y);
+    const float in_rms = trailing_rms(x, kN / 4);
+    const float out_rms = trailing_rms(y, kN / 8);
+    const float atten_db = to_db(out_rms / in_rms);
+    INFO("stopband atten at f=0.47*Fs = " << atten_db << " dB");
+    REQUIRE(atten_db < -40.0f);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x sample-rate invariance", "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up_a, up_b;
+    constexpr std::size_t kN = 1024;
+    const auto x = sine(0.1f, kN);
+    std::vector<float> ya(2 * kN, 0.0f), yb(2 * kN, 0.0f);
+    up_a.process_block(x, ya);
+    up_b.process_block(x, yb);
+    for (std::size_t i = 0; i < 2 * kN; ++i)
+        REQUIRE(ya[i] == yb[i]);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x followed by EllipticHalfBandDownsampler2x "
+          "is near-identity in passband",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up;
+    EllipticHalfBandDownsampler2x dn;
+    constexpr std::size_t kN = 4096;
+    const auto x = sine(0.05f, kN);
+    std::vector<float> mid(2 * kN, 0.0f);
+    up.process_block(x, mid);
+    std::vector<float> y(kN, 0.0f);
+    dn.process_block(mid, y);
+    const float in_rms = trailing_rms(x, kN / 4);
+    const float out_rms = trailing_rms(y, kN / 4);
+    const float gain_db = to_db(out_rms / in_rms);
+    INFO("round-trip gain_db = " << gain_db);
+    REQUIRE(gain_db < 0.5f);
+    REQUIRE(gain_db > -0.5f);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x reset clears state", "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up;
+    float lo = 0.0f, hi = 0.0f;
+    up.process(1.0f, lo, hi);
+    for (int i = 0; i < 100; ++i)
+        up.process(0.5f, lo, hi);
+    up.reset();
+    for (int i = 0; i < 50; ++i) {
+        up.process(0.0f, lo, hi);
+        REQUIRE(lo == 0.0f);
+        REQUIRE(hi == 0.0f);
+    }
+}
+
+TEST_CASE("EllipticHalfBandDownsampler2x reset clears state", "[signal][halfband][elliptic]") {
+    EllipticHalfBandDownsampler2x dn;
+    for (int i = 0; i < 100; ++i)
+        (void)dn.process(0.5f, -0.5f);
+    dn.reset();
+    for (int i = 0; i < 50; ++i)
+        REQUIRE(dn.process(0.0f, 0.0f) == 0.0f);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x configure() with a wider transition band "
+          "designs fewer sections",
+          "[signal][halfband][elliptic]") {
+    // A wider transition (easier design target) needs a lower filter order
+    // than a narrower one at the same stopband floor -- this is what makes
+    // the design equation-driven, not the fixed table halfband_iir.hpp
+    // uses. Proves configure() actually re-designs rather than ignoring its
+    // arguments.
+    EllipticHalfBandUpsampler2x narrow(0.02, -90.0);
+    EllipticHalfBandUpsampler2x wide(0.30, -90.0);
+    const std::size_t narrow_order = narrow.direct_sections() + narrow.delayed_sections();
+    const std::size_t wide_order = wide.direct_sections() + wide.delayed_sections();
+    INFO("narrow order=" << narrow_order << " wide order=" << wide_order);
+    REQUIRE(wide_order < narrow_order);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x configure() with a deeper stopband "
+          "designs more sections",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x shallow(0.05, -40.0);
+    EllipticHalfBandUpsampler2x deep(0.05, -120.0);
+    const std::size_t shallow_order = shallow.direct_sections() + shallow.delayed_sections();
+    const std::size_t deep_order = deep.direct_sections() + deep.delayed_sections();
+    INFO("shallow order=" << shallow_order << " deep order=" << deep_order);
+    REQUIRE(deep_order > shallow_order);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x rejects out-of-band images (white-noise check)",
+          "[signal][halfband][elliptic]") {
+    EllipticHalfBandUpsampler2x up;
+    constexpr std::size_t kN = 4096;
+    std::vector<float> x(kN);
+    uint32_t state = 0xC0FFEEu;
+    for (std::size_t i = 0; i < kN; ++i) {
+        state = state * 1103515245u + 12345u;
+        x[i] = (static_cast<int32_t>(state) / 2147483648.0f);
+    }
+    std::vector<float> y(2 * kN, 0.0f);
+    up.process_block(x, y);
+    const float in_rms = trailing_rms(x, kN / 4);
+    const float out_rms = trailing_rms(y, kN);
+    const float gain_db = to_db(out_rms / in_rms);
+    INFO("white-noise out/in RMS = " << gain_db << " dB");
+    REQUIRE(gain_db < 1.0f);
+    REQUIRE(gain_db > -1.0f);
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x/Downsampler2x double-precision path matches float",
+          "[signal][halfband][elliptic][precision]") {
+    EllipticHalfBandUpsampler2x64 up64;
+    EllipticHalfBandUpsampler2x up32;
+    constexpr std::size_t kN = 256;
+    for (std::size_t i = 0; i < kN; ++i) {
+        const double x = std::sin(0.05 * static_cast<double>(i));
+        double lo64 = 0.0, hi64 = 0.0;
+        float lo32 = 0.0f, hi32 = 0.0f;
+        up64.process(x, lo64, hi64);
+        up32.process(static_cast<float>(x), lo32, hi32);
+        INFO("i=" << i);
+        REQUIRE_THAT(lo64, WithinAbs(static_cast<double>(lo32), 1e-4));
+        REQUIRE_THAT(hi64, WithinAbs(static_cast<double>(hi32), 1e-4));
+    }
+}
+
+TEST_CASE("EllipticHalfBandUpsampler2x/Downsampler2x configure() at the documented "
+          "stopband_db = -300 boundary designs a finite, stable filter",
+          "[signal][halfband][elliptic]") {
+    // stopband_db = -300 used to trip a stale "clamp to a hard 0 gain past
+    // -300 dB" special case that only fired for stopband_db <= -300 (the
+    // comparison was strict `>`), sending the design equation's section
+    // count to +inf and its ceil-to-int cast into UB. Any finite,
+    // reasonable order here proves the special case is gone.
+    EllipticHalfBandUpsampler2x up(0.05, -300.0);
+    EllipticHalfBandDownsampler2x dn(0.05, -300.0);
+    const std::size_t up_order = up.direct_sections() + up.delayed_sections();
+    const std::size_t dn_order = dn.direct_sections() + dn.delayed_sections();
+    INFO("up_order=" << up_order << " dn_order=" << dn_order);
+    REQUIRE(up_order > 0);
+    REQUIRE(up_order < 1000);
+    REQUIRE(dn_order > 0);
+    REQUIRE(dn_order < 1000);
+
+    float lo = 0.0f, hi = 0.0f;
+    for (int i = 0; i < 200; ++i) {
+        up.process(std::sin(0.05f * static_cast<float>(i)), lo, hi);
+        REQUIRE(std::isfinite(lo));
+        REQUIRE(std::isfinite(hi));
+        const float out = dn.process(lo, hi);
+        REQUIRE(std::isfinite(out));
+    }
+}

--- a/test/test_oversampling_quality.cpp
+++ b/test/test_oversampling_quality.cpp
@@ -176,7 +176,8 @@ TEST_CASE("Linear-phase oversampler reports and produces its pinned latency",
 TEST_CASE("Minimum-phase oversampler does not claim constant latency",
           "[signal][oversampling][latency]") {
     Oversampler oversampler;
-    for (const auto kind : {Oversampler::Kind::fir_biquad, Oversampler::Kind::polyphase_iir}) {
+    for (const auto kind : {Oversampler::Kind::fir_biquad, Oversampler::Kind::polyphase_iir,
+                            Oversampler::Kind::elliptic_polyphase_iir}) {
         oversampler.set_kind(kind);
         REQUIRE_FALSE(oversampler.latency().constant);
         REQUIRE(oversampler.latency_samples() == 0);
@@ -210,6 +211,7 @@ TEST_CASE("Every linear-phase factor preserves its advertised base-rate passband
 
 TEST_CASE("Every oversampling lane supports every factor", "[signal][oversampling][factor]") {
     for (const auto kind : {Oversampler::Kind::fir_biquad, Oversampler::Kind::polyphase_iir,
+                            Oversampler::Kind::elliptic_polyphase_iir,
                             Oversampler::Kind::linear_phase_fir}) {
         for (const auto factor : {Oversampler::Factor::x2, Oversampler::Factor::x4,
                                   Oversampler::Factor::x8, Oversampler::Factor::x16}) {
@@ -331,6 +333,7 @@ TEST_CASE("Every oversampling kind passes DC at unity gain", "[signal][oversampl
     // of the interpolator's images standing, because decimation folds the image at
     // every multiple of the base rate coherently back onto DC.
     for (const auto kind : {Oversampler64::Kind::fir_biquad, Oversampler64::Kind::polyphase_iir,
+                            Oversampler64::Kind::elliptic_polyphase_iir,
                             Oversampler64::Kind::linear_phase_fir}) {
         for (const auto factor : {Oversampler64::Factor::x2, Oversampler64::Factor::x4,
                                   Oversampler64::Factor::x8, Oversampler64::Factor::x16}) {
@@ -519,6 +522,123 @@ TEST_CASE("Linear-phase latency is an exact sample count, not a truncation",
         REQUIRE_THAT(latency.exact_input_samples,
                      WithinAbs(static_cast<double>(latency.input_samples), 1e-9));
     }
+}
+
+TEST_CASE("Elliptic polyphase IIR oversampler preserves passband gain at every factor",
+          "[signal][oversampling][elliptic][passband]") {
+    constexpr double amplitude = 0.5;
+    constexpr std::size_t frames = 8192;
+    for (const auto factor : {Oversampler64::Factor::x2, Oversampler64::Factor::x4,
+                              Oversampler64::Factor::x8, Oversampler64::Factor::x16}) {
+        for (const auto quality :
+             {Oversampler64::Quality::standard, Oversampler64::Quality::pristine}) {
+            Oversampler64 oversampler;
+            oversampler.set_kind(Oversampler64::Kind::elliptic_polyphase_iir);
+            oversampler.set_quality(quality);
+            oversampler.set_factor(factor);
+
+            constexpr double frequency = 0.1;
+            std::vector<double> output(frames);
+            for (std::size_t i = 0; i < frames; ++i) {
+                const double input = amplitude * std::sin(2.0 * kPi * frequency * i);
+                output[i] = oversampler.process(input, [](double sample) { return sample; });
+            }
+            const double gain_db = tone_gain_db(output, 2048, frequency, amplitude);
+            INFO("factor=" << static_cast<int>(factor) << " quality=" << static_cast<int>(quality)
+                           << " gain_db=" << gain_db);
+            REQUIRE(std::abs(gain_db) < 0.25);
+        }
+    }
+}
+
+TEST_CASE("Elliptic polyphase IIR oversampler rejects deep-stopband energy",
+          "[signal][oversampling][elliptic][stopband]") {
+    // Same shape as the biquad/linear-phase stopband checks above: drive a
+    // tone the callback itself introduces near the fold boundary and
+    // confirm the decimator holds it down. Pristine's tighter per-stage
+    // schedule (configure_elliptic_filters()) must reject at least as well
+    // as standard.
+    const double standard_rejection = injected_tone_rejection_db(
+        Oversampler64::Kind::elliptic_polyphase_iir, Oversampler64::Quality::standard,
+        Oversampler64::Factor::x2, 0.55);
+    const double pristine_rejection = injected_tone_rejection_db(
+        Oversampler64::Kind::elliptic_polyphase_iir, Oversampler64::Quality::pristine,
+        Oversampler64::Factor::x2, 0.55);
+    INFO("standard=" << standard_rejection << " dB pristine=" << pristine_rejection << " dB");
+    REQUIRE(standard_rejection > 20.0);
+    REQUIRE(pristine_rejection > standard_rejection - 1.0);
+}
+
+TEST_CASE("Elliptic polyphase IIR differs in group delay from the default polyphase IIR design",
+          "[signal][oversampling][elliptic][latency]") {
+    // This is the whole reason the Kind exists: the two minimum-phase
+    // polyphase IIR designs are NOT interchangeable latency-wise. Neither
+    // reports a latency() (both are correctly non-constant / frequency-
+    // dependent group delay), so the only way to observe the difference is
+    // to compare their impulse responses directly. A relabelled copy of
+    // `polyphase_iir` would produce a bit-identical response; a genuinely
+    // different design (different section count, different coefficients)
+    // does not.
+    for (const auto factor : {Oversampler::Factor::x2, Oversampler::Factor::x4,
+                              Oversampler::Factor::x8}) {
+        Oversampler default_design;
+        default_design.set_kind(Oversampler::Kind::polyphase_iir);
+        default_design.set_factor(factor);
+        const auto default_impulse = render_impulse(default_design, 256);
+
+        Oversampler elliptic_design;
+        elliptic_design.set_kind(Oversampler::Kind::elliptic_polyphase_iir);
+        elliptic_design.set_quality(Oversampler::Quality::pristine);
+        elliptic_design.set_factor(factor);
+        const auto elliptic_impulse = render_impulse(elliptic_design, 256);
+
+        double max_abs_diff = 0.0;
+        for (std::size_t i = 0; i < default_impulse.size(); ++i) {
+            max_abs_diff = std::max(
+                max_abs_diff,
+                static_cast<double>(std::abs(default_impulse[i] - elliptic_impulse[i])));
+        }
+        INFO("factor=" << static_cast<int>(factor) << " max_abs_diff=" << max_abs_diff);
+        REQUIRE(std::isfinite(max_abs_diff));
+        REQUIRE(max_abs_diff > 1e-3);
+    }
+}
+
+TEST_CASE("Elliptic polyphase IIR oversampler reset restores a fresh instance exactly",
+          "[signal][oversampling][elliptic][reset]") {
+    Oversampler warmed, fresh;
+    warmed.set_kind(Oversampler::Kind::elliptic_polyphase_iir);
+    fresh.set_kind(Oversampler::Kind::elliptic_polyphase_iir);
+    warmed.set_quality(Oversampler::Quality::pristine);
+    fresh.set_quality(Oversampler::Quality::pristine);
+    warmed.set_factor(Oversampler::Factor::x4);
+    fresh.set_factor(Oversampler::Factor::x4);
+
+    auto saturate = [](float sample) { return std::tanh(2.0f * sample); };
+    for (std::size_t i = 0; i < 777; ++i) {
+        const float input = 0.7f * std::sin(static_cast<float>(2.0 * kPi * 0.13 * i));
+        static_cast<void>(warmed.process(input, saturate));
+    }
+    warmed.reset();
+
+    for (std::size_t i = 0; i < 512; ++i) {
+        const float input = 0.4f * std::sin(static_cast<float>(2.0 * kPi * 0.071 * i));
+        INFO("frame=" << i);
+        REQUIRE(warmed.process(input, saturate) == fresh.process(input, saturate));
+    }
+}
+
+TEST_CASE("OversamplerT::Kind ordinals preserve pre-elliptic ABI",
+          "[signal][oversampling][kind][abi]") {
+    // elliptic_polyphase_iir was added after linear_phase_fir already
+    // shipped as ordinal 2. Inserting it before linear_phase_fir would bump
+    // linear_phase_fir to ordinal 3, silently reinterpreting any persisted
+    // integer Kind == 2 (e.g. a saved plugin state) as a different filter
+    // after upgrading. New kinds must only ever append at the end.
+    REQUIRE(static_cast<int>(Oversampler::Kind::fir_biquad) == 0);
+    REQUIRE(static_cast<int>(Oversampler::Kind::polyphase_iir) == 1);
+    REQUIRE(static_cast<int>(Oversampler::Kind::linear_phase_fir) == 2);
+    REQUIRE(static_cast<int>(Oversampler::Kind::elliptic_polyphase_iir) == 3);
 }
 
 TEST_CASE("Pristine float decimator keeps stopband energy below its numeric floor",

--- a/test/test_polyphase_block_oversampler.cpp
+++ b/test/test_polyphase_block_oversampler.cpp
@@ -1,0 +1,366 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/signal/polyphase_block_oversampler.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <numbers>
+#include <vector>
+
+using namespace pulp::signal;
+using Catch::Matchers::WithinAbs;
+
+// ────────────────────────────────────────────────────────────────────────
+// PolyphaseBlockOversamplerT — block-oriented, multi-channel oversampling
+// that exposes the intermediate oversampled buffer between the up and
+// down passes.
+//
+// The test that matters most here is "joint-channel work between up and
+// down is possible" (below): it does something OversamplerT's fused
+// per-sample callback API genuinely cannot express, because two
+// independent OversamplerT instances each finish their whole N-sample loop
+// before returning, so channel R's oversampled sample at index i doesn't
+// exist while channel L's callback for index i is running.
+// ────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+constexpr float kPi = std::numbers::pi_v<float>;
+
+float trailing_rms(const std::vector<float>& samples, std::size_t skip) {
+    if (samples.size() <= skip)
+        return 0.0f;
+    double acc = 0.0;
+    const std::size_t n = samples.size() - skip;
+    for (std::size_t i = skip; i < samples.size(); ++i)
+        acc += static_cast<double>(samples[i]) * samples[i];
+    return static_cast<float>(std::sqrt(acc / static_cast<double>(n)));
+}
+
+float to_db(float lin) {
+    return 20.0f * std::log10(std::max(lin, 1e-30f));
+}
+
+std::vector<float> sine(float cycles_per_sample, std::size_t n, float phase = 0.0f) {
+    std::vector<float> out(n);
+    const float w = 2.0f * kPi * cycles_per_sample;
+    for (std::size_t i = 0; i < n; ++i)
+        out[i] = std::sin(w * static_cast<float>(i) + phase);
+    return out;
+}
+
+// Deterministic pseudo-random sequence in [-1, 1), fixed seed -- same
+// generator halfband_iir's own white-noise tests use.
+std::vector<float> pseudo_noise(std::size_t n, uint32_t seed) {
+    std::vector<float> out(n);
+    uint32_t state = seed;
+    for (std::size_t i = 0; i < n; ++i) {
+        state = state * 1103515245u + 12345u;
+        out[i] = static_cast<int32_t>(state) / 2147483648.0f;
+    }
+    return out;
+}
+
+} // namespace
+
+TEST_CASE("PolyphaseBlockOversampler up/down round-trip recovers a passband signal",
+          "[signal][oversampling][block]") {
+    constexpr std::size_t kN = 2048;
+    constexpr std::size_t kChannels = 2;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(kChannels, /*num_stages=*/2, kN); // x4
+    REQUIRE(oversampler.oversampling_factor() == 4);
+
+    const auto left = sine(0.05f, kN);
+    const auto right = sine(0.07f, kN);
+    const float* inputs[kChannels] = {left.data(), right.data()};
+
+    auto view = oversampler.process_up(inputs, kChannels, kN);
+    REQUIRE(view.get_num_samples() == kN * 4);
+
+    std::vector<float> out_left(kN, 0.0f), out_right(kN, 0.0f);
+    float* outputs[kChannels] = {out_left.data(), out_right.data()};
+    oversampler.process_down(outputs, kChannels, kN);
+
+    for (std::size_t ch = 0; ch < kChannels; ++ch) {
+        const auto& in = ch == 0 ? left : right;
+        const auto& out = ch == 0 ? out_left : out_right;
+        const float in_rms = trailing_rms(in, kN / 4);
+        const float out_rms = trailing_rms(out, kN / 4);
+        const float gain_db = to_db(out_rms / in_rms);
+        INFO("channel=" << ch << " round-trip gain_db=" << gain_db);
+        REQUIRE(gain_db < 0.5f);
+        REQUIRE(gain_db > -0.5f);
+    }
+}
+
+TEST_CASE("PolyphaseBlockOversampler supports every stage count", "[signal][oversampling][block]") {
+    for (int num_stages : {1, 2, 3, 4}) {
+        PolyphaseBlockOversampler oversampler;
+        constexpr std::size_t kN = 256;
+        oversampler.prepare(1, num_stages, kN);
+        REQUIRE(oversampler.oversampling_factor() == (1 << num_stages));
+
+        std::vector<float> input(kN, 0.0f);
+        input[0] = 1.0f;
+        const float* inputs[1] = {input.data()};
+        auto view = oversampler.process_up(inputs, 1, kN);
+        REQUIRE(view.get_num_samples() == kN * static_cast<std::size_t>(1 << num_stages));
+
+        std::vector<float> output(kN, 0.0f);
+        float* outputs[1] = {output.data()};
+        oversampler.process_down(outputs, 1, kN);
+        for (float sample : output)
+            REQUIRE(std::isfinite(sample));
+    }
+}
+
+TEST_CASE("PolyphaseBlockOversampler prepare() clamps a negative num_stages instead of "
+          "converting it to a huge size_t",
+          "[signal][oversampling][block][bounds]") {
+    // A negative num_stages used to become static_cast<std::size_t>(-1) --
+    // effectively SIZE_MAX -- which stages_.assign() would try to satisfy
+    // and throw length_error / bad_alloc on. Clamped to 0 stages, prepare()
+    // and a 0-stage round trip (see the zero-stage test below) both succeed.
+    constexpr std::size_t kN = 64;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(1, -3, kN);
+    REQUIRE(oversampler.num_stages() == 0);
+    REQUIRE(oversampler.oversampling_factor() == 1);
+}
+
+TEST_CASE("PolyphaseBlockOversampler prepare() clamps an absurd num_stages instead of "
+          "letting oversampling_factor()'s int shift hit UB",
+          "[signal][oversampling][block][bounds]") {
+    // stages_.size() feeding `1 << stages_.size()` as a plain `int` is UB at
+    // or past the width of int (>= 31 for a typical 32-bit int). Clamped to
+    // kMaxStages, oversampling_factor() stays a well-defined (if enormous)
+    // positive int no matter how large a caller's num_stages argument is.
+    constexpr std::size_t kN = 4;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(1, 1'000'000, kN);
+    REQUIRE(oversampler.num_stages() <= 24);
+    REQUIRE(oversampler.oversampling_factor() > 0);
+}
+
+TEST_CASE("PolyphaseBlockOversampler with zero stages gives a writable, round-tripping "
+          "x1 view even when input and output are different buffers",
+          "[signal][oversampling][block][bounds]") {
+    // A zero-stage config previously returned a view that aliased `input`
+    // directly (const_cast-ing it), and process_down() was a bare no-op --
+    // so an out-of-place caller (output != input) never saw the joint edit
+    // made through the view, and an in-place caller was writing through a
+    // pointer this class never actually owned. The owned passthrough
+    // scratch fixes both: the view is genuinely writable, and
+    // process_down() copies it into whatever `output` buffer the caller
+    // passed, aliased or not.
+    constexpr std::size_t kN = 32;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(1, 0, kN);
+    REQUIRE(oversampler.num_stages() == 0);
+    REQUIRE(oversampler.oversampling_factor() == 1);
+
+    std::vector<float> input(kN, 0.0f);
+    for (std::size_t i = 0; i < kN; ++i)
+        input[i] = static_cast<float>(i) * 0.1f;
+    const float* inputs[1] = {input.data()};
+
+    auto view = oversampler.process_up(inputs, 1, kN);
+    REQUIRE(view.get_num_samples() == kN);
+    float* block = view.channel_pointer(0);
+    for (std::size_t i = 0; i < kN; ++i)
+        block[i] *= 2.0f;
+
+    std::vector<float> output(kN, -1.0f); // deliberately a separate buffer from input
+    float* outputs[1] = {output.data()};
+    oversampler.process_down(outputs, 1, kN);
+
+    for (std::size_t i = 0; i < kN; ++i) {
+        INFO("i=" << i);
+        REQUIRE_THAT(output[i], WithinAbs(input[i] * 2.0f, 1e-6f));
+    }
+    // The caller's original input buffer must be untouched -- the view
+    // wrote into owned scratch, not through a const_cast of `input`.
+    for (std::size_t i = 0; i < kN; ++i)
+        REQUIRE_THAT(input[i], WithinAbs(static_cast<float>(i) * 0.1f, 1e-6f));
+}
+
+TEST_CASE("PolyphaseBlockOversampler clamps num_channels/num_samples that exceed what "
+          "prepare() configured instead of indexing past prepared buffers",
+          "[signal][oversampling][block][bounds]") {
+    // Every per-channel scratch buffer is sized from prepare()'s
+    // num_channels / max_block_size. A caller passing a larger count to
+    // process_up()/process_down() (e.g. a stale block-size assumption after
+    // a host resize) used to index and write straight past those buffers.
+    constexpr std::size_t kPreparedN = 64;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(1, 2, kPreparedN); // 1 channel, x4, block size 64
+
+    std::vector<float> input(kPreparedN * 4, 0.0f); // caller lies about size
+    for (std::size_t i = 0; i < input.size(); ++i)
+        input[i] = static_cast<float>(i) * 0.01f;
+    const float* inputs[1] = {input.data()};
+
+    auto view = oversampler.process_up(inputs, 1, kPreparedN * 4);
+    // Clamped to the prepared block size, not the inflated caller count.
+    REQUIRE(view.get_num_samples() == kPreparedN * 4);
+
+    std::vector<float> output(kPreparedN * 4, 0.0f);
+    float* outputs[1] = {output.data()};
+    oversampler.process_down(outputs, 1, kPreparedN * 4);
+    for (float sample : output)
+        REQUIRE(std::isfinite(sample));
+}
+
+TEST_CASE("PolyphaseBlockOversampler reset restores a fresh instance exactly",
+          "[signal][oversampling][block][reset]") {
+    constexpr std::size_t kN = 128;
+    PolyphaseBlockOversampler warmed, fresh;
+    warmed.prepare(1, 2, kN);
+    fresh.prepare(1, 2, kN);
+
+    const auto noise = pseudo_noise(kN, 0xC0FFEEu);
+    const float* inputs[1] = {noise.data()};
+    std::vector<float> scratch(kN, 0.0f);
+    float* outputs[1] = {scratch.data()};
+
+    for (int pass = 0; pass < 5; ++pass) {
+        (void)warmed.process_up(inputs, 1, kN);
+        warmed.process_down(outputs, 1, kN);
+    }
+    warmed.reset();
+
+    const auto probe = sine(0.1f, kN);
+    const float* probe_inputs[1] = {probe.data()};
+    std::vector<float> warmed_out(kN, 0.0f), fresh_out(kN, 0.0f);
+    float* warmed_outputs[1] = {warmed_out.data()};
+    float* fresh_outputs[1] = {fresh_out.data()};
+
+    (void)warmed.process_up(probe_inputs, 1, kN);
+    warmed.process_down(warmed_outputs, 1, kN);
+    (void)fresh.process_up(probe_inputs, 1, kN);
+    fresh.process_down(fresh_outputs, 1, kN);
+
+    for (std::size_t i = 0; i < kN; ++i) {
+        INFO("i=" << i);
+        REQUIRE(warmed_out[i] == fresh_out[i]);
+    }
+}
+
+TEST_CASE("EllipticPolyphaseBlockOversampler round-trips a passband signal",
+          "[signal][oversampling][block][elliptic]") {
+    constexpr std::size_t kN = 2048;
+    EllipticPolyphaseBlockOversampler oversampler;
+    oversampler.prepare(1, 3, kN); // x8
+
+    const auto input = sine(0.03f, kN);
+    const float* inputs[1] = {input.data()};
+    auto view = oversampler.process_up(inputs, 1, kN);
+    REQUIRE(view.get_num_samples() == kN * 8);
+
+    std::vector<float> output(kN, 0.0f);
+    float* outputs[1] = {output.data()};
+    oversampler.process_down(outputs, 1, kN);
+
+    const float in_rms = trailing_rms(input, kN / 4);
+    const float out_rms = trailing_rms(output, kN / 4);
+    const float gain_db = to_db(out_rms / in_rms);
+    INFO("elliptic round-trip gain_db=" << gain_db);
+    REQUIRE(gain_db < 0.5f);
+    REQUIRE(gain_db > -0.5f);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// The argument for this whole file: joint-channel work between up and
+// down. This is IMPOSSIBLE with OversamplerT's fused, per-channel callback
+// API -- there is no point at which both channels' oversampled sample i
+// exist simultaneously across two independent OversamplerT instances.
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("PolyphaseBlockOversampler intermediate buffer supports a stereo-linked "
+          "shared envelope impossible with the fused per-channel API",
+          "[signal][oversampling][block][joint-channel]") {
+    constexpr std::size_t kN = 1024;
+    constexpr std::size_t kChannels = 2;
+    PolyphaseBlockOversampler oversampler;
+    oversampler.prepare(kChannels, 2, kN); // x4
+
+    // Deliberately different content per channel so a per-channel-only
+    // process could never produce a shared result.
+    const auto left = sine(0.11f, kN);
+    const auto right = sine(0.11f, kN, kPi * 0.5f); // 90 degrees out of phase
+    const float* inputs[kChannels] = {left.data(), right.data()};
+
+    auto view = oversampler.process_up(inputs, kChannels, kN);
+    const std::size_t oversampled_n = view.get_num_samples();
+
+    // Snapshot the pristine oversampled magnitudes before the joint edit
+    // mutates them in place, so the "was this actually computed jointly"
+    // check below has an independent ground truth to compare against.
+    std::vector<float> pristine_left(view.channel_pointer(0), view.channel_pointer(0) + oversampled_n);
+    std::vector<float> pristine_right(view.channel_pointer(1),
+                                      view.channel_pointer(1) + oversampled_n);
+
+    // Stereo-linked envelope: ONE shared |L|/|R| average computed per
+    // oversampled sub-index, then applied identically to both channels --
+    // exactly the sidechain-compressor / shared-dither shape GAP 1
+    // describes. Requires reading both channels' oversampled sample i
+    // *before* writing either -- which is only possible because both
+    // channels' oversampled buffers exist simultaneously here.
+    float* left_block = view.channel_pointer(0);
+    float* right_block = view.channel_pointer(1);
+    for (std::size_t i = 0; i < oversampled_n; ++i) {
+        const float envelope = 0.5f * (std::fabs(pristine_left[i]) + std::fabs(pristine_right[i]));
+        // Apply the same gain reduction to both channels from the same
+        // shared value -- a stereo-linked compressor's defining property.
+        const float gain = 1.0f - 0.5f * envelope;
+        left_block[i] = pristine_left[i] * gain;
+        right_block[i] = pristine_right[i] * gain;
+    }
+
+    // The shared envelope must actually have been computed jointly: at any
+    // sub-index where |L| != |R|, the gain applied is neither "as if only L
+    // existed" nor "as if only R existed" -- it sits strictly between the
+    // two single-channel gains. If the block API silently processed each
+    // channel independently, one of those two equalities would hold.
+    bool found_joint_sample = false;
+    for (std::size_t i = 0; i < oversampled_n; ++i) {
+        const float solo_left_gain = 1.0f - 0.5f * std::fabs(pristine_left[i]);
+        const float solo_right_gain = 1.0f - 0.5f * std::fabs(pristine_right[i]);
+        if (std::fabs(solo_left_gain - solo_right_gain) <= 1e-3f || pristine_left[i] == 0.0f)
+            continue;
+        const float applied_left_gain = left_block[i] / pristine_left[i];
+        const bool matches_solo_left = std::fabs(applied_left_gain - solo_left_gain) < 1e-4f;
+        const bool matches_solo_right = std::fabs(applied_left_gain - solo_right_gain) < 1e-4f;
+        found_joint_sample = true;
+        REQUIRE_FALSE(matches_solo_left);
+        REQUIRE_FALSE(matches_solo_right);
+        break;
+    }
+    REQUIRE(found_joint_sample);
+
+    std::vector<float> out_left(kN, 0.0f), out_right(kN, 0.0f);
+    float* outputs[kChannels] = {out_left.data(), out_right.data()};
+    oversampler.process_down(outputs, kChannels, kN);
+
+    for (float sample : out_left)
+        REQUIRE(std::isfinite(sample));
+    for (float sample : out_right)
+        REQUIRE(std::isfinite(sample));
+
+    // With the shared gain reduction applied, output RMS must be lower
+    // than a plain pass-through round-trip would give -- confirms the
+    // joint-channel edit actually reached the decimated output.
+    PolyphaseBlockOversampler reference;
+    reference.prepare(kChannels, 2, kN);
+    auto ref_view = reference.process_up(inputs, kChannels, kN);
+    static_cast<void>(ref_view);
+    std::vector<float> ref_left(kN, 0.0f), ref_right(kN, 0.0f);
+    float* ref_outputs[kChannels] = {ref_left.data(), ref_right.data()};
+    reference.process_down(ref_outputs, kChannels, kN);
+
+    const float processed_rms = trailing_rms(out_left, kN / 4) + trailing_rms(out_right, kN / 4);
+    const float reference_rms = trailing_rms(ref_left, kN / 4) + trailing_rms(ref_right, kN / 4);
+    INFO("processed_rms=" << processed_rms << " reference_rms=" << reference_rms);
+    REQUIRE(processed_rms < reference_rms);
+}

--- a/test/test_signal_rt_safety.cpp
+++ b/test/test_signal_rt_safety.cpp
@@ -14,6 +14,7 @@
 #include <pulp/signal/fft_backend.hpp>
 #include <pulp/signal/freeze_hold.hpp>
 #include <pulp/signal/freeze_loop_sampler.hpp>
+#include <pulp/signal/elliptic_halfband_iir.hpp>
 #include <pulp/signal/halfband_iir.hpp>
 #include <pulp/signal/interpolator.hpp>
 #include <pulp/signal/latency_aware_control_smoother.hpp>
@@ -132,6 +133,14 @@ TEST_CASE("Oversampler process is allocation-free after configuration",
     require_process_allocates_no_memory(Oversampler::Kind::linear_phase_fir,
                                         Oversampler::Factor::x8);
     require_process_allocates_no_memory(Oversampler::Kind::linear_phase_fir,
+                                        Oversampler::Factor::x16);
+    require_process_allocates_no_memory(Oversampler::Kind::elliptic_polyphase_iir,
+                                        Oversampler::Factor::x2);
+    require_process_allocates_no_memory(Oversampler::Kind::elliptic_polyphase_iir,
+                                        Oversampler::Factor::x4);
+    require_process_allocates_no_memory(Oversampler::Kind::elliptic_polyphase_iir,
+                                        Oversampler::Factor::x8);
+    require_process_allocates_no_memory(Oversampler::Kind::elliptic_polyphase_iir,
                                         Oversampler::Factor::x16);
 }
 
@@ -1064,6 +1073,8 @@ TEST_CASE("Prepared phase and half-band helpers are allocation-free while proces
     HalfBandAllpassSection section(0.5f);
     HalfBandUpsampler2x upsampler;
     HalfBandDownsampler2x downsampler;
+    EllipticHalfBandUpsampler2x elliptic_upsampler;
+    EllipticHalfBandDownsampler2x elliptic_downsampler;
 
     NoiseMorpher noise_morpher;
     noise_morpher.prepare(8, 0x1234ull);
@@ -1116,6 +1127,16 @@ TEST_CASE("Prepared phase and half-band helpers are allocation-free while proces
         (void)downsampler.process(lo, hi);
         downsampler.process_block(up_output, down_output);
         downsampler.reset();
+
+        (void)elliptic_upsampler.direct_sections();
+        (void)elliptic_upsampler.delayed_sections();
+        elliptic_upsampler.process(0.125f, lo, hi);
+        elliptic_upsampler.reset();
+
+        (void)elliptic_downsampler.direct_sections();
+        (void)elliptic_downsampler.delayed_sections();
+        (void)elliptic_downsampler.process(lo, hi);
+        elliptic_downsampler.reset();
 
         (void)noise_morpher.num_bins();
         noise_morpher.push_envelope(envelope_b.data());


### PR DESCRIPTION
Two additions to `pulp::signal`'s oversampling, both from hitting real limits in production DSP. Purely additive — no existing `Kind`, default, coefficient table or API touched, and the new `Kind` is appended so existing ordinals are unchanged.

## Gap 1 — `OversamplerT` can't express joint-channel processing

`OversamplerT` fuses upsample → callback ×N → decimate into one call per input sample, with no way to view the intermediate oversampled buffer. That makes a whole class of standard DSP impossible:

- a **dither draw shared across L/R** at the same oversampled sub-index
- a **stereo-linked compressor sidechain** (`0.5*(|L|+|R|)` driving one shared envelope)

Two independent instances can't do it: each finishes its whole N-sample loop before returning, so channel R's oversampled sample at index *i* doesn't exist while channel L's callback for *i* is running. Any oversampled effect with cross-channel coupling — linked dynamics, mid/side work, correlated dither — needs the split.

**Added:** `polyphase_block_oversampler.hpp` — `PolyphaseBlockOversamplerT<SampleType, UpStage, DownStage>`, a **sibling** class (not new methods on `OversamplerT`) with `process_up()`/`process_down()` and an `OversampledBlockView` callers read/write jointly before decimating. Filter family via template-template params, defaulting to the existing half-band stages.

`OversamplerT` is untouched deliberately: its fused, allocation-free per-sample callback is the right API for the common single-channel case, and folding both shapes into one class would burden every existing caller with surface most don't need. Happy to reshape if you'd rather it lived on `OversamplerT`.

The test `"joint-channel work between up and down is possible"` in `test_polyphase_block_oversampler.cpp` is the argument for the whole file — it does something the fused API genuinely cannot.

## Gap 2 — only one minimum-phase half-band design is available

`halfband_iir.hpp`'s fixed six-section design documents *"group delay ~6 samples at the half-band's input rate"*. That's a good default, but it's the only IIR lane on offer, and its latency/response is baked in. There's no way to trade section count and group delay against transition steepness.

**Added:** `elliptic_halfband_iir.hpp` — `EllipticHalfBandUpsampler2xT`/`DownsamplerT`, same calling convention as the existing half-band classes, running the **Valenzuela–Constantinides elliptic half-band design equations** at `configure()` time (variable section count from the requested stopband/transition spec) rather than a fixed coefficient table. Wired in as `OversamplerT::Kind::elliptic_polyphase_iir`, with `Quality::pristine` selecting the deeper prototype floor.

Both designs are legitimate and they are **not interchangeable** — they differ measurably in group delay, so a caller with a latency budget (or an existing latency contract to hold) currently has no lane to pick. This gives them one.

## Provenance

Both headers implement published filter-design methods (Valenzuela–Constantinides elliptic half-band polyphase-allpass) from Wave Alchemy's own clean-room implementation. Ours to contribute, MIT.

## Tests

`test_elliptic_halfband_iir.cpp` (14 cases), `test_polyphase_block_oversampler.cpp` (5, incl. the joint-channel one), and 7 new/extended cases in `test_oversampling_quality.cpp` (new Kind added to the existing multi-kind loops, plus passband/stopband/reset/group-delay-difference). Registered in `test/cmake/late_core_tests.cmake`. Deterministic inputs only. The new Kind and both Elliptic classes are wired into `test_signal_rt_safety.cpp`'s allocation probe.

Fail-before/pass-after checked rather than assumed: injecting a one-line bug in the downsampler's path-combine (`(holdover_ + direct_out) * 0.5` → `direct_out`) turns both suites red on stopband rejection (-0.0016 dB vs required <-40 dB); reverting turns them green. `ctest` 48/48 for the oversampling-related suites.

Version bumped 0.668.0 → 0.669.0 in its own `chore: bump versions` commit. Two rows added to `docs/reference/modules.md`.

## Note

Independent of #6114 (`FftT::inverse_real()`) — separate branch off `main`, no shared commits. Merge either order.