### PR TITLE
DesignFrameView: knob hover highlight drawn at rest angle instead of live value

### DIFF
--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -125,6 +125,44 @@ void wrap_thumb_translation(std::string& svg, const std::string& marker,
 
 constexpr float kSweepDeg = 270.0f;  // value 0->-135, 0.5->0 (up), 1->+135
 
+// The restyle overlay (hover brighten / disabled desaturate) redraws the SAME
+// needle/thumb/dot fragment the frame already painted, on top of it — so it
+// must carry the SAME live transform paint() applied, not the identity. This
+// mirrors the per-kind math in paint() exactly (angle/translation formulas
+// duplicated on purpose: paint() mutates the SVG string in place, this builds
+// a standalone FragmentTransform for the fragment mini-document instead).
+FragmentTransform element_marker_transform(const DesignFrameElement& e) {
+    FragmentTransform t;
+    switch (e.kind) {
+        case DesignFrameElement::Kind::knob:
+            t.rotate_deg = (e.value - 0.5f) * kSweepDeg;
+            t.pivot_x = e.cx;
+            t.pivot_y = e.cy;
+            break;
+        case DesignFrameElement::Kind::fader:
+            if (e.w > e.h) {
+                const float target_x = e.x + e.value * e.w;
+                t.dx = target_x - e.cx;
+            } else {
+                const float target_y = e.y + (1.0f - e.value) * e.h;
+                t.dy = target_y - e.cy;
+            }
+            break;
+        case DesignFrameElement::Kind::xy_pad:
+            t.dx = (e.x + e.value * e.w) - e.cx;
+            t.dy = (e.y + e.value_y * e.h) - e.cy;
+            break;
+        case DesignFrameElement::Kind::toggle: {
+            const float dx_on = 2.0f * e.x + e.w - 2.0f * e.cx;
+            t.dx = e.value * dx_on;
+            break;
+        }
+        default:
+            break;
+    }
+    return t;
+}
+
 }  // namespace
 
 bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
