### PR TITLE
docs: capability plan from a downstream team — four gaps, with evidence

### DIFF
--- a/docs/analysis/downstream-capability-plan-2026-07.md
+++ b/docs/analysis/downstream-capability-plan-2026-07.md
@@ -1,0 +1,55 @@
+# docs: Capability plan — oversampling seam, half-band latency lane, real inverse FFT, AAX entry point
+
+We're a commercial audio-plugin team building on Pulp — as far as we know, ours will be the first commercial plugin to ship on it. This PR contributes a plan rather than patches: for each gap we describe the capability, the evidence, and the published method, so the design and implementation stay entirely in the Pulp team's hands. We're glad to supply test vectors, characterisation data, and review for any of them.
+
+Four gaps, roughly in the order we hit them. Honest priorities at the end of each.
+
+## 1. Joint-channel block oversampling
+
+**Gap.** The oversampler is fused and single-channel: an instance runs its entire N-sample loop before returning, so there is no seam between the upsample and the downsample stages. Any processing that must see more than one channel at the oversampled rate — a stereo-linked sidechain detector, a shared dither draw across channels — is structurally impossible to express through the current API, not merely awkward.
+
+**Ask.** A block-oriented API that exposes the seam: upsample a block, hand the caller the oversampled buffers for all channels together, then downsample. The existing fused per-sample path stays as the convenience wrapper on top.
+
+**Acceptance.** The test *is* the argument: a two-channel test whose inter-stage work reads both channels' oversampled data (e.g., a max-of-channels gain law) and produces output that no fused per-channel run can. Plus: output identical to the fused path when the inter-stage work is per-channel independent, and an allocation probe confirming nothing allocates between prepare and process.
+
+**Priority.** High for us — with #2 it unblocks a latency-critical processing path.
+
+## 2. A latency-compatible half-band lane
+
+**Gap.** The current half-band design carries roughly 6 samples of group delay per stage. A caller with an existing latency contract, or a fixed latency budget, has no alternative lane to select.
+
+**Ask.** An additional, selectable half-band kind: elliptic polyphase-allpass half-band filters, designed by Valenzuela & Constantinides' published method ("Digital signal processing schemes for efficient interpolation and decimation", IEE Proceedings G, 1983). In our characterisation, an allpass design of this family measures ≈2.34 samples of group delay at 2×, versus the ~6 per stage of the current design — the two are measurably not interchangeable, which is precisely why the caller needs the choice. Both designs are legitimate; neither replaces the other.
+
+**Acceptance.** Characterisation tests: passband ripple and stopband attenuation against a stated spec, measured group delay, reset fully clearing filter state, and a real-time-safety allocation probe on the process path.
+
+**Priority.** High, paired with #1.
+
+## 3. A real-valued inverse FFT
+
+**Gap.** The FFT type has a forward real transform but no inverse. Every consumer that needs one composes it by hand from the complex machinery — repeatedly, and each one can get the normalisation wrong independently.
+
+**Ask.** A real-valued inverse alongside the forward, with its normalisation convention stated in the docs.
+
+**Acceptance.** Round-trip fidelity (forward → inverse ≈ identity within a stated tolerance) on **both** the accelerated path and the portable fallback. The fallback must be exercised explicitly: a round-trip test that takes the accelerated path on Apple hardware cannot fail in the fallback branch and proves nothing about it.
+
+**One correctness trap, noted honestly:** the FFT type has a hand-written move constructor. If the inverse adds a scratch buffer as a new member, that constructor must transfer it — otherwise transforming through a moved-into instance is undefined behaviour. So the plan should include a move-then-transform test that reaches the fallback branch, for the same reason as above.
+
+**Priority.** Lowest of the four — a convenience, but one with a real trap attached, so worth doing deliberately whenever the type is next touched.
+
+## 4. The AAX entry point
+
+**Gap.** `pulp_add_plugin(... FORMATS aax)` wires up `PULP_ENABLE_AAX` / `PULP_AAX_SDK_DIR` and creates the module target, then errors with *"no aax_entry.cpp was found"* — that translation unit does not exist in the tree. AAX is reachable in the build system but not shippable.
+
+**Context.** The vendor SDK we hold is v2.9.0, CMake-native, exporting proper targets, so the integration surface is small. We can supply the SDK on our own machines for testing against; the entry translation unit itself has to live in Pulp.
+
+**Acceptance.** With a valid `PULP_AAX_SDK_DIR`, `FORMATS aax` produces a bundle that loads in the host and passes the format holder's validation tool; without the SDK dir, configuration fails with a clear message (as it already does).
+
+**Priority.** For us this is the only hard blocker in the list — it gates an entire distribution format. In fairness: nobody has shipped this format on Pulp yet, so today we may be the only ones waiting on it.
+
+## A packaging question (not a defect report)
+
+The install step appears to ship about 5 of the ~19 state headers — the preset/undo manager, store, parameter, properties-file, and midi-parameter-map headers are absent from the installed set. Is that an intentional public-API boundary, or a packaging oversight? If the latter, we're happy to enumerate exactly which headers we consume.
+
+---
+
+None of this is a demand. It's the list of the four places where we've had to work around the library rather than with it, written down so the fixes can be designed once, upstream, by the people who own the design. Test vectors, ripple/group-delay characterisation data, and review bandwidth are on offer for all of it.


