### PR TITLE
docs(skill): friction-report — retarget the confirm-the-failure cross-reference

### DIFF
--- a/.agents/skills/friction-report/SKILL.md
+++ b/.agents/skills/friction-report/SKILL.md
@@ -116,7 +116,7 @@ that is the smell. Split it. Usually the failures need *different* mechanisms �
 one, a hook for another, a habit for a third — and some may have **no clean mechanism at all**,
 which you must say plainly rather than paper over.
 
-*(This is the same discipline as the personal `verify-the-instrument` skill, applied to the
+*(This is the same discipline as the personal `confirm-the-failure` skill, applied to the
 FIX rather than to a measurement: prove the instrument can report the thing before you trust
 it. If that skill is available in your environment, use it here.)*
 
@@ -285,7 +285,7 @@ calendar date.**
 - **Verify the instrument before acting on it.** Before an agent acts on a report's finding —
   especially to change code, revert, or block a merge — it must confirm the finding is real
   (run the check against a known-good control). A report is a *claim*, not a verdict. See the
-  `verify-the-instrument` discipline.
+  `confirm-the-failure` discipline.
 
 ### The anti-goal (restate at every level)
 


### PR DESCRIPTION
`friction-report` cross-references the *"check the check before you trust a finding"* discipline in two places. That personal skill was renamed **verify-the-instrument → confirm-the-failure**, leaving these two references pointing at a name that no longer exists.

Retargets both. Docs-only — the reference is already guarded with *"if that skill is available in your environment,"* so pulp-only clones (which don't have the personal skill) are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["1·claude", "2·m5", "3·w1", "4·XX ✳ Check m3 server…"], "prov": {"agent": "claude", "tab": "XX ✳ Check m3 server for wedged processes"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m5` |
| **Workspace** | `w1` |
| **Tab** | XX ✳ Check m3 server for wedged processes |
| **Directory** | `~/Code/pulp-wt-frfix` |
| **Session** | `66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea` |

**Resume**
```
claude --resume 66a0a72f-6390-4fa6-aef6-db7f4f7ff3ea
```
**Jump to this tab**
```
cmux surface focus 1A350525-6AEA-4AA2-A909-FF4EDDA57431
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 1A350525-6AEA-4AA2-A909-FF4EDDA57431
```
**Restore URL** — https://claude.ai/code/session_019r8FBnJNrYQbDGy3hERhPj

<sub>stamped 2026-07-16 23:53 UTC</sub>
<!-- /whence -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `friction-report` skill docs to retarget two references from `verify-the-instrument` to the renamed `confirm-the-failure`, keeping the cross-reference accurate. Docs-only; guarded wording means environments without that personal skill are unaffected.

<sup>Written for commit 4309f9038222af95f9a6ca83531268101eee131d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