@@ -1225,10 +1263,11 @@ void DesignFrameView::paint(canvas::Canvas& canvas) {
     for (int i = 0; i < static_cast<int>(elements_.size()); ++i) {
         const auto& e = elements_[i];
         if (e.needle_d.empty()) continue;
+        const auto xform = element_marker_transform(e);
         if (!e.enabled) {
-            draw_fragment_marker(canvas, e.needle_d, {}, 0.45f, "#6b7280");
+            draw_fragment_marker(canvas, e.needle_d, xform, 0.45f, "#6b7280");
         } else if (i == hovered_element_) {
-            draw_fragment_marker(canvas, e.needle_d, {}, 0.18f, "#ffffff");
+            draw_fragment_marker(canvas, e.needle_d, xform, 0.18f, "#ffffff");
         }
     }
 

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -246,6 +246,48 @@ TEST_CASE("DesignFrameView renders + the needle rotates at a non-panel aspect",
     CHECK(cmp.similarity < 0.999f);
 }
 
+TEST_CASE("DesignFrameView hover highlight tracks the knob's live rotation, not its rest pose",
+          "[view][design-import][frame][hover]") {
+    // make_knob()'s needle is baked pointing straight UP (path "M50 38L50 30",
+    // center (50,50)). At value 1.0 the live render rotates it +135 degrees off
+    // that rest pose (kSweepDeg = 270, angle = (value-0.5)*270), i.e. down-and-
+    // right of center. The per-element hover overlay is a second, translucent
+    // redraw of the SAME needle fragment — it should track that same live
+    // rotation, so hovering must only ADD a highlight down-and-right of center,
+    // never up-and-level with it.
+    DesignFrameView baseline(make_design_svg(), {make_knob()});
+    DesignFrameView hovered(make_design_svg(), {make_knob()});
+    baseline.set_bounds({0, 0, 80, 80});
+    hovered.set_bounds({0, 0, 80, 80});
+    baseline.set_element_value(0, 1.0f);
+    hovered.set_element_value(0, 1.0f);
+
+    hovered.simulate_hover({40, 40});  // -> SVG (50,50): over the knob dome
+
+    auto base_png = render_to_png(baseline, 80, 80, 2.0f, ScreenshotBackend::skia);
+    if (base_png.empty()) SKIP("Skia raster screenshot backend unavailable");
+    auto hover_png = render_to_png(hovered, 80, 80, 2.0f, ScreenshotBackend::skia);
+    REQUIRE_FALSE(hover_png.empty());
+
+    // Isolate exactly what the hover highlight painted: the two renders are
+    // otherwise identical (same value, same everything else), so every
+    // differing pixel comes from the highlight redraw alone.
+    const auto bounds = diff_bounds(base_png, hover_png, /*tolerance=*/4);
+    REQUIRE(bounds.valid);
+
+    // The knob center (SVG 50,50; panel origin 10,10) lands at pixel (80,80) in
+    // this 2x-scaled render.
+    const float ghost_cx = bounds.x + bounds.width * 0.5f;
+    const float ghost_cy = bounds.y + bounds.height * 0.5f;
+
+    // BUG: fails today. The highlight's center comes out at/above (80,80) —
+    // the needle's BAKED rest position (straight up) — because the hover
+    // overlay is drawn with an identity transform regardless of value, instead
+    // of the value's live rotation.
+    CHECK(ghost_cx > 80.0f);
+    CHECK(ghost_cy > 80.0f);
+}
+
 namespace {
 // A knob carrying a host-parameter binding key — the surface a foreign-host
 // (the embed shim) binder reads to wire a hand-built native view to host params.


### PR DESCRIPTION
## Bug

In `DesignFrameView::paint()` (`core/view/src/design_frame_view.cpp`), the
per-element hover highlight for a `Kind::knob` element is drawn with an
identity transform, so it always shows the needle's baked rest pose instead
of the live, value-driven rotation the main render applies a few lines above.

Main render (applies the live rotation):

```cpp
if (e.kind == DesignFrameElement::Kind::knob && !e.needle_d.empty())
    wrap_needle_rotation(s, e.needle_d, (e.value - 0.5f) * kSweepDeg, e.cx, e.cy);
```
(design_frame_view.cpp, ~line 782-783)

Hover-highlight redraw (identity transform, ignores `e.value` entirely):

```cpp
for (int i = 0; i < static_cast<int>(elements_.size()); ++i) {
    const auto& e = elements_[i];
    if (e.needle_d.empty()) continue;
    if (!e.enabled) {
        draw_fragment_marker(canvas, e.needle_d, {}, 0.45f, "#6b7280");
    } else if (i == hovered_element_) {
        draw_fragment_marker(canvas, e.needle_d, {}, 0.18f, "#ffffff");
    }
}
```
(design_frame_view.cpp, ~line 830-838; the offending call is line ~836)

`draw_fragment_marker` is called with `xform = {}` (identity) for the hover
case, so it re-extracts the needle fragment from the SVG at its baked
position and redraws it there — not at the angle `wrap_needle_rotation`
already rotated it to for the main frame.

## Repro

Added `test/test_design_frame_view.cpp`:
`"DesignFrameView hover highlight tracks the knob's live rotation, not its
rest pose"` (tag `[hover]`).

It builds a knob whose needle is baked pointing straight up, sets its value
to `1.0` (which rotates the live needle +135 degrees off rest, i.e.
down-and-right of the knob's center), then renders it once hovered and once
not. Diffing those two renders isolates exactly the pixels the hover
highlight painted. The isolated highlight comes out centered at/above the
knob's center (the rest position) instead of down-and-right of it (the live
position) — the test's assertions on the highlight's center coordinates fail
against current behavior, pinning the bug.

Run:
```
ninja pulp-test-design-frame-view
./test/pulp-test-design-frame-view "[hover]"
```

Expected: highlight center is down-and-right of the knob's center (tracking
the live rotation).
Actual: highlight center is at/above the knob's center (the baked rest
angle), regardless of the element's value.

## Suggested fix (left to the maintainers)

The hover-highlight draw call should apply the same rotation transform
`wrap_needle_rotation` already computes for the main render — i.e. pass a
transform built from `(e.value - 0.5f) * kSweepDeg` around `(e.cx, e.cy)`
instead of `{}` — at the call site around line 836 (and, for consistency,
the disabled-element overlay at line 834 has the identical issue).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DesignFrameView` overlays to use the control’s live transform (rotation/translation) instead of the baked rest pose. Knob highlights now track the current needle angle; `fader`, `xy_pad`, and `toggle` markers align to their live positions.

- **Bug Fixes**
  - Added `element_marker_transform()` mirroring the main render’s value-based math: rotate knobs; translate `fader`, `xy_pad`, and `toggle` markers.
  - Applied this transform to `draw_fragment_marker` for hovered and disabled overlays in `DesignFrameView::paint()`.
  - Added a regression test that diffs hovered vs non-hovered renders to isolate the highlight and assert it appears at the live position; it now passes.

<sup>Written for commit 2186fe6a2b9ac1dd30747452df5b257ff5fde997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