### PR DESCRIPTION
We're building a commercial audio plugin on Pulp — as far as we know, the first to ship commercially on it. This PR contributes **a plan rather than patches**: for each gap, the capability, the evidence, and the published method, so the design and implementation stay entirely in your team's hands.

The document lands in `docs/analysis/`, alongside the existing plan/handoff docs there. Happy to move it if you'd rather it lived elsewhere, or to close this and carry it as an issue instead — the content is the point, not the location.

## The four gaps

1. **Joint-channel block oversampling** — the oversampler is fused and single-channel, so there's no seam between up and down. A stereo-linked sidechain or a shared dither draw is structurally inexpressible, not merely awkward. The acceptance test *is* the argument.
2. **A latency-compatible half-band lane** — an elliptic polyphase-allpass kind (Valenzuela & Constantinides, IEE Proc. G, 1983). We measure **≈2.34 samples** group delay at 2× against **~6/stage** today. Measurably not interchangeable — which is exactly why a caller with a latency contract needs the choice. Both designs are legitimate; neither replaces the other.
3. **A real-valued inverse FFT** — with an honest trap attached: the hand-written move constructor must transfer any new scratch buffer, or a moved-into instance is UB. And the move test has to reach the **fallback** branch — one that takes the accelerated path on Apple hardware cannot fail there and proves nothing.
4. **The AAX entry point** — `FORMATS aax` wires `PULP_ENABLE_AAX` / `PULP_AAX_SDK_DIR` and builds the module target, then errors with *"no aax_entry.cpp was found"*. Reachable in the build system, not shippable. Our only hard blocker — though we may be the only ones waiting, since nobody has shipped the format yet.

Plus a **packaging question** (framed as a question, not a defect): the install step appears to ship ~5 of ~19 state headers. Intentional API boundary, or oversight?

## Notes

- **Provenance: original work.** Our own analysis and measurements. No code, no third-party material.
- Every commit is DCO signed off.
- We're glad to supply **test vectors, ripple/group-delay characterisation data, and review** for any of these.

## Gate friction, reported rather than worked around

- `local_diff_cover` blocked the push: `diff_cover` won't install here — this machine's Python has a broken `pyexpat`/`libexpat` link, which is our problem, not yours. Used the narrow documented `PULP_DISABLE_PREPUSH_DIFF_COVER=1` (never the blanket skip). It's a docs-only diff, so there's no coverage to measure.
- We don't have `shipyard` available, so this went via direct push — which your pre-push hook lists as an acceptable fallback for exactly that. Flagging it rather than staying quiet.

No demand attached. This is just the list of places we've had to work around the library rather than with it, written down so the fixes can be designed once, by the people who own the design.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a capability plan doc in docs/analysis that outlines four gaps blocking a commercial plugin and proposes acceptance criteria for each. Requests joint‑channel block oversampling (expose the up/down seam), a selectable low‑latency half‑band lane (elliptic polyphase‑allpass), a real‑valued inverse FFT with defined normalization and move safety, and an AAX entry point; also asks about missing installed state headers.

<sup>Written for commit ad8a3854ddb961c69c615e33af7d44193e0d4d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

