### PR TITLE
feat(osc): suite tail — render --seed/--engine, Tier B click novelty + Allan, WP-4 fitter, corpus+perf, docs

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -486,6 +486,16 @@ harness or `ctest`.
   `engine [--input <wav>] --character <c>` (validate the REAL stretch engine, reference-free
   on a dry input), `engine-baseline` (regression gate: did an engine change make it worse?),
   `corpus list|add` (versioned, license-guarded corpus).
+- **`corpus.seed()`** ships FIVE synthetic families, not just the two stretch-oriented ones:
+  `synthetic_drumbreak` / `synthetic_tonalpad` (time-stretch / tonal) plus three oscillator
+  families (`family: "oscillator"`, `material_class: "synth"`) built from `osc_fixtures.py`'s
+  corpus-render helpers (`render_static_shapes`, `render_sync_sweep`, `render_tzfm_grid`) —
+  `synthetic_osc_static_shapes` (sine/saw/square/triangle at a few pitches), `synthetic_osc_sync_sweep`
+  (`hard_synced_saw` swept across master frequencies), `synthetic_osc_tzfm_grid` (`tzfm_sine` over a
+  mod-rate/index grid). They gate on the SAME `regression_net` ratchet as any other family — no
+  bespoke oscillator ratchet — typically via the `added-hf` axis (aliasing reads as added HF energy)
+  and `dsp.null_residual_db`'s bit-identical clamp (`-160.0`) for the determinism check. See
+  `tests/test_corpus_osc.py`.
 - Aligns a candidate to a reference (onset-map + local cross-correlation), runs the
   detectors (`transient_sharpness`, `spectral_centroid`, `hf_fizz`, `spectral_flux`, `hnr` —
   tonal noise/roughness via autocorrelation HNR; plus the standalone `stereo_width` for

--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -814,12 +814,19 @@ Durable "why / watch-out-for" notes so this isn't re-litigated (rationale, not w
   oscillator: on a polyBLEP saw/square, `sr/f0` is fractional, so the discontinuity lands at a
   different sub-sample phase every period and the comb leaves a per-edge *approximation* residual
   that reads a false −20 to −30 dB "click" even when the render's alias floor is −55 dB or lower.
-  `detect()` now discriminates that regime with two measurements — `localization_db` (worst
-  excursion over the MEDIAN per-period peak: a one-off seam towers over the background, smear
-  recurs so it barely exceeds the median) AND `edge_concentration` (cosine similarity of
-  `|residual|` to `|diff(y)|`: smear rides the waveform's own edges, a block-rate zipper does
-  not) — and REFUSES (`low_coverage`, `fired=False`, a *third* refusal precondition alongside
-  low period-confidence and pitch drift) rather than false-firing. A refusal is NOT a pass:
+  `detect()` discriminates that regime with two measurements — `template_novelty_db` and
+  `edge_concentration` — and REFUSES (`low_coverage`, `fired=False`, a *third* refusal
+  precondition alongside low period-confidence and pitch drift) rather than false-firing.
+  `template_novelty_db` aligns the comb residual into per-period frames at the fitted fractional
+  period, builds the median-frame TEMPLATE, and scores the worst period's departure from it over
+  the median period's — a one-off seam is the single period that does NOT match the recurring
+  template (a large outlier), while the smear repeats the same per-edge shape every period so it
+  barely departs. It is a per-period RATIO, so it is **render-length INDEPENDENT** (a longer clip
+  only adds more template-matching periods — it moves neither the worst nor the median): the same
+  near-floor seam that a global statistic dropped on a multi-second render now fires at any length.
+  `edge_concentration` (cosine similarity of `|residual|` to `|diff(y)|`) is kept, but ONLY to
+  split smear (rides the waveform's own edges) from a block-rate zipper (off the edges) — novelty
+  alone reads a stationary zipper as low-novelty and would wrongly refuse it. A refusal is NOT a pass:
   the honest gate for a discontinuous real oscillator is a **frozen-reference null**
   (`dsp.null_residual_db` — render the same patch with the offending parameter held frozen), not
   the comb self-reference. When you add a click fixture for a new oscillator, grow a REAL polyBLEP

--- a/docs/guides/oscillators.md
+++ b/docs/guides/oscillators.md
@@ -1,0 +1,277 @@
+# Oscillator suite
+
+`pulp::signal::osc` (`core/signal/include/pulp/signal/osc/`) is a family of
+seven headers that compose into four oscillator "flavors" — VA, VCO, DCO, and
+WT (in two tiers) — over two shared primitives, a phase accumulator and a set
+of BLEP/BLAMP anti-aliasing kernels. This is a **different, newer class
+family** than `signal::Oscillator` (`oscillator.hpp`, documented in
+[Signal Processing §3](signal-processing.md#3-oscillators)) — that one is a
+simpler polyBLEP oscillator with float phase and an integrated triangle;
+extend the suite on this page for new work, and see `oscillator.hpp`'s own
+header comment for exactly how the two differ.
+
+Each family is a standalone class — pick the one whose character matches
+what you're building, not a shared base class. All of them take a per-sample
+phase increment (`frequency / sample_rate`) rather than holding a frequency
+internally, so through-zero FM and per-sample pitch modulation compose
+without any API change.
+
+```cpp
+#include <pulp/signal/osc/va.hpp>
+
+pulp::signal::osc::VaOscillator osc;
+osc.set_shape(pulp::signal::osc::VaShape::saw);
+
+for (int i = 0; i < num_samples; ++i)
+    output[i] = static_cast<float>(osc.next(440.0 / sample_rate));
+```
+
+## Which one do I want?
+
+| Family | Reach for it when you want... | Header |
+|---|---|---|
+| VA | The default bandlimited analog shapes — clean, deterministic, hard sync, through-zero FM | `va.hpp` |
+| VCO | The above plus analog "imperfection": drift, jitter, waveshaping, a bowed ramp | `vco.hpp` |
+| DCO | Crystal-stable pitch with the *quantization* character of a divider-clocked synth, not drift | `dco.hpp` |
+| WT (modern) | A wavetable set with smooth scan/morph and click-free band-switching | `wt.hpp` |
+| WT (lo-fi) | Deliberately gritty ZOH wavetable playback — pitch-tracking aliasing as the point | `wt_lofi.hpp` |
+
+DCO and VCO both build on VA's shape stage (`VaOscillator`); the two
+wavetable tiers are independent engines with opposite goals (clean vs. lo-fi)
+and don't share code with each other or with VA.
+
+## VA — virtual-analog core
+
+`va.hpp` is the shared bandlimited core: sine, saw, square (with pulse
+width), and triangle, generated directly from the phase and corrected at
+each discontinuity by composing `PhaseAccumulator` (below) with the
+BLEP/BLAMP kernels. It underpins VCO and DCO — neither reimplements shape
+generation, they configure and drive this class.
+
+- **Anti-aliasing is polyBLEP, not a tabulated minBLEP** — an *improved*,
+  not alias-free, correction: roughly 11-15 dB better than the trivial
+  waveform below 20 kHz. A free-running sine needs no correction and is
+  bit-identical to `std::sin`; a *synced* sine does step and is corrected
+  like any other shape.
+- **Hard sync** (`next_synced`) and **through-zero FM** (a negative
+  increment) both compose with the correction structurally — a sample with
+  several coincident discontinuities just sums their corrections, so sync +
+  TZFM need no special-cased combination. Measured benefit is 11-34 dB over
+  the trivial waveform across sync, TZFM, and the two together, but the
+  benefit collapses as the instantaneous frequency approaches Nyquist: a
+  synced sine gains 12 dB at a 5 kHz deviation, 6 dB at 20 kHz, and nothing
+  at 60 kHz. Past that point the carrier itself is unrepresentable and no
+  discontinuity correction can rescue it — oversampling the FM path is a
+  separate concern this doesn't attempt.
+- **Pulse width** on the square is clamped to [0, 1]; a width narrower than
+  one sample period can't be represented cleanly (the two edges' corrections
+  overlap), but the output stays finite and bounded rather than blowing up.
+
+```cpp
+osc.set_shape(VaShape::square);
+osc.set_pulse_width(0.3);
+double sample = osc.next(increment);
+
+// Hard sync at a caller-detected reset point:
+double synced = osc.next_synced(increment, sync_frac, 0.0);
+```
+
+## VCO — circuit-flavored analog character
+
+`vco.hpp` wraps a `VaOscillator` core with the deterministic front-to-back
+path of an analog voltage-controlled oscillator: a pitch-control front end
+(`VcoTuning`, 1 V/octave with scale error and HF-compression knobs), an
+integrator-leak "bow" on the saw ramp, a per-shape lumped waveshaper, a
+level-vs-pitch tilt, and an output DC-blocking (AC-coupling) stage — plus
+two seeded, deterministic pitch-noise sources layered onto the increment
+before it reaches the core:
+
+- **Drift** — a slow, bandlimited random walk (one-pole-colored white
+  noise) with a corner around 0.4 Hz by default. `drift_depth` is the RMS
+  pitch excursion in cents; the wander evolves over hundreds of
+  milliseconds.
+- **Jitter** — fast, near-white cycle-to-cycle frequency noise, independent
+  per sample. `jitter_depth` is the RMS per-sample frequency deviation in
+  cents.
+
+Every stage defaults to its neutral value, so a default-constructed
+`VcoOscillator` is bit-for-bit a `VaOscillator` — the "analog" behavior is
+opt-in, not baked in. The noise source is seed-reproducible (`set_seed`, no
+`random_device`): the same seed and inputs give bit-identical output.
+
+```cpp
+VcoOscillator vco;
+vco.prepare(sample_rate);
+vco.set_shape(VaShape::saw);
+vco.set_bow(2.0);              // charge-curve ramp instead of linear
+vco.set_drift_depth(3.0);      // 3 cents RMS slow wander
+vco.set_jitter_depth(0.5);     // 0.5 cents RMS per-sample noise
+vco.set_seed(12345);
+
+double sample = vco.next(increment);
+```
+
+Be aware the bow and waveshaper are memoryless maps applied *after* the
+core's own bandlimited correction — standard analog-modeling composition,
+but honest about its limit: a nonlinearity on an already-bandlimited signal
+reintroduces a little aliasing, same as an analog circuit's own stages do.
+
+## DCO — divider-clocked, quantized pitch
+
+`dco.hpp` models a late-1970s/early-1980s divider-clocked oscillator: a
+crystal-derived master clock (`master_clock_hz`, default 8 MHz) is divided
+down by a programmable counter, and each terminal-count reset drives the
+shared VA shape stage. Unlike VCO, this front-end owns **no drift or jitter
+parameter at all** — that would contradict the architecture. A DCO's
+characteristic imperfection is **pitch quantization**, not drift, because an
+integer divider can only realize the discrete set `f_clk / N`.
+
+Two divider schemes, selected by `DcoProfile::divider_scheme`:
+
+- **Integer-N** — `N = round(f_clk / f_note)`; the reset interval is
+  exactly `N` master clocks, perfectly periodic in continuous time. No
+  forced sync needed — the natural phase wrap *is* the divider reset.
+  Quantization error grows with note frequency (doubles per octave up).
+- **Fractional-N** — a `B`-bit accumulator adds a tuning word each master
+  clock and resets on carry-out, so the *average* pitch can sit arbitrarily
+  close to the note. That accuracy is bought with deterministic **±1-clock
+  period jitter** (the reset interval alternates between `floor` and `ceil`
+  clocks around the average) — the opposite quantization/jitter tradeoff of
+  integer-N, and largest at *low* notes rather than high ones.
+
+```cpp
+DcoOscillator dco;
+dco.prepare(sample_rate);
+DcoProfile profile;
+profile.master_clock_hz = 8'000'000.0;
+profile.divider_scheme = DcoDivider::integer_n;
+dco.set_profile(profile);
+dco.set_shape(VaShape::square);
+dco.set_note_hz(440.0);
+
+double sample = dco.next();
+double cents_off = dco.detune_cents();  // the quantization error, exposed
+```
+
+Reach for DCO instead of VCO when you want the crisp, drift-free character
+of a divider-clocked synth voice (Juno/Jupiter-era) and the audible
+"almost-but-not-quite-in-tune" quality of integer division — not a smoothly
+wandering analog pitch.
+
+## WT (modern tier) — wavetable with clean scan/morph
+
+`wt.hpp` is a thin osc-module front-end over the shipped
+`WavetableBankT`/`WavetableT` engine (`signal/wavetable.hpp`): it plays a
+set of single-cycle tables with band-limited band-switching (each
+`WavetableT` selects the band whose Nyquist budget covers the current
+frequency and crossfades across 128 samples on a band change) and a smooth
+scan across the table set. This front-end adds only what the bank doesn't
+already own:
+
+- The osc-module per-sample frequency contract (`next(increment)`, matching
+  VA/VCO/DCO).
+- A one-pole **scan slew** (`set_scan_time_ms`, default 5 ms) so a
+  block-rate scan control doesn't zipper — this is the *clean* wavetable
+  tier.
+
+```cpp
+WtOscillator wt;
+wt.prepare(sample_rate);
+wt.set_wavetable_set(std::move(tables));  // off the audio thread
+wt.set_position(0.6);                     // slews toward this target
+wt.set_scan_time_ms(8.0);
+
+double sample = wt.next(increment);
+```
+
+Playback is for positive frequencies only — through-zero FM is VA/VCO's
+domain, not the wavetable engine's. The very first frequency after
+construction or `reset()` **snaps** to its band rather than crossfading, so
+a fresh voice never plays an aliased fade-in from the default band.
+
+## WT (lo-fi tier) — a dedicated variable-clock ZOH engine
+
+`wt_lofi.hpp` is a **separate engine**, not a mode of `WtOscillator`. It
+plays a raw short single-cycle table with nearest/zero-order-hold lookup at
+a playback clock that tracks pitch (`fs_play = f0 · table_length`), so its
+spectral-image ladder rides at `n · L · f0` and moves with the note — that
+pitch-tracking image ladder *is* the lo-fi sound, and it's exactly what a
+fixed-rate, band-limited, linearly-interpolated engine like `WtOscillator`
+cannot produce (linear interpolation alone suppresses the first image by
+~42 dB). Five mechanisms combine to give it its character:
+
+1. **Variable-clock ZOH images** — the pitch-tracking replication described
+   above.
+2. **Optional bit-depth quantization** (default 8 bits) of the *stored*
+   table, undithered, about zero — odd-harmonic grit, ~49.9 dB aggregate
+   SNR at 8 bits.
+3. **A real reconstruction stage** (oversample → lowpass → decimate) that
+   keeps a supra-Nyquist fold from re-entering the band as an unwanted
+   artifact, while preserving the sub-Nyquist images that are the point.
+   `set_reconstruction(false)` exposes the raw naive path for A/B or for
+   callers who want the rawer grit.
+4. **Hard (stepped) wave-scan** — `set_scan` selects the nearest table with
+   no interpolation and no slew, so crossing a table boundary is an
+   instantaneous step: the classic wavetable "zipper," faithfully
+   reproduced rather than smoothed away.
+5. **Short-table harmonic ceiling** — a length-`L` table represents at most
+   `L/2` harmonics, so low notes are intrinsically darker and high notes
+   fold, a direct consequence of playing the raw table.
+
+```cpp
+LofiWtOscillator lofi;
+lofi.prepare(sample_rate);
+lofi.set_tables(std::move(raw_tables), /*bit_depth=*/8);
+lofi.set_scan(0.5);   // hard select, no slew
+
+double sample = lofi.next(increment);
+```
+
+This engine ships no wavetable data of its own — you supply the raw
+table(s); it reproduces the *playback engine's* character, not any
+particular waveform's content.
+
+## Shared primitives
+
+Both VA and DCO (and therefore VCO, which builds on VA) are wiring over two
+lower-level headers most callers won't touch directly, but are worth
+knowing if you're building a new oscillator family on top of them.
+
+### `phase.hpp` — `PhaseAccumulator`
+
+A phase accumulator over the unit circle `[0, 1)` that reports every
+discontinuity ("event") crossed during an `advance()` — a phase wrap,
+either direction — or a forced `advance_synced()` reset — with the
+event's exact sub-sample position and its `phase_before`/`phase_after`
+endpoints. Negative increments run the phase backward (through-zero FM);
+any magnitude is accepted (multiple wraps per sample), bounded by
+`max_events_per_sample` (8) with a `truncated()` flag if exceeded — the
+phase itself always stays exact even when the event list is capped.
+Events compose: two events landing at the same sub-sample position simply
+sum, which is what makes combinations like "sync to 0 under a negative
+increment" (a sync event plus a backward wrap) come out correct without
+being enumerated as a special case.
+
+### `blep.hpp` — polyBLEP/polyBLAMP kernels
+
+The correction kernels VA (and everything built on it) uses to bandlimit a
+discontinuity: **BLEP** for a step in the *value* (a saw wrap, a square
+edge, a hard-sync reset), **BLAMP** for a break in the *slope* (a triangle
+apex — the value stays continuous, only the derivative jumps; BLAMP is
+BLEP's integral). Every kernel returns a correction to *add* to the trivial
+signal, split across the sample before and after the discontinuity
+(`Correction{before, after}`) — a generator needs to be able to reach back
+one sample to apply the `before` term. This is a two-point polynomial
+approximation of the ideal (infinite-support) BLEP, not a tabulated
+minBLEP: it buys tens of dB over the trivial waveform, not the ~100 dB a
+deep-floor design reaches.
+
+## RT contract
+
+Every family follows the same rule the rest of `pulp::signal` does:
+allocation happens at setup (`set_wavetable_set`, `set_tables`,
+`set_oversample_factor`, `prepare`) and must run off the audio thread;
+`next()`/`next_synced()`, `reset()`, and the per-sample setters allocate
+nothing, lock nothing, and perform no I/O. All classes compute in `double`
+throughout; a `float` caller narrows once on store. `vco.hpp`'s `exp`/`tanh`
+and `va.hpp`'s `sin` are libcalls but not allocations, locks, or I/O.

--- a/docs/guides/signal-processing.md
+++ b/docs/guides/signal-processing.md
@@ -202,6 +202,13 @@ buffer application, `reset()`, and accessors are real-time safe.
 
 ## 3. Oscillators
 
+This section covers only the legacy `signal::Oscillator` below. For the
+newer VA/VCO/DCO/wavetable suite (`pulp::signal::osc`, under
+`core/signal/include/pulp/signal/osc/`) — analog-modeled shapes, a
+divider-clocked DCO, and two wavetable tiers — see the
+[oscillators guide](oscillators.md). The two are separate, unrelated class
+families; prefer the suite for new work.
+
 ### Oscillator
 
 Band-limited oscillator with polyBLEP anti-aliasing. Supports sine, saw, square, and triangle waveforms.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -517,7 +517,8 @@ a working convolution and would hide the bug. Assert
 | ADSR | `adsr.hpp` | Attack-decay-sustain-release envelope generator for amplitude or filter modulation |
 | FFT | `fft.hpp` | Fast Fourier Transform — uses vDSP on Apple, fallback on other platforms |
 | Multi-Channel Meter | `multi_channel_meter.hpp` | Peak and RMS level measurement across multiple channels |
-| Oscillator | `oscillator.hpp` | Wavetable oscillator with sine, saw, square, triangle waveforms |
+| Oscillator | `oscillator.hpp` | Legacy polyBLEP oscillator with sine, saw, square, triangle waveforms (float phase, integrated triangle) |
+| Oscillator suite (`osc/`) | `osc/va.hpp`, `osc/vco.hpp`, `osc/dco.hpp`, `osc/wt.hpp`, `osc/wt_lofi.hpp` | Newer VA/VCO/DCO/wavetable family sharing a phase accumulator and BLEP/BLAMP kernels — see the [oscillators guide](../guides/oscillators.md) |
 | Spectrogram | `spectrogram.hpp` | Rolling time-frequency analysis for visual display of spectral content |
 | STFT | `stft.hpp` | Short-time Fourier Transform for visualization (analysis-only; for processing use `spectral_frame_engine.hpp`) |
 

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -199,6 +199,11 @@ docs:
     kind: guide
     summary: DSP algorithm reference — 20 processors with usage examples and parameter docs
 
+  - slug: oscillators
+    path: guides/oscillators.md
+    kind: guide
+    summary: The pulp::signal::osc oscillator suite — VA, VCO, DCO, and WT (modern + lo-fi tiers) over shared phase/BLEP primitives; distinct from the legacy signal::Oscillator
+
   - slug: examples
     path: guides/examples.md
     kind: guide

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -27,7 +27,7 @@ modules:
     docs: reference/modules.md#midi
 
   - name: signal
-    summary: 30+ DSP processors — filters (IIR, FIR, SVF, ladder, Linkwitz-Riley), oscillators, convolution, compressor, limiter, reverb, chorus, delay, oversampling, FFT (vDSP), SIMD ops, dry/wet mixer
+    summary: 30+ DSP processors — filters (IIR, FIR, SVF, ladder, Linkwitz-Riley), oscillators (legacy signal::Oscillator plus the pulp::signal::osc VA/VCO/DCO/WT suite), convolution, compressor, limiter, reverb, chorus, delay, oversampling, FFT (vDSP), SIMD ops, dry/wet mixer
     status: usable
     dependencies: []
     docs: reference/modules.md#signal

--- a/test/cmake/app_audio_host_tests.cmake
+++ b/test/cmake/app_audio_host_tests.cmake
@@ -183,6 +183,16 @@ target_link_libraries(pulp-test-wav-bridge PRIVATE pulp-audio-test-support Catch
 catch_discover_tests(pulp-test-wav-bridge)
 add_executable(pulp-osc-render-wav osc_render_wav.cpp)
 target_link_libraries(pulp-osc-render-wav PRIVATE pulp-audio-test-support)
+
+# CLI argv smoke for the tool above: shells out per --engine and for --seed,
+# asserting exit code + a non-empty WAV. See test_osc_render_wav_cli.cpp.
+add_executable(pulp-test-osc-render-wav-cli test_osc_render_wav_cli.cpp)
+target_link_libraries(pulp-test-osc-render-wav-cli PRIVATE
+    pulp::platform Catch2::Catch2WithMain)
+add_dependencies(pulp-test-osc-render-wav-cli pulp-osc-render-wav)
+target_compile_definitions(pulp-test-osc-render-wav-cli PRIVATE
+    PULP_OSC_RENDER_WAV_BINARY="$<TARGET_FILE:pulp-osc-render-wav>")
+catch_discover_tests(pulp-test-osc-render-wav-cli)
 if(PULP_HAS_VST3)
     # The VST3 sibling of the CLAP null above: same deterministic Processor,
     # same stimulus, driven through the real PulpVst3Processor::process()

--- a/test/cmake/benchmark_tests.cmake
+++ b/test/cmake/benchmark_tests.cmake
@@ -39,3 +39,19 @@ if(PULP_BENCHMARK AND TARGET pulp-render)
         catch_discover_tests(pulp-test-bench-integration)
     endif()
 endif()
+
+# ── Oscillator throughput benchmark ─────────────────────────────────────────
+#
+# Tooling-only, gated on PULP_BENCHMARK like the zero-copy benchmark above,
+# but deliberately does NOT require `pulp-render`/PULP_ENABLE_GPU: oscillator
+# `next()` throughput has nothing to do with the GPU pipeline, so this target
+# stays buildable with just `-DPULP_BENCHMARK=ON` (pulp::signal is
+# header-only and always present). ${choc_SOURCE_DIR} is named directly
+# rather than linking a Pulp target that re-exports it, mirroring
+# test/cmake/design_import_tool_cli_tests.cmake's pulp-test-import-design-tool.
+if(PULP_BENCHMARK)
+    pulp_add_test_suite(pulp-test-osc-bench
+        LIBRARIES pulp::signal
+        INCLUDE_DIRS ${choc_SOURCE_DIR}
+        LABELS "bench")
+endif()

--- a/test/osc_render_wav.cpp
+++ b/test/osc_render_wav.cpp
@@ -1,21 +1,30 @@
 // osc-render-wav — render an in-tree Pulp oscillator to a WAV file, so the
 // offline Python Quality Lab can analyze oscillator output without a plugin
-// bundle. It drives the in-tree `VcoOscillator` through a Processor and
-// HeadlessHost (RenderScenario), then writes the render with the shipped WAV
-// writer. Deterministic: identical arguments produce a byte-identical file.
+// bundle. It drives an in-tree oscillator engine (vco/dco/wt) through a
+// Processor and HeadlessHost (RenderScenario), then writes the render with
+// the shipped WAV writer. Deterministic: identical arguments produce a
+// byte-identical file.
 //
 // Usage:
-//   osc-render-wav --out PATH [--shape sine|saw|square|triangle]
+//   osc-render-wav --out PATH [--engine vco|dco|wt]
+//                  [--shape sine|saw|square|triangle]
 //                  [--freq HZ] [--sr HZ] [--dur-ms MS] [--channels N]
-//                  [--drift-cents C] [--jitter-cents C] [--bits float|int24]
+//                  [--drift-cents C] [--jitter-cents C] [--seed N]
+//                  [--bits float|int24]
 //
-// Defaults render a 250 ms 440 Hz sine at 48 kHz, mono, float32.
+// Defaults render a 250 ms 440 Hz sine at 48 kHz, mono, float32, through the
+// vco engine. --drift-cents/--jitter-cents/--seed apply only to vco (dco has
+// no drift/jitter — its imperfection is pitch quantization; wt has no noise
+// source at all); --shape does not apply to wt, which plays a fixed
+// wavetable set instead of a classical shape.
 
 #include "support/osc_wav_scenario.hpp"
 #include "support/wav_bridge.hpp"
 
 #include <pulp/audio/audio_file.hpp>
 
+#include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -23,13 +32,16 @@
 
 namespace {
 
+using pulp::test::audio::OscEngine;
 using pulp::test::audio::OscRenderSpec;
 
 void usage(const char* argv0) {
     std::fprintf(stderr,
-                 "usage: %s --out PATH [--shape sine|saw|square|triangle] "
+                 "usage: %s --out PATH [--engine vco|dco|wt] "
+                 "[--shape sine|saw|square|triangle] "
                  "[--freq HZ] [--sr HZ] [--dur-ms MS] [--channels N] "
-                 "[--drift-cents C] [--jitter-cents C] [--bits float|int24]\n",
+                 "[--drift-cents C] [--jitter-cents C] [--seed N] "
+                 "[--bits float|int24]\n",
                  argv0);
 }
 
@@ -49,6 +61,10 @@ int main(int argc, char** argv) {
     OscRenderSpec spec;
     std::string out_path;
     auto bit_depth = pulp::audio::WavBitDepth::Float32;
+    bool shape_given = false;
+    bool drift_given = false;
+    bool jitter_given = false;
+    bool seed_given = false;
 
     for (int i = 1; i < argc; ++i) {
         const char* arg = argv[i];
@@ -56,6 +72,16 @@ int main(int argc, char** argv) {
             const char* v = value_for(argc, argv, i, "--out");
             if (!v) return 2;
             out_path = v;
+        } else if (std::strcmp(arg, "--engine") == 0) {
+            const char* v = value_for(argc, argv, i, "--engine");
+            if (!v) return 2;
+            auto engine = pulp::test::audio::parse_engine(v);
+            if (!engine) {
+                std::fprintf(stderr, "osc-render-wav: unknown engine '%s' "
+                                     "(want vco, dco, or wt)\n", v);
+                return 2;
+            }
+            spec.engine = *engine;
         } else if (std::strcmp(arg, "--shape") == 0) {
             const char* v = value_for(argc, argv, i, "--shape");
             if (!v) return 2;
@@ -65,6 +91,7 @@ int main(int argc, char** argv) {
                 return 2;
             }
             spec.shape = *shape;
+            shape_given = true;
         } else if (std::strcmp(arg, "--freq") == 0) {
             const char* v = value_for(argc, argv, i, "--freq");
             if (!v) return 2;
@@ -85,10 +112,29 @@ int main(int argc, char** argv) {
             const char* v = value_for(argc, argv, i, "--drift-cents");
             if (!v) return 2;
             spec.drift_cents = std::atof(v);
+            drift_given = true;
         } else if (std::strcmp(arg, "--jitter-cents") == 0) {
             const char* v = value_for(argc, argv, i, "--jitter-cents");
             if (!v) return 2;
             spec.jitter_cents = std::atof(v);
+            jitter_given = true;
+        } else if (std::strcmp(arg, "--seed") == 0) {
+            const char* v = value_for(argc, argv, i, "--seed");
+            if (!v) return 2;
+            char* end = nullptr;
+            errno = 0;
+            const unsigned long long parsed = std::strtoull(v, &end, 10);
+            if (end == v || *end != '\0' || errno == ERANGE ||
+                parsed > pulp::test::audio::kOscMaxExactSeed) {
+                std::fprintf(stderr,
+                             "osc-render-wav: --seed must be an integer in "
+                             "[0, %llu] (exact in float32)\n",
+                             static_cast<unsigned long long>(
+                                 pulp::test::audio::kOscMaxExactSeed));
+                return 2;
+            }
+            spec.seed = static_cast<std::uint64_t>(parsed);
+            seed_given = true;
         } else if (std::strcmp(arg, "--bits") == 0) {
             const char* v = value_for(argc, argv, i, "--bits");
             if (!v) return 2;
@@ -121,6 +167,26 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "osc-render-wav: --channels must be >= 1\n");
         return 2;
     }
+    if (spec.engine != OscEngine::vco && (drift_given || jitter_given)) {
+        std::fprintf(stderr,
+                     "osc-render-wav: --drift-cents/--jitter-cents apply "
+                     "only to --engine vco (%s has no seeded pitch noise)\n",
+                     pulp::test::audio::engine_name(spec.engine));
+        return 2;
+    }
+    if (spec.engine != OscEngine::vco && seed_given) {
+        std::fprintf(stderr,
+                     "osc-render-wav: --seed applies only to --engine vco "
+                     "(%s has no noise seed)\n",
+                     pulp::test::audio::engine_name(spec.engine));
+        return 2;
+    }
+    if (spec.engine == OscEngine::wt && shape_given) {
+        std::fprintf(stderr,
+                     "osc-render-wav: --shape does not apply to --engine wt "
+                     "(it plays a fixed wavetable set)\n");
+        return 2;
+    }
 
     pulp::test::audio::ScenarioResult result;
     try {
@@ -136,10 +202,15 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::printf("wrote %s: shape=%s freq=%.4f Hz sr=%.1f frames=%zu "
+    // `wt` has no shape parameter — report "n/a" rather than the spec's
+    // unused default, which would misleadingly imply the render used it.
+    const char* shape_field = spec.engine == OscEngine::wt
+                                   ? "n/a"
+                                   : pulp::test::audio::shape_name(spec.shape);
+    std::printf("wrote %s: engine=%s shape=%s freq=%.4f Hz sr=%.1f frames=%zu "
                 "channels=%d bits=%s\n",
-                out_path.c_str(), pulp::test::audio::shape_name(spec.shape),
-                spec.frequency_hz, spec.sample_rate,
+                out_path.c_str(), pulp::test::audio::engine_name(spec.engine),
+                shape_field, spec.frequency_hz, spec.sample_rate,
                 result.output.num_samples(), spec.channels,
                 bit_depth == pulp::audio::WavBitDepth::Float32 ? "float"
                                                               : "int24");

--- a/test/support/osc_wav_scenario.cpp
+++ b/test/support/osc_wav_scenario.cpp
@@ -1,5 +1,5 @@
 // osc_wav_scenario.cpp — build a RenderScenario for the in-tree oscillator
-// source, plus the shape-name mapping the CLI tool and tests share.
+// engines, plus the shape/engine name mappings the CLI tool and tests share.
 
 #include "osc_wav_scenario.hpp"
 
@@ -8,17 +8,37 @@ namespace pulp::test::audio {
 using pulp::signal::osc::VaShape;
 
 RenderScenario make_oscillator_scenario(const OscRenderSpec& spec) {
-    RenderScenario scenario(create_osc_source);
+    pulp::format::ProcessorFactory factory = create_osc_source_vco;
+    switch (spec.engine) {
+        case OscEngine::vco: factory = create_osc_source_vco; break;
+        case OscEngine::dco: factory = create_osc_source_dco; break;
+        case OscEngine::wt:  factory = create_osc_source_wt;  break;
+    }
+
+    RenderScenario scenario(factory);
     scenario.name(spec.name)
         .sample_rate(spec.sample_rate)
         .block_size(spec.block_size)
         .channels(0, spec.channels)
         .duration_ms(spec.duration_ms)
-        .set_param(kOscFrequencyHz, static_cast<float>(spec.frequency_hz))
-        .set_param(kOscShape,
-                   static_cast<float>(static_cast<int>(spec.shape)))
-        .set_param(kOscDriftCents, static_cast<float>(spec.drift_cents))
-        .set_param(kOscJitterCents, static_cast<float>(spec.jitter_cents));
+        .set_param(kOscFrequencyHz, static_cast<float>(spec.frequency_hz));
+
+    // `wt` has no shape parameter — it plays its own (fixed) wavetable set.
+    if (spec.engine != OscEngine::wt) {
+        scenario.set_param(kOscShape,
+                            static_cast<float>(static_cast<int>(spec.shape)));
+    }
+
+    // Drift, jitter, and the noise seed are `vco`-only: `dco` has no noise
+    // (its imperfection is quantization, not drift) and `wt` has no noise
+    // source at all.
+    if (spec.engine == OscEngine::vco) {
+        scenario.set_param(kOscDriftCents, static_cast<float>(spec.drift_cents))
+            .set_param(kOscJitterCents, static_cast<float>(spec.jitter_cents));
+        if (spec.seed.has_value())
+            scenario.set_param(kOscSeed, static_cast<float>(*spec.seed));
+    }
+
     return scenario;
 }
 
@@ -36,6 +56,22 @@ const char* shape_name(VaShape shape) {
         case VaShape::saw: return "saw";
         case VaShape::square: return "square";
         case VaShape::triangle: return "triangle";
+    }
+    return "unknown";
+}
+
+std::optional<OscEngine> parse_engine(std::string_view name) {
+    if (name == "vco") return OscEngine::vco;
+    if (name == "dco") return OscEngine::dco;
+    if (name == "wt") return OscEngine::wt;
+    return std::nullopt;
+}
+
+const char* engine_name(OscEngine engine) {
+    switch (engine) {
+        case OscEngine::vco: return "vco";
+        case OscEngine::dco: return "dco";
+        case OscEngine::wt: return "wt";
     }
     return "unknown";
 }

--- a/test/support/osc_wav_scenario.hpp
+++ b/test/support/osc_wav_scenario.hpp
@@ -4,25 +4,40 @@
 /// Render an in-tree oscillator through RenderScenario, so the offline analysis
 /// lane can study it without a plugin bundle.
 ///
-/// `OscSourceProcessor` is a minimal instrument Processor that emits one
-/// `VcoOscillator` voice at a fixed frequency. Its configuration — frequency,
-/// shape, and the two seeded pitch-noise depths (drift / jitter) — flows in
+/// Three engines are selectable (`OscEngine`), each a minimal instrument
+/// Processor that emits one oscillator voice at a fixed frequency:
+///
+///   * `vco` (`VcoSourceProcessor`) — `VcoOscillator`, the circuit-flavored
+///     analog voice with seeded drift/jitter pitch noise.
+///   * `dco` (`DcoSourceProcessor`) — `DcoOscillator`, the divider-clocked
+///     voice with quantized (not drifting) pitch; no noise parameters.
+///   * `wt` (`WtSourceProcessor`) — `WtOscillator` over a single default
+///     bandlimited saw table; no shape/noise parameters, since a wavetable
+///     is smooth everywhere and this render never scans its (one-entry) set.
+///
+/// Their configuration — frequency, shape, the two seeded pitch-noise depths
+/// (drift / jitter, `vco` only), and the noise seed (`vco` only) — flows in
 /// through parameters, because a RenderScenario factory is a bare function
-/// pointer and cannot capture per-render state. The oscillator's noise seed is
-/// its deterministic default, so a given configuration renders bit-for-bit
-/// reproducibly (identical seed and inputs → identical output — the same
-/// contract the OSC-VCO suite gates), which is exactly what an offline
-/// drift/jitter analysis needs.
+/// pointer and cannot capture per-render state. `vco`'s noise seed defaults to
+/// the oscillator's built-in deterministic value (`OscRenderSpec::seed` unset,
+/// which reads back as parameter value 0 — see `kOscSeed` below), so a given
+/// configuration renders bit-for-bit reproducibly (identical seed and inputs →
+/// identical output — the same contract the OSC-VCO suite gates), which is
+/// exactly what an offline drift/jitter analysis needs.
 ///
 /// Test/tool layer only.
 
 #include "render_scenario.hpp"
 
 #include <pulp/format/processor.hpp>
+#include <pulp/signal/osc/dco.hpp>
 #include <pulp/signal/osc/va.hpp>
 #include <pulp/signal/osc/vco.hpp>
+#include <pulp/signal/osc/wt.hpp>
+#include <pulp/signal/wavetable.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -30,19 +45,33 @@
 
 namespace pulp::test::audio {
 
-/// Parameter ids for the in-tree oscillator source processor.
+/// Parameter ids for the in-tree oscillator source processors. Each engine's
+/// processor registers only the subset that applies to it (see the per-class
+/// `define_parameters()`); the ids are shared across engines purely to avoid
+/// three parallel enums; they never collide because each engine's Processor
+/// owns its own StateStore.
 enum OscSourceParam : pulp::state::ParamID {
-    kOscFrequencyHz = 1,  ///< Fundamental, Hz.
-    kOscShape = 2,        ///< 0=sine, 1=saw, 2=square, 3=triangle.
-    kOscDriftCents = 3,   ///< Slow drift depth, cents RMS (0 = off).
-    kOscJitterCents = 4,  ///< Per-sample jitter depth, cents RMS (0 = off).
+    kOscFrequencyHz = 1,  ///< Fundamental, Hz. All engines.
+    kOscShape = 2,        ///< 0=sine, 1=saw, 2=square, 3=triangle. vco/dco only.
+    kOscDriftCents = 3,   ///< Slow drift depth, cents RMS (0 = off). vco only.
+    kOscJitterCents = 4,  ///< Per-sample jitter depth, cents RMS (0 = off). vco only.
+    kOscSeed = 5,         ///< Noise seed, 0 = "no override". vco only.
 };
+
+/// `kOscSeed`'s upper bound: the largest integer a `float` (the StateStore's
+/// value type) represents exactly, `2^24 - 1`. A seed above this would lose
+/// precision round-tripping through the parameter, silently landing on a
+/// different (still deterministic, but not the requested) seed.
+inline constexpr std::uint64_t kOscMaxExactSeed = (std::uint64_t{1} << 24) - 1;
+
+/// The oscillator engine an `OscRenderSpec` renders through.
+enum class OscEngine { vco, dco, wt };
 
 /// A minimal instrument that plays one `VcoOscillator` at the frequency held in
 /// its parameters. No MIDI, no input — it just fills its output block with the
 /// oscillator's samples, so an in-tree oscillator can be rendered offline
 /// through HeadlessHost and captured to a WAV.
-class OscSourceProcessor : public pulp::format::Processor {
+class VcoSourceProcessor : public pulp::format::Processor {
 public:
     pulp::format::PluginDescriptor descriptor() const override {
         return {
@@ -67,6 +96,9 @@ public:
                              {0.0f, 1200.0f, 0.0f, 0.0f}});
         store.add_parameter({kOscJitterCents, "Jitter", "ct",
                              {0.0f, 1200.0f, 0.0f, 0.0f}});
+        store.add_parameter({kOscSeed, "Seed", "",
+                             {0.0f, static_cast<float>(kOscMaxExactSeed), 0.0f,
+                              1.0f}});
     }
 
     void prepare(const pulp::format::PrepareContext& ctx) override {
@@ -76,12 +108,27 @@ public:
         // shape; reset() also restarts the seeded noise streams, so the render
         // begins from a known, reproducible point.
         osc_.reset(kStartPhase);
+        seed_applied_ = false;
     }
 
     void process(pulp::audio::BufferView<float>& output,
                  const pulp::audio::BufferView<const float>&,
                  pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
                  const pulp::format::ProcessContext&) override {
+        // `set_param()` on the RenderScenario applies AFTER prepare(), so the
+        // seed override can only be read (and applied) once the first block
+        // starts — before this. Applying it once here, before any sample is
+        // generated, keeps the render fully seeded from the start; applying it
+        // every block would re-seed (and truncate) the noise streams
+        // repeatedly. A seed of 0 means "no override": the oscillator keeps
+        // the built-in deterministic seed set by reset() in prepare().
+        if (!seed_applied_) {
+            const float raw_seed = state().get_value(kOscSeed);
+            if (raw_seed > 0.0f)
+                osc_.set_seed(static_cast<std::uint64_t>(raw_seed));
+            seed_applied_ = true;
+        }
+
         const auto shape = static_cast<pulp::signal::osc::VaShape>(
             std::clamp(static_cast<int>(state().get_value(kOscShape)), 0, 3));
         osc_.set_shape(shape);
@@ -105,15 +152,161 @@ private:
 
     pulp::signal::osc::VcoOscillator osc_;
     double sample_rate_ = 48000.0;
+    bool seed_applied_ = false;
 };
 
-inline std::unique_ptr<pulp::format::Processor> create_osc_source() {
-    return std::make_unique<OscSourceProcessor>();
+inline std::unique_ptr<pulp::format::Processor> create_osc_source_vco() {
+    return std::make_unique<VcoSourceProcessor>();
+}
+
+/// A minimal instrument that plays one `DcoOscillator` at the frequency held in
+/// its parameters. Unlike the VCO engine, a DCO has no drift/jitter — its
+/// characteristic imperfection is pitch quantization from a fixed master
+/// clock — so it exposes only frequency and shape.
+class DcoSourceProcessor : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "OscSourceDco",
+            .manufacturer = "Pulp",
+            .bundle_id = "com.pulp.test.osc-source-dco",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Instrument,
+            .input_buses = {},
+            .output_buses = {{"Audio Out", 1}},
+            .accepts_midi = false,
+            .produces_midi = false,
+            .tail_samples = 0,
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({kOscFrequencyHz, "Frequency", "Hz",
+                             {1.0f, 40000.0f, 440.0f, 0.0f}});
+        store.add_parameter({kOscShape, "Shape", "", {0.0f, 3.0f, 0.0f, 1.0f}});
+    }
+
+    void prepare(const pulp::format::PrepareContext& ctx) override {
+        sample_rate_ = ctx.sample_rate > 0.0 ? ctx.sample_rate : sample_rate_;
+        pulp::signal::osc::DcoProfile profile;
+        profile.master_clock_hz = kMasterClockHz;
+        profile.divider_scheme = pulp::signal::osc::DcoDivider::integer_n;
+        osc_.set_profile(profile);
+        osc_.prepare(sample_rate_);
+        // Same clean-start convention as the VCO engine; a DCO reset carries
+        // no seeded state (there is none), just phase and the divider
+        // schedule.
+        osc_.reset(kStartPhase);
+        last_note_hz_ = -1.0;
+    }
+
+    void process(pulp::audio::BufferView<float>& output,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {
+        const auto shape = static_cast<pulp::signal::osc::VaShape>(
+            std::clamp(static_cast<int>(state().get_value(kOscShape)), 0, 3));
+        osc_.set_shape(shape);
+
+        // `set_note_hz()` re-derives the divider and calls `reset(phase())`,
+        // which drops any in-flight discontinuity correction — harmless once,
+        // but calling it every block for an unchanged note would do that
+        // needlessly on every block boundary. Guard on an actual change.
+        const double frequency = state().get_value(kOscFrequencyHz);
+        if (frequency != last_note_hz_) {
+            osc_.set_note_hz(frequency);
+            last_note_hz_ = frequency;
+        }
+
+        for (std::size_t i = 0; i < output.num_samples(); ++i) {
+            const auto sample = static_cast<float>(osc_.next());
+            for (std::size_t ch = 0; ch < output.num_channels(); ++ch)
+                output.channel(ch)[i] = sample;
+        }
+    }
+
+private:
+    /// 1 MHz: a plausible mid-range DCO master clock, giving a small,
+    /// audible-if-you-look-for-it quantization error at the top of the
+    /// keyboard rather than an unrealistically fine (or coarse) one.
+    static constexpr double kMasterClockHz = 1'000'000.0;
+    static constexpr double kStartPhase = 0.13;
+
+    pulp::signal::osc::DcoOscillator osc_;
+    double sample_rate_ = 48000.0;
+    double last_note_hz_ = -1.0;
+};
+
+inline std::unique_ptr<pulp::format::Processor> create_osc_source_dco() {
+    return std::make_unique<DcoSourceProcessor>();
+}
+
+/// A minimal instrument that plays one `WtOscillator` over a single default
+/// bandlimited saw table. No shape parameter (a wavetable set replaces the
+/// classical-shape switch) and no drift/jitter (the wavetable engine has no
+/// noise source).
+class WtSourceProcessor : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "OscSourceWt",
+            .manufacturer = "Pulp",
+            .bundle_id = "com.pulp.test.osc-source-wt",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Instrument,
+            .input_buses = {},
+            .output_buses = {{"Audio Out", 1}},
+            .accepts_midi = false,
+            .produces_midi = false,
+            .tail_samples = 0,
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({kOscFrequencyHz, "Frequency", "Hz",
+                             {1.0f, 40000.0f, 440.0f, 0.0f}});
+    }
+
+    void prepare(const pulp::format::PrepareContext& ctx) override {
+        sample_rate_ = ctx.sample_rate > 0.0 ? ctx.sample_rate : sample_rate_;
+        // A one-entry table set: this render is a single fixed-shape voice,
+        // so the scan position (left at its default, 0) never moves off the
+        // only table in the set. `WavetableBankT`'s single-table fast path
+        // then makes this equivalent to playing one `WavetableT` directly.
+        osc_.set_wavetable_set({pulp::signal::Wavetable64::make_saw(
+            /*bands=*/10, /*table_length=*/2048,
+            static_cast<double>(sample_rate_))});
+        osc_.prepare(sample_rate_);
+        osc_.reset();
+    }
+
+    void process(pulp::audio::BufferView<float>& output,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {
+        const double frequency = state().get_value(kOscFrequencyHz);
+        const double increment = frequency / sample_rate_;
+
+        for (std::size_t i = 0; i < output.num_samples(); ++i) {
+            const auto sample = static_cast<float>(osc_.next(increment));
+            for (std::size_t ch = 0; ch < output.num_channels(); ++ch)
+                output.channel(ch)[i] = sample;
+        }
+    }
+
+private:
+    pulp::signal::osc::WtOscillator osc_;
+    double sample_rate_ = 48000.0;
+};
+
+inline std::unique_ptr<pulp::format::Processor> create_osc_source_wt() {
+    return std::make_unique<WtSourceProcessor>();
 }
 
 /// One named oscillator render request. Field defaults render a quarter-second
-/// 440 Hz sine at 48 kHz, mono.
+/// 440 Hz sine at 48 kHz, mono, through the `vco` engine.
 struct OscRenderSpec {
+    OscEngine engine = OscEngine::vco;
     pulp::signal::osc::VaShape shape = pulp::signal::osc::VaShape::sine;
     double frequency_hz = 440.0;
     double sample_rate = 48000.0;
@@ -122,6 +315,11 @@ struct OscRenderSpec {
     double duration_ms = 250.0;
     double drift_cents = 0.0;
     double jitter_cents = 0.0;
+    /// Noise seed override, `vco` engine only. Unset (the default) renders
+    /// with the oscillator's built-in deterministic seed — the same output
+    /// as before this field existed. Values above `kOscMaxExactSeed` lose
+    /// precision round-tripping through the (float) StateStore parameter.
+    std::optional<std::uint64_t> seed;
     std::string name = "osc";
 };
 
@@ -133,5 +331,11 @@ std::optional<pulp::signal::osc::VaShape> parse_shape(std::string_view name);
 
 /// Canonical lowercase name for a shape ("sine"/"saw"/"square"/"triangle").
 const char* shape_name(pulp::signal::osc::VaShape shape);
+
+/// Parse an engine name ("vco"/"dco"/"wt"); std::nullopt on an unknown name.
+std::optional<OscEngine> parse_engine(std::string_view name);
+
+/// Canonical lowercase name for an engine ("vco"/"dco"/"wt").
+const char* engine_name(OscEngine engine);
 
 } // namespace pulp::test::audio

--- a/test/test_osc_bench.cpp
+++ b/test/test_osc_bench.cpp
@@ -1,0 +1,269 @@
+// Oscillator per-sample throughput bench (osc corpus + perf rig, WP-0
+// leftovers). ADVISORY ONLY — per governing decision D8, this NEVER fails the
+// build: the only thing asserted is that a bench_diff-compatible JSON got
+// written, never a performance threshold. A regression here is meant to be
+// read by a human (or `tools/scripts/bench_diff.py`) diffing a baseline
+// capture against a current one, not to redden CI.
+//
+// Mirrors `test_bench_perf_counters.cpp`'s PULP_BENCHMARK gating
+// (test/cmake/benchmark_tests.cmake) and the zero-copy JSON schema
+// `examples/ui-preview/main.cpp`'s --benchmark-seconds mode emits, which
+// `tools/scripts/bench_diff.py` already knows how to diff
+// (host/date/pulp_commit/platform/widget/seconds/samples/per_frame_us/
+// per_frame_bytes/frame_budget_us/memory_bandwidth_fraction). This target
+// reuses that exact schema rather than inventing a new one — "per_frame_us"
+// here holds the average per-*call* time of each oscillator's `next()`
+// rather than a literal render-frame duration, since the metric of interest
+// is raw throughput, not a frame budget.
+//
+// Measures the VA / VCO / DCO / WT oscillator engines
+// (core/signal/include/pulp/signal/osc/{va,vco,dco,wt}.hpp). Deliberately
+// does NOT link pulp::render (unlike the zero-copy perf-counter test) —
+// oscillator throughput has nothing to do with the GPU pipeline, so this
+// target only needs pulp::signal (header-only) and stays buildable with
+// PULP_BENCHMARK=ON regardless of PULP_ENABLE_GPU.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/signal/osc/dco.hpp>
+#include <pulp/signal/osc/va.hpp>
+#include <pulp/signal/osc/vco.hpp>
+#include <pulp/signal/osc/wt.hpp>
+#include <pulp/signal/wavetable.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+using pulp::signal::Wavetable64;
+using pulp::signal::osc::DcoDivider;
+using pulp::signal::osc::DcoOscillator;
+using pulp::signal::osc::DcoProfile;
+using pulp::signal::osc::VaOscillator;
+using pulp::signal::osc::VaShape;
+using pulp::signal::osc::VcoOscillator;
+using pulp::signal::osc::WtOscillator;
+
+namespace {
+
+constexpr double kSampleRate = 48000.0;
+constexpr double kNoteHz = 220.0;
+constexpr int kWarmupSamples = 4096;
+// Enough calls that the measured average isn't dominated by timer
+// resolution, while keeping the whole TEST_CASE well under a second even
+// on a Debug build (the self-hosted mac CI lane builds Debug on purpose —
+// see the shipyard-debug-lane-catches-odr memory).
+constexpr int kNumSamples = 200'000;
+
+double now_us() {
+    return std::chrono::duration<double, std::micro>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+// Times `kNumSamples` calls to `step(i)` after a warm-up pass (so the
+// first-call cost — branch prediction, cache fill — doesn't dominate the
+// measured average) and returns the average per-call time in microseconds.
+template <typename Step>
+double time_per_sample_us(Step&& step) {
+    volatile double sink = 0.0;
+    for (int i = 0; i < kWarmupSamples; ++i) sink += step(i);
+    const double t0 = now_us();
+    for (int i = 0; i < kNumSamples; ++i) sink += step(i);
+    const double elapsed_us = now_us() - t0;
+    (void)sink;  // keep the loop from being optimized away
+    return elapsed_us / static_cast<double>(kNumSamples);
+}
+
+// A saw OSC-WT with the engine's default band count, mirroring
+// test_osc_wt.cpp's make_saw_osc() fixture.
+WtOscillator make_wt_osc() {
+    std::vector<Wavetable64> tables;
+    tables.push_back(Wavetable64::make_saw(10, 2048, kSampleRate));
+    WtOscillator osc;
+    osc.set_wavetable_set(std::move(tables));
+    osc.prepare(kSampleRate);
+    osc.reset();
+    return osc;
+}
+
+std::string current_platform_tag() {
+#if defined(__APPLE__)
+#if defined(__aarch64__)
+    return "darwin-arm64";
+#else
+    return "darwin-x86_64";
+#endif
+#elif defined(_WIN32)
+#if defined(_M_ARM64)
+    return "windows-arm64";
+#else
+    return "windows-x86_64";
+#endif
+#elif defined(__linux__)
+#if defined(__aarch64__)
+    return "linux-arm64";
+#else
+    return "linux-x86_64";
+#endif
+#else
+    return "unknown";
+#endif
+}
+
+std::string current_host_short() {
+#if defined(_WIN32)
+    char buf[256] = {0};
+    DWORD len = sizeof(buf);
+    if (::GetComputerNameA(buf, &len)) return std::string(buf);
+#else
+    char buf[256] = {0};
+    if (::gethostname(buf, sizeof(buf) - 1) == 0) {
+        std::string nodename = buf;
+        auto dot = nodename.find('.');
+        if (dot != std::string::npos) nodename.resize(dot);
+        return nodename;
+    }
+#endif
+    return "unknown";
+}
+
+std::string current_iso8601_utc() {
+    const auto now = std::chrono::system_clock::now();
+    const auto tt = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_utc{};
+#if defined(_WIN32)
+    gmtime_s(&tm_utc, &tt);
+#else
+    gmtime_r(&tt, &tm_utc);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+    return buf;
+}
+
+// Best-effort `git rev-parse --short HEAD`. Advisory only: a detached
+// tarball or missing git yields "unknown" rather than failing the bench.
+std::string current_short_sha() {
+#if defined(_WIN32)
+    std::FILE* pipe = ::_popen("git rev-parse --short HEAD 2>NUL", "r");
+#else
+    std::FILE* pipe = ::popen("git rev-parse --short HEAD 2>/dev/null", "r");
+#endif
+    if (!pipe) return "unknown";
+    char buf[64] = {0};
+    std::string out;
+    while (std::fgets(buf, sizeof(buf), pipe) != nullptr) out += buf;
+#if defined(_WIN32)
+    ::_pclose(pipe);
+#else
+    ::pclose(pipe);
+#endif
+    while (!out.empty() && (out.back() == '\n' || out.back() == '\r' || out.back() == ' ')) {
+        out.pop_back();
+    }
+    return out.empty() ? std::string("unknown") : out;
+}
+
+std::filesystem::path output_path() {
+    if (const char* env = std::getenv("PULP_OSC_BENCH_OUTPUT"); env && *env) {
+        return std::filesystem::path(env);
+    }
+    return std::filesystem::path("osc-bench-result.json");
+}
+
+}  // namespace
+
+TEST_CASE("Oscillator next() throughput emits a bench_diff-compatible JSON",
+          "[bench][osc]") {
+    const double increment = kNoteHz / kSampleRate;
+
+    VaOscillator va;
+    va.set_shape(VaShape::saw);
+    va.reset(0.0);
+    const double va_us = time_per_sample_us([&](int) { return va.next(increment); });
+
+    VcoOscillator vco;
+    vco.prepare(kSampleRate);
+    vco.set_shape(VaShape::saw);
+    vco.reset(0.0);
+    const double vco_us = time_per_sample_us([&](int) { return vco.next(increment); });
+
+    // DcoOscillator::next() takes NO argument — unlike VA/VCO/WT, it holds
+    // its own note/divider state (set via set_note_hz/set_profile) rather
+    // than taking a per-sample phase increment.
+    DcoOscillator dco;
+    DcoProfile profile;
+    profile.master_clock_hz = 8'000'000.0;
+    profile.divider_scheme = DcoDivider::integer_n;
+    dco.prepare(kSampleRate);
+    dco.set_profile(profile);
+    dco.set_shape(VaShape::saw);
+    dco.set_note_hz(kNoteHz);
+    dco.reset(0.0);
+    const double dco_us = time_per_sample_us([&](int) { return dco.next(); });
+
+    WtOscillator wt = make_wt_osc();
+    const double wt_us = time_per_sample_us([&](int) { return wt.next(increment); });
+
+    INFO("va_next_us=" << va_us << " vco_next_us=" << vco_us
+                        << " dco_next_us=" << dco_us << " wt_next_us=" << wt_us);
+
+    // Sanity only — never a performance gate. A next() call that measured
+    // as literally free (<= 0us) would mean the timing loop itself is
+    // broken, which IS worth catching; a slow call is not.
+    REQUIRE(va_us >= 0.0);
+    REQUIRE(vco_us >= 0.0);
+    REQUIRE(dco_us >= 0.0);
+    REQUIRE(wt_us >= 0.0);
+
+    auto per_frame_us = choc::value::createObject("");
+    per_frame_us.addMember("va_next_us", va_us);
+    per_frame_us.addMember("vco_next_us", vco_us);
+    per_frame_us.addMember("dco_next_us", dco_us);
+    per_frame_us.addMember("wt_next_us", wt_us);
+
+    auto root = choc::value::createObject("");
+    root.addMember("host", current_host_short());
+    root.addMember("date", current_iso8601_utc());
+    root.addMember("pulp_commit", current_short_sha());
+    root.addMember("platform", current_platform_tag());
+    root.addMember("widget", std::string("osc-bench"));
+    root.addMember("seconds", static_cast<int64_t>(0));  // not frame-paced; see file header
+    root.addMember("samples", static_cast<int64_t>(kNumSamples));
+    root.addMember("per_frame_us", per_frame_us);
+    // No per_frame_bytes / memory_bandwidth_fraction: an oscillator's
+    // next() moves no GPU/CPU bytes, so those fields are intentionally
+    // omitted rather than reported as a misleading zero. bench_diff.py
+    // already treats both as optional ("(not reported)").
+
+    const auto json_str = choc::json::toString(root, /*pretty=*/true);
+
+    const auto out_path = output_path();
+    if (out_path.has_parent_path()) {
+        std::filesystem::create_directories(out_path.parent_path());
+    }
+    std::ofstream out(out_path);
+    REQUIRE(out.is_open());
+    out << json_str << "\n";
+    out.close();
+
+    std::cout << "[osc-bench] wrote " << out_path.string() << "\n" << json_str << "\n";
+
+    REQUIRE(std::filesystem::exists(out_path));
+}

--- a/test/test_osc_render_wav_cli.cpp
+++ b/test/test_osc_render_wav_cli.cpp
@@ -1,0 +1,114 @@
+// osc-render-wav CLI smoke: shells out to the built tool and asserts exit
+// code 0 plus a non-empty WAV, once per `--engine` value and once for
+// `--seed`. The bridge library (osc_wav_scenario.*) already has API-level
+// coverage in test_wav_bridge.cpp and the Python quality-lab bridge test;
+// this exercises the argv surface those two do not reach — per CLAUDE.md's
+// "CLI behavior changes" testing rule (shell out, assert exit code).
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/child_process.hpp>
+
+#include "test_cli_shellout_util.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path tool_binary() {
+#if defined(PULP_OSC_RENDER_WAV_BINARY)
+    return fs::path(PULP_OSC_RENDER_WAV_BINARY);
+#else
+    return {};
+#endif
+}
+
+struct TempFile {
+    fs::path path;
+    explicit TempFile(const std::string& name) {
+        path = fs::temp_directory_path() /
+               (name + "-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch()
+                                   .count()) +
+                ".wav");
+    }
+    ~TempFile() {
+        std::error_code ec;
+        fs::remove(path, ec);
+    }
+};
+
+pulp::platform::ProcessResult run_tool(const std::vector<std::string>& args) {
+    pulp::platform::ProcessOptions options;
+    // Same shared hang-guard other CLI shell-out suites use; see
+    // test_cli_shellout_util.hpp — a real render here takes milliseconds.
+    options.timeout_ms = pulp_test_cli::shellout_timeout_ms();
+    return pulp::platform::ChildProcess::run(tool_binary().string(), args, options);
+}
+
+}  // namespace
+
+TEST_CASE("osc-render-wav writes a non-empty WAV for every --engine",
+          "[cli][osc-render-wav]") {
+    if (tool_binary().empty()) {
+        SUCCEED("pulp-osc-render-wav not built");
+        return;
+    }
+
+    for (const std::string& engine : {"vco", "dco", "wt"}) {
+        TempFile out("osc-engine-" + engine);
+        const auto result =
+            run_tool({"--out", out.path.string(), "--engine", engine,
+                      "--dur-ms", "10"});
+        INFO("engine=" << engine << " stdout=" << result.stdout_output
+                        << " stderr=" << result.stderr_output);
+        REQUIRE(result.exit_code == 0);
+
+        std::error_code ec;
+        REQUIRE(fs::exists(out.path, ec));
+        REQUIRE(fs::file_size(out.path, ec) > 0);
+    }
+}
+
+TEST_CASE("osc-render-wav writes a non-empty WAV with --seed",
+          "[cli][osc-render-wav]") {
+    if (tool_binary().empty()) {
+        SUCCEED("pulp-osc-render-wav not built");
+        return;
+    }
+
+    TempFile out("osc-seed");
+    const auto result =
+        run_tool({"--out", out.path.string(), "--engine", "vco",
+                  "--jitter-cents", "10", "--seed", "42", "--dur-ms", "10"});
+    INFO("stdout=" << result.stdout_output
+                    << " stderr=" << result.stderr_output);
+    REQUIRE(result.exit_code == 0);
+
+    std::error_code ec;
+    REQUIRE(fs::exists(out.path, ec));
+    REQUIRE(fs::file_size(out.path, ec) > 0);
+}
+
+TEST_CASE("osc-render-wav rejects --seed on a non-vco engine",
+          "[cli][osc-render-wav]") {
+    if (tool_binary().empty()) {
+        SUCCEED("pulp-osc-render-wav not built");
+        return;
+    }
+
+    TempFile out("osc-seed-rejected");
+    const auto result =
+        run_tool({"--out", out.path.string(), "--engine", "dco", "--seed",
+                  "42"});
+    REQUIRE(result.exit_code == 2);
+    REQUIRE_FALSE(result.stderr_output.empty());
+
+    std::error_code ec;
+    REQUIRE_FALSE(fs::exists(out.path, ec));
+}

--- a/tools/audio/quality-lab/corpus/MANIFEST.json
+++ b/tools/audio/quality-lab/corpus/MANIFEST.json
@@ -17,6 +17,81 @@
       }
     },
     {
+      "name": "synthetic_osc_static_shapes",
+      "kind": "generator",
+      "generator": "osc_static_shapes",
+      "material_class": "synth",
+      "license": "synthetic",
+      "expected_artifacts": "added HF / alias energy on a static bandlimited render",
+      "family": "oscillator",
+      "params": {
+        "sr": 48000,
+        "dur_s": 0.4,
+        "shapes": [
+          "sine",
+          "saw",
+          "square",
+          "triangle"
+        ],
+        "pitches": [
+          110.0,
+          440.0,
+          1760.0
+        ],
+        "gap_s": 0.05
+      }
+    },
+    {
+      "name": "synthetic_osc_sync_sweep",
+      "kind": "generator",
+      "generator": "osc_sync_sweep",
+      "material_class": "synth",
+      "license": "synthetic",
+      "expected_artifacts": "reset-seam artifacts swept across the hard-sync range",
+      "family": "oscillator",
+      "params": {
+        "sr": 48000,
+        "dur_s": 0.3,
+        "f_master_list": [
+          110.0,
+          220.0,
+          440.0,
+          880.0
+        ],
+        "f_slave_ratio": 2.5,
+        "gap_s": 0.05
+      }
+    },
+    {
+      "name": "synthetic_osc_tzfm_grid",
+      "kind": "generator",
+      "generator": "osc_tzfm_grid",
+      "material_class": "synth",
+      "license": "synthetic",
+      "expected_artifacts": "through-zero FM sideband aliasing across a mod-rate/index grid",
+      "family": "oscillator",
+      "params": {
+        "sr": 48000,
+        "dur_s": 0.3,
+        "f_carrier": 220.0,
+        "mod_grid": [
+          [
+            55.0,
+            2.0
+          ],
+          [
+            110.0,
+            4.0
+          ],
+          [
+            27.5,
+            6.0
+          ]
+        ],
+        "gap_s": 0.05
+      }
+    },
+    {
       "name": "synthetic_tonalpad",
       "kind": "generator",
       "generator": "tonal_pad",

--- a/tools/audio/quality-lab/quality_lab/cli.py
+++ b/tools/audio/quality-lab/quality_lab/cli.py
@@ -190,6 +190,67 @@ def _cmd_compare(args: argparse.Namespace) -> int:
     return 2 if report["verdict"] == compare.VERDICT_INVALID else 0
 
 
+def _cmd_fit(args: argparse.Namespace) -> int:
+    """WP-4 F1 — fit an OSC-VCO profile from a measurement kit (Quality-Lab lane).
+
+    Demonstrates Gate 1 end-to-end: render a kit from a known profile, then recover
+    the deterministic parameters and report each with its confidence interval and
+    the measurement that produced it. Pinned (stage-2 drift/jitter) rows are
+    labeled, never presented as measured.
+    """
+    import math
+    from . import fit as fitmod
+    from .osc_forward import Shape, VcoProfile, VcoTuning, WaveshaperParams
+
+    true = VcoProfile()
+    true.tuning = VcoTuning(tune_offset_cents=7.0, scale_error=1.0025,
+                            hf_compression=0.03, hf_knee_octaves=3.0)
+    true.bow = 2.5
+    true.shapers[Shape.triangle] = WaveshaperParams(amount=0.7, drive=2.2, asymmetry=0.35)
+    true.level_tilt_db_per_octave = 2.5
+    true.core_reset_seconds = 3.0e-6
+    true.ac_corner_hz = 8.0
+    true.pulse_width = 0.42
+
+    kit = fitmod.build_measurement_kit(true)
+    fitted = fitmod.fit_profile(kit, VcoProfile(),
+                                pinned={"drift_depth": 4.0, "jitter_depth": 0.5})
+
+    truth = {
+        "tune_offset_cents": true.tuning.tune_offset_cents,
+        "scale_error": true.tuning.scale_error,
+        "hf_compression": true.tuning.hf_compression,
+        "hf_knee_octaves": true.tuning.hf_knee_octaves,
+        "bow": true.bow,
+        "shaper_triangle_amount": true.shapers[Shape.triangle].amount,
+        "shaper_triangle_drive": true.shapers[Shape.triangle].drive,
+        "shaper_triangle_asymmetry": true.shapers[Shape.triangle].asymmetry,
+        "ac_corner_hz": true.ac_corner_hz,
+        "level_tilt_db_per_octave": true.level_tilt_db_per_octave,
+        "core_reset_seconds": true.core_reset_seconds,
+        "pulse_width": true.pulse_width,
+    }
+    print("[quality-lab fit] F1 synthetic round-trip (Gate 1) — stages 1, 3, 4, 5")
+    print(f"  {'parameter':30s} {'disposition':11s} {'estimate':>13s} {'known':>13s}")
+    for p in fitted.params:
+        known = truth.get(p.name)
+        known_s = f"{known:13.6g}" if known is not None else f"{'(deferred)':>13s}"
+        print(f"  {p.name:30s} {p.disposition:11s} {p.estimate:13.6g} {known_s}  "
+              f"[{p.stage}] {p.measurement}")
+
+    # Pitch curve recovery (the doc's ±1-cent tolerance is on the curve, not raw params).
+    rp = fitted.to_profile()
+    cents = max(abs(1200.0 * math.log2(rp.tuning.frequency_hz(v) / true.tuning.frequency_hz(v)))
+                for v in [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.5])
+    print(f"  pitch curve max error: {cents:.3f} cents (tolerance 1.0)")
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(fitted.to_dict(), fh, indent=2)
+        print(f"  wrote fitted profile -> {args.out}")
+    return 0
+
+
 def _cmd_regression_net(args: argparse.Namespace) -> int:
     from . import compare, regression_net
     try:
@@ -317,6 +378,13 @@ def main(argv: list[str] | None = None) -> int:
                       help="materiality threshold override (defaults to the axis's own default)")
     cmp_.add_argument("--json", default="", help="write the full report JSON to this path")
     cmp_.set_defaults(func=_cmd_compare)
+
+    ft = sub.add_parser(
+        "fit",
+        help="WP-4 F1: fit an OSC-VCO profile from a measurement kit (synthetic "
+             "round-trip demo; recovers the deterministic parameters, labels pinned rows)")
+    ft.add_argument("--out", default="", help="write the fitted profile JSON to this path")
+    ft.set_defaults(func=_cmd_fit)
 
     rnet = sub.add_parser(
         "regression-net",

--- a/tools/audio/quality-lab/quality_lab/corpus.py
+++ b/tools/audio/quality-lab/quality_lab/corpus.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from typing import Any
 
-from . import audio_io, generate, provenance
+from . import audio_io, generate, osc_fixtures, provenance
 
 # Permissive licenses allowed in the committed corpus (plus the synthetic marker).
 PERMISSIVE_LICENSES = {
@@ -121,6 +121,16 @@ _GENERATORS = {
         int(p.get("sr", 48000)), p.get("bpm", 120.0), p.get("ratio", 1.0), int(p.get("seed", 0)))[0],
     "tonal_pad": lambda p: generate.render_tonal(
         int(p.get("sr", 48000)), p.get("dur_s", 2.5), int(p.get("seed", 0)))[0],
+    "osc_static_shapes": lambda p: osc_fixtures.render_static_shapes(
+        int(p.get("sr", 48000)), p.get("dur_s", 0.4), p.get("pitches", [110.0, 440.0, 1760.0]),
+        p.get("shapes"), p.get("gap_s", 0.05)),
+    "osc_sync_sweep": lambda p: osc_fixtures.render_sync_sweep(
+        int(p.get("sr", 48000)), p.get("dur_s", 0.3),
+        p.get("f_master_list", [110.0, 220.0, 440.0, 880.0]),
+        p.get("f_slave_ratio", 2.5), p.get("gap_s", 0.05)),
+    "osc_tzfm_grid": lambda p: osc_fixtures.render_tzfm_grid(
+        int(p.get("sr", 48000)), p.get("dur_s", 0.3), p.get("f_carrier", 220.0),
+        p.get("mod_grid", [[55.0, 2.0], [110.0, 4.0], [27.5, 6.0]]), p.get("gap_s", 0.05)),
 }
 
 
@@ -146,8 +156,11 @@ def materialize(corpus_dir: str, name: str) -> str:
 
 
 def seed(corpus_dir: str | None = None) -> dict[str, Any]:
-    """Seed the committed corpus with the two synthetic families (regenerable, license-
-    clean) so it is never empty and the workflow is demonstrated."""
+    """Seed the committed corpus with the synthetic families (regenerable, license-
+    clean) so it is never empty and the workflow is demonstrated: two stretch-oriented
+    families (drum break, tonal pad) plus three oscillator families (static shapes,
+    hard-sync sweep, TZFM grid) that give the alias/HF regression axis oscillator
+    material to gate on, not just drum/tonal stimuli."""
     corpus_dir = corpus_dir or default_corpus_dir()
     register_generated(corpus_dir, name="synthetic_drumbreak", generator="drum_break",
                        material_class="percussive", family="time-stretch",
@@ -157,4 +170,22 @@ def seed(corpus_dir: str | None = None) -> dict[str, Any]:
                        material_class="tonal", family="tonal",
                        expected="graininess / dulling on sustained material",
                        params={"sr": 48000, "dur_s": 2.5, "seed": 0})
+    register_generated(corpus_dir, name="synthetic_osc_static_shapes", generator="osc_static_shapes",
+                       material_class="synth", family="oscillator",
+                       expected="added HF / alias energy on a static bandlimited render",
+                       params={"sr": 48000, "dur_s": 0.4,
+                               "shapes": ["sine", "saw", "square", "triangle"],
+                               "pitches": [110.0, 440.0, 1760.0], "gap_s": 0.05})
+    register_generated(corpus_dir, name="synthetic_osc_sync_sweep", generator="osc_sync_sweep",
+                       material_class="synth", family="oscillator",
+                       expected="reset-seam artifacts swept across the hard-sync range",
+                       params={"sr": 48000, "dur_s": 0.3,
+                               "f_master_list": [110.0, 220.0, 440.0, 880.0],
+                               "f_slave_ratio": 2.5, "gap_s": 0.05})
+    register_generated(corpus_dir, name="synthetic_osc_tzfm_grid", generator="osc_tzfm_grid",
+                       material_class="synth", family="oscillator",
+                       expected="through-zero FM sideband aliasing across a mod-rate/index grid",
+                       params={"sr": 48000, "dur_s": 0.3, "f_carrier": 220.0,
+                               "mod_grid": [[55.0, 2.0], [110.0, 4.0], [27.5, 6.0]],
+                               "gap_s": 0.05})
     return load_manifest(corpus_dir)

--- a/tools/audio/quality-lab/quality_lab/detectors/click.py
+++ b/tools/audio/quality-lab/quality_lab/detectors/click.py
@@ -110,10 +110,12 @@ than no gate. Each of these is measured by a test in `tests/test_click.py`:
   whose alias floor is -55 dB or lower, i.e. genuinely clean. This is NOT tunable away: a
   threshold high enough to pass the smear (-20 dB) blinds the detector to real -25 to
   -45 dB seams. So the detector detects the regime and REFUSES it instead — the smear is
-  not a localized outlier (its worst excursion barely exceeds the median per-period peak)
+  not a per-period NOVELTY outlier (aligned into period-synchronous frames, it repeats the
+  same shape every period, so it barely departs from the per-period median-frame template)
   and it rides the waveform's own edges, and both together separate it from a real seam
-  (localized) and from a block-rate zipper (off the edges). A refusal here is correct, not
-  a miss: on a real oscillator you HAVE a reference — render the same patch without the
+  (the one period that does NOT match the template — a large outlier) and from a block-rate
+  zipper (off the edges, and itself not a per-period outlier). A refusal here is correct,
+  not a miss: on a real oscillator you HAVE a reference — render the same patch without the
   defect — so the honest gate is `dsp.null_residual_db`, not the comb self-reference. See
   "Which detector to reach for".
 
@@ -123,18 +125,21 @@ SUBTRACTS the edge rather than thresholding around it, so the edge does not mask
 anything), and a hard-sync reset does not need special-casing — fitting the period
 finds the master period on its own.
 
-* **The edge-smear REFUSAL band is render-length dependent for seams close to the smear
-  floor.** `edge_concentration` is a global statistic, so the recurring smear dominates
-  it more as the period count grows: a seam only a few dB above a real BLEP oscillator's
-  smear floor can read localized (and FIRE) on a short clip yet smeared (and be REFUSED)
-  on a multi-second one. It is never a silent pass — a refusal is always `low_coverage`,
-  "not proven clean" — and a seam well clear of the smear floor fires at any length; only
-  the near-floor band moves. When gating a real oscillator at length, prefer the honest
-  frozen-reference `dsp.null_residual_db` (render the same patch without the defect) over
-  the comb self-reference, or analyze a shorter window. Making the refusal fully
-  length-independent needs a background-only, per-period-robust concentration that still
-  fires the near-floor seam the current tests pin — a discriminator redesign, tracked
-  separately, not a threshold tweak.
+* **The edge-smear refusal is render-length INDEPENDENT.** The smear-vs-seam decision keys
+  on `template_novelty_db`, a per-period RATIO (worst period's departure from the recurring
+  residual template over the median period's), so a longer render only adds more
+  template-matching periods — it moves neither the max nor the median, and the verdict is
+  the same at 0.3 s and 3.0 s. This replaced an earlier global `edge_concentration` /
+  `localization` statistic whose value drifted with the period count, so the SAME near-floor
+  seam could fire on a short clip and be refused on a multi-second one (the N3 length-
+  dependent-verdict bug). `edge_concentration` is still consulted, but only for the
+  smear-vs-zipper (on-edge vs off-edge) distinction, where it is stable with length. A
+  novelty-firing seam fires at any length; a below-smear-floor seam (novelty under the
+  threshold) is refused at any length — and a refusal is never a silent pass (it is always
+  `low_coverage`, "not proven clean"). The one axis that stays length-limited is a seam
+  quieter than the smear floor: the comb cannot see below the smear, so gate a real
+  oscillator at length with the frozen-reference `dsp.null_residual_db` (render the same
+  patch without the defect) when the seam may be below the floor.
 
 ## Which detector to reach for
 
@@ -190,6 +195,7 @@ from typing import NamedTuple
 
 import numpy as np
 
+from ..dsp import resample_to_length
 from ..schema import DetectorResult, WorstRegion
 
 TOLERANCE_CLASS = "click.v1"
@@ -233,18 +239,32 @@ _MULTIPLE_MARGIN = 6.0
 # EDGES, and the comb leaves a per-edge residual — approximation error, not a click — that
 # reads as a false -20 to -30 dB "click". Two measurements separate that smear from a real
 # one-off seam, and the detector refuses (rather than reports) when both hold:
-#   * localization — the worst residual excursion barely exceeds the MEDIAN per-period
-#     peak. A one-off seam has no predecessor and towers over the per-period background;
-#     smear recurs at every edge, so its worst excursion is not an outlier.
+#   * template novelty — the residual is aligned into per-period frames at the fitted
+#     fractional period (period-synchronous resample, then reshape), a robust per-period
+#     TEMPLATE is built (the median frame), and each period is scored by how far it departs
+#     from that template. A real BLEP oscillator repeats the SAME approximation-error shape
+#     every period, so the template captures it and every period departs from it only by
+#     noise; a one-off seam is the single period whose residual does NOT match the recurring
+#     template, so it is a large outlier in the template-subtracted domain. `template_novelty_db`
+#     is the worst period's departure over the MEDIAN period's departure, in dB. Crucially
+#     this is a per-period ratio — level-independent AND render-length-independent — which is
+#     what the earlier global `localization`/`edge_concentration` statistics were not: a global
+#     sum lets the recurring smear dominate more as the period count grows, so the SAME
+#     near-floor seam could fire on a short clip and be refused on a long one (the N3 bug this
+#     replaced). The per-period ratio yields the same verdict at any length.
 #   * edge concentration — the residual sits ON the waveform's own edges. Smear does; a
-#     block-rate zipper and a period-doubled defect do not (they recur off the edges).
+#     block-rate zipper and a period-doubled defect do not (they recur off the edges). This
+#     is what keeps a STATIONARY zipper — which, like the smear, is not a per-period outlier,
+#     so template novelty alone is blind to it (both are stationary churn) — from being
+#     wrongly refused as smear: a zipper rides no edge, so its edge concentration is low and
+#     the refusal does not apply.
 # Measured across the grid (pinned in `tests/test_click.py`): clean BLEP renders read a
-# localization <= 7 dB and an edge concentration >= 0.46, while a one-off seam reads a
-# localization >= 20 dB and a zipper / period-doubled defect an edge concentration <= 0.31.
-# The thresholds sit in the gap either side. A refusal here is correct — the honest gate
-# for a discontinuous real oscillator is the frozen-reference null (`dsp.null_residual_db`),
-# not the comb self-reference — and it is NOT a pass.
-_LOCALIZED_MARGIN_DB = 15.0
+# template novelty <= 4.5 dB at any length and an edge concentration >= 0.46, while a one-off
+# seam well above the smear floor reads a novelty >= 17 dB (unchanged across 0.3-3.0 s) and a
+# zipper an edge concentration <= 0.31. The thresholds sit in the gap either side. A refusal
+# here is correct — the honest gate for a discontinuous real oscillator is the frozen-reference
+# null (`dsp.null_residual_db`), not the comb self-reference — and it is NOT a pass.
+_TEMPLATE_NOVELTY_DB = 12.0
 _EDGE_CONCENTRATION = 0.40
 
 
@@ -258,8 +278,8 @@ class ClickAnalysis(NamedTuple):
     period_confidence: float  # normalized correlation one period on, 0..1
     period_drift: float       # relative period difference between the two halves
     residual: np.ndarray      # the band-limited comb residual
-    localization_db: float = 0.0     # worst excursion over the median per-period peak, dB
-    edge_concentration: float = 0.0  # residual's alignment with the waveform's own edges, 0..1
+    template_novelty_db: float = 0.0  # worst per-period departure from the residual template over the median, dB
+    edge_concentration: float = 0.0   # residual's alignment with the waveform's own edges, 0..1
 
 
 def _delay_kernel(frac: float, taps: int, beta: float) -> np.ndarray:
@@ -498,20 +518,66 @@ def measure_period_drift(y: np.ndarray, seed: float, guard: int) -> float:
     return max(spreads) if spreads else float("nan")
 
 
+def _template_novelty_db(residual: np.ndarray, period: float, guard: int) -> float:
+    """How much the WORST period's residual departs from the recurring per-period template,
+    over how much the MEDIAN period departs, in dB — the render-length-independent core of
+    the edge-smear refusal (see the module docstring and `_TEMPLATE_NOVELTY_DB`).
+
+    The construction: a real BLEP oscillator repeats the SAME approximation-error shape at
+    every edge, phase-advanced by the fractional period. So the interior residual is first
+    made period-synchronous — resampled by `round(P)/P` so one period occupies exactly
+    `round(P)` samples — and reshaped into per-period frames that line up sample-for-sample.
+    The median frame is a robust TEMPLATE of the recurring shape; subtracting it removes the
+    smear a real oscillator leaves every period, whatever its level. Each period's residual
+    energy AFTER template subtraction (`novelty`) is then near-zero for smear (every period
+    matches the template) and large for the one period a one-off seam lands in (it does not).
+
+    The reported value is `20*log10(max(novelty) / median(novelty))`: a per-period RATIO, so
+    it is invariant to the seam's absolute level AND to the render length (a longer render
+    adds more template-matching periods without moving either the max or the median). That is
+    the property the earlier global localization/edge-concentration statistics lacked — a
+    global sum lets the recurring smear dominate more as the period count grows, flipping a
+    near-floor seam's verdict with length (the N3 bug this replaced).
+
+    Returns +inf ("treat as an outlier, do not refuse on this axis") when there are too few
+    periods to build a stable template — matching the module's convention that an
+    unmeasurable guard withholds the refusal rather than asserting smear it never saw.
+    """
+    interior = residual[guard : len(residual) - guard]
+    m = int(round(period))
+    if len(interior) < 4 or m < 2:
+        return np.inf
+    # Period-synchronous: resample so each period spans exactly `m` samples, then the reshape
+    # aligns edges sample-for-sample and the median frame is a clean template of the smear.
+    target = int(round(len(interior) * m / period))
+    synchronous = resample_to_length(interior, target)
+    n_periods = len(synchronous) // m
+    if n_periods < 4:
+        return np.inf
+    frames = synchronous[: n_periods * m].reshape(n_periods, m)
+    template = np.median(frames, axis=0)
+    novelty = np.sqrt(np.mean((frames - template) ** 2, axis=1))  # per-period residual-of-residual
+    median = float(np.median(novelty))
+    worst = float(novelty.max())
+    return 20.0 * np.log10(worst / median) if median > 0.0 else np.inf
+
+
 def _edge_smear_signature(
     y: np.ndarray, residual: np.ndarray, period: float, guard: int
 ) -> tuple[float, float]:
     """The two numbers that tell a real one-off click from a BLEP oscillator's per-edge
-    approximation residual (see the module docstring and `_LOCALIZED_MARGIN_DB`).
+    approximation residual (see the module docstring and `_TEMPLATE_NOVELTY_DB`).
 
-    `localization_db` — the worst interior residual excursion over the MEDIAN per-period
-    peak, in dB. A one-off seam towers over the per-period background; a per-edge smear
-    recurs every period, so its worst barely exceeds the median. Infinite (i.e. "treat as
-    localized, do not refuse") when the interior is too short to establish a background.
+    `template_novelty_db` — the worst period's departure from the recurring residual template
+    over the median period's, in dB; see `_template_novelty_db`. A one-off seam is a large
+    outlier; a per-edge smear leaves every period close to the template. Render-length- and
+    level-independent by construction.
 
     `edge_concentration` — the cosine similarity in [0,1] between the interior |residual|
     and the waveform's own edge strength |diff(y)|. Smear rides the edges; a block-rate
-    zipper and a period-doubled defect land off them.
+    zipper and a period-doubled defect land off them. This is what keeps a stationary zipper
+    — which template novelty is blind to, for the same reason spectral flux is: it is churn,
+    not a per-period outlier — from being wrongly refused as smear.
     """
     interior = np.abs(residual[guard : len(residual) - guard])
     if not len(interior):
@@ -520,19 +586,12 @@ def _edge_smear_signature(
     if worst <= 0.0:
         return 0.0, 0.0
 
-    p = int(round(period))
-    n_periods = len(interior) // p if p >= 1 else 0
-    if n_periods >= 3:
-        per_peak = interior[: n_periods * p].reshape(n_periods, p).max(axis=1)
-        median = float(np.median(per_peak))
-        localization_db = 20.0 * np.log10(worst / median) if median > 0.0 else np.inf
-    else:
-        localization_db = np.inf
+    template_novelty_db = _template_novelty_db(residual, period, guard)
 
     edge = np.abs(np.diff(y, prepend=y[0]))[guard : len(residual) - guard][: len(interior)]
     denom = float(np.linalg.norm(interior) * np.linalg.norm(edge))
     edge_concentration = float(np.dot(interior, edge) / denom) if denom > 1e-30 else 0.0
-    return localization_db, edge_concentration
+    return template_novelty_db, edge_concentration
 
 
 def analyze(y: np.ndarray, sr: int, f0_hint: float | None = None) -> ClickAnalysis:
@@ -572,9 +631,9 @@ def analyze(y: np.ndarray, sr: int, f0_hint: float | None = None) -> ClickAnalys
     idx = int(np.argmax(np.abs(interior))) + guard
     worst = float(abs(residual[idx]))
     click_db = 20.0 * np.log10(worst / peak) if worst > 0 else -np.inf
-    localization_db, edge_concentration = _edge_smear_signature(y, residual, period, guard)
+    template_novelty_db, edge_concentration = _edge_smear_signature(y, residual, period, guard)
     return ClickAnalysis(click_db, idx / sr, period, confidence, drift, residual,
-                         localization_db, edge_concentration)
+                         template_novelty_db, edge_concentration)
 
 
 def detect(
@@ -584,7 +643,7 @@ def detect(
     fire_threshold_db: float = -45.0,
     min_period_confidence: float = 0.5,
     max_period_drift: float = 3e-5,
-    min_localized_db: float = _LOCALIZED_MARGIN_DB,
+    min_template_novelty_db: float = _TEMPLATE_NOVELTY_DB,
     max_edge_concentration: float = _EDGE_CONCENTRATION,
 ) -> DetectorResult:
     """Fire when `signal` contains a discontinuity its own period does not predict.
@@ -610,12 +669,14 @@ def detect(
       fixtures measure below 7e-6.
     * the reading is per-edge approximation smear, not a click. A real BLEP/BLIT
       oscillator at a fractional period leaves a -22 to -31 dB per-edge residual the comb
-      cannot null (see the module docstring). It is refused when the excursion is not a
-      localized outlier (`localization_db` below `min_localized_db`) AND rides the
-      waveform's own edges (`edge_concentration` above `max_edge_concentration`) — two
-      conditions that together separate it from a one-off seam (localized) and a
-      block-rate zipper (off the edges). The honest gate for that regime is a
-      frozen-reference null; see "Which detector to reach for" in the module docstring.
+      cannot null (see the module docstring). It is refused when the worst period is not a
+      template outlier (`template_novelty_db` below `min_template_novelty_db`) AND the
+      residual rides the waveform's own edges (`edge_concentration` above
+      `max_edge_concentration`) — two conditions that together separate it from a one-off
+      seam (a large per-period outlier at any render length) and a block-rate zipper (off
+      the edges, and — like the smear — not a per-period outlier, so novelty alone cannot
+      tell them apart). The honest gate for that regime is a frozen-reference null; see
+      "Which detector to reach for" in the module docstring.
 
     `max_period_drift=3e-5` is a measured trade with no clean answer, and the shape of
     the trade matters more than the number. The guard cannot distinguish a moving pitch
@@ -646,13 +707,13 @@ def detect(
     a = analyze(signal, sr, f0_hint)
     steady = a.period_drift <= max_period_drift
     # A reading is edge smear — the comb self-reference failing on a fractional-period BLEP
-    # oscillator, NOT a click — when the excursion it would report is not a localized
+    # oscillator, NOT a click — when the period it would report is not a per-period template
     # outlier AND the residual rides the waveform's own edges. Refuse it: the honest gate
-    # here is a frozen-reference null, not the comb (see `_LOCALIZED_MARGIN_DB`).
+    # here is a frozen-reference null, not the comb (see `_TEMPLATE_NOVELTY_DB`).
     edge_smear = (
         np.isfinite(a.click_db)
         and a.click_db >= fire_threshold_db
-        and a.localization_db < min_localized_db
+        and a.template_novelty_db < min_template_novelty_db
         and a.edge_concentration > max_edge_concentration
     )
     trustworthy = (
@@ -682,7 +743,7 @@ def detect(
     elif edge_smear:
         note += (
             " — residual is per-edge approximation smear, not a localized click "
-            f"(localization {a.localization_db:.1f} dB, edge concentration "
+            f"(template novelty {a.template_novelty_db:.1f} dB, edge concentration "
             f"{a.edge_concentration:.2f}); a comb self-reference cannot null a "
             "fractional-period BLEP oscillator — use a frozen-reference null"
         )

--- a/tools/audio/quality-lab/quality_lab/dsp.py
+++ b/tools/audio/quality-lab/quality_lab/dsp.py
@@ -43,6 +43,19 @@ class LagEstimate(NamedTuple):
     confidence: float
 
 
+class AllanDeviation(NamedTuple):
+    """Result of :func:`overlapping_allan_deviation`. `taus` are the averaging factors (in
+    samples of the input series) the deviation was evaluated at; `deviations` is the
+    overlapping Allan deviation at each tau; `slope` is the robust log-log slope of deviation
+    vs tau. The SLOPE SIGN is the discriminator: white frequency noise (clock jitter) falls as
+    tau^(-1/2) (slope ~ -0.5, NEGATIVE), while random-walk frequency noise (analog drift) rises
+    as tau^(+1/2) (slope ~ +0.5, POSITIVE). A near-zero slope is the flicker/white-PM regime in
+    between. Empty arrays and a 0.0 slope when the series was too short to form even one tau."""
+    taus: np.ndarray
+    deviations: np.ndarray
+    slope: float
+
+
 def highband(y: np.ndarray) -> np.ndarray:
     """Cheap high-pass via first difference — emphasizes attack edges (>~300 Hz)."""
     return np.diff(np.asarray(y, dtype=np.float64), prepend=0.0)
@@ -765,3 +778,55 @@ def theil_sen_slope(x: np.ndarray, y: np.ndarray) -> float:
             if dx != 0.0:
                 slopes.append((y[j] - y[i]) / dx)
     return float(np.median(slopes)) if slopes else 0.0
+
+
+def overlapping_allan_deviation(
+    freq: np.ndarray, max_averaging: int | None = None
+) -> AllanDeviation:
+    """Overlapping Allan deviation of a frequency series `freq` (e.g. an f0(t) track), plus the
+    robust log-log slope that separates analog DRIFT from clock JITTER by its SIGN.
+
+    Allan deviation answers a question a plain standard deviation cannot: it is stable against —
+    in fact designed to characterize — a signal whose variance never converges (a random walk
+    has unbounded variance in the limit), and its DEPENDENCE ON THE AVERAGING TIME tau
+    fingerprints the noise type. White frequency noise (clock jitter — each sample independent)
+    averages DOWN as tau^(-1/2); random-walk frequency noise (analog drift — the accumulation of
+    small independent kicks) grows as tau^(+1/2). So the slope of log(deviation) vs log(tau) is
+    ~-1/2 for jitter and ~+1/2 for drift: opposite signs, a clean separation the two processes do
+    not otherwise offer to a single scalar.
+
+    Computed via the phase (second-difference) estimator over octave-spaced averaging factors m:
+    integrate the frequency to phase x, then
+
+        sigma^2(m) = 1 / (2 m^2 (N - 2m)) * sum_i (x[i+2m] - 2 x[i+m] + x[i])^2,
+
+    the standard overlapping estimator — every overlapping second-difference triple at each m, so
+    each tau uses the whole record. tau is reported in input-sample units (tau0 = 1); a physical
+    tau0 would only rescale tau, shifting the log-log intercept, never the slope. The slope is fit
+    with :func:`theil_sen_slope` so a single anomalous tau cannot swing its sign.
+
+    `max_averaging` caps the largest averaging factor (default: the largest octave with at least
+    one overlapping triple, m <= (N-1)/2). Pure numpy; deterministic. Returns empty arrays and a
+    0.0 slope when the series is too short to form even one tau."""
+    y = np.asarray(freq, dtype=np.float64)
+    x = np.concatenate(([0.0], np.cumsum(y)))          # phase = integrated frequency (tau0 = 1)
+    n = x.size
+    limit = (n - 1) // 2
+    if max_averaging is not None:
+        limit = min(limit, int(max_averaging))
+    taus: list[float] = []
+    devs: list[float] = []
+    m = 1
+    while m <= limit:                                  # octave-spaced m = 1, 2, 4, … ≤ limit
+        d2 = x[2 * m:] - 2.0 * x[m:-m] + x[:-2 * m]    # all overlapping second differences at lag m
+        var = float(np.sum(d2 * d2)) / (2.0 * m * m * (n - 2 * m))
+        if var > 0.0:
+            taus.append(float(m))
+            devs.append(float(np.sqrt(var)))
+        m *= 2
+    taus_arr = np.asarray(taus, dtype=np.float64)
+    devs_arr = np.asarray(devs, dtype=np.float64)
+    slope = (
+        theil_sen_slope(np.log(taus_arr), np.log(devs_arr)) if taus_arr.size >= 2 else 0.0
+    )
+    return AllanDeviation(taus_arr, devs_arr, slope)

--- a/tools/audio/quality-lab/quality_lab/fit.py
+++ b/tools/audio/quality-lab/quality_lab/fit.py
@@ -1,0 +1,681 @@
+"""WP-4 F1 — offline OSC-VCO profile fitting tool (Quality-Lab lane).
+
+Recovers the deterministic parameters of the in-tree ``VcoOscillator`` from a
+rendered measurement kit. This is the tool bound by
+``planning/2026-07-16-wp4-fitting-tool-scope-bound.md``:
+
+* It is NOT a global optimizer. It is a fixed sequence of small least-squares
+  fits, each run against the ONE measurement that identifies its parameters
+  (§3). The drift/jitter ridge and shaper/clip degeneracy never enter a cost
+  surface because the regularization is structural — a parameter the signal
+  does not determine is simply not in any fit's search space.
+
+* F1 ships stages 1, 3, 4, 5 — the DETERMINISTIC parameters (§5). Stage 2
+  (frequency-noise: drift/jitter) is DEFERRED: those rows are hand-set
+  placeholders, labeled ``pinned``, with no stochastic estimation here.
+
+* The identifiability table (§2) is encoded in ``IDENTIFIABILITY`` and is the
+  single bound that collapses "unbounded research project" into "estimation
+  over the identifiable subspace". The tool REFUSES to fit any pinned or cut
+  parameter (Gate 3).
+
+Only ONE new estimator is authorized for F1: the single-cycle parametric fitter
+for the core/shaper stages (``_lm`` + the stage fitters below). The f0(t)/Allan
+demodulator is stage 2 and is intentionally absent.
+
+Stage → engine mapping (the fit follows the header's actual math; where the
+generic §5 stage model and vco.hpp's math place an effect differently, vco.hpp
+wins — code is the source of truth):
+
+1. Pitch      → tune_offset_cents, scale_error, hf_compression, hf_knee_octaves
+                (pitch-vs-note: FFT fundamental across control voltages).
+2. Freq-noise → DEFERRED (drift/jitter hand-set, pinned).
+3. Core       → bow (saw single cycle, time domain). In this engine the "finite
+                reset time" is a frequency-proportional LEVEL sag (``level_for``),
+                not a literal edge, so it is fit from the level-vs-pitch curve in
+                stage 5, cross-referenced here.
+4. Shaper     → per-shape lumped nonlinearity from a phase-aligned single cycle,
+                using the fixed core as the known input. Fit on the triangle (a
+                full-range input); the square is 2-valued so its shaper is
+                unidentifiable, the saw's folds into the bow — both reported, not
+                falsely fit.
+5. Output     → ac_corner_hz + level_tilt_db_per_octave + core_reset_seconds
+                (one joint fit over the sine level-vs-pitch curve — the three own
+                distinct frequency regimes), and pulse_width (square duty).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from . import osc_forward as fw
+from .osc_forward import Shape, VcoProfile
+
+
+# ── Identifiability table (§2) — drives the report and the Gate-3 refusal ──────
+
+
+@dataclass(frozen=True)
+class Disposition:
+    """One parameter's classification. ``klass`` is (a)/(b)/(c) shorthand:
+    ``fit`` = identifiable, ``pin`` = not identifiable from audio (data input),
+    ``cut`` = permanently out of scope (the signal cannot determine it)."""
+
+    klass: str          # "fit" | "pin" | "cut"
+    measurement: str
+    note: str = ""
+
+
+IDENTIFIABILITY: dict[str, Disposition] = {
+    # Stage 1 — pitch (all directly identifiable from pitch-vs-note).
+    "tune_offset_cents": Disposition("fit", "pitch-vs-note curve"),
+    "scale_error": Disposition("fit", "pitch-vs-note curve"),
+    "hf_compression": Disposition("fit", "pitch-vs-note curve (high end)"),
+    "hf_knee_octaves": Disposition("fit", "pitch-vs-note curve (high end)"),
+    # Stage 3/5 — core + output level.
+    "bow": Disposition("fit", "saw single-cycle time-domain fit"),
+    "ac_corner_hz": Disposition("fit", "sine level-vs-pitch (low-frequency roll-off)"),
+    "level_tilt_db_per_octave": Disposition("fit", "sine level-vs-pitch (log-linear tilt)"),
+    "core_reset_seconds": Disposition(
+        "fit", "sine level-vs-pitch (high-frequency sag)",
+        "modeled as a frequency-proportional level sag in vco.hpp, not an edge"),
+    # Stage 4 — per-shape shaper.
+    "shaper": Disposition(
+        "fit", "phase-aligned single-cycle time-domain fit (full-range shape)",
+        "one lumped nonlinearity per shape; square is 2-valued (insensitive), "
+        "saw folds into bow"),
+    "pulse_width": Disposition("fit", "square duty cycle"),
+    # Stage 2 — DEFERRED in F1 (stochastic amplitudes). Pinned/hand-set.
+    "drift_depth": Disposition(
+        "pin", "(stage 2 — f0(t) Allan long-tau)",
+        "F1 defers stochastic estimation; hand-set placeholder"),
+    "drift_rate_hz": Disposition(
+        "pin", "(stage 2 — f0(t) Allan long-tau)",
+        "F1 defers stochastic estimation; hand-set placeholder"),
+    "jitter_depth": Disposition(
+        "pin", "(stage 2 — f0(t) Allan short-tau)",
+        "F1 defers stochastic estimation; hand-set placeholder; upper bound (AM leakage)"),
+    # Pinned by construction — not identifiable from audio (§2, class (c)).
+    "drift_family": Disposition(
+        "pin", "circuit class", "single-realization exponent is statistically hopeless"),
+    "jitter_color": Disposition("pin", "-", "not resolvable above the measurement floor"),
+    "comparator_hysteresis": Disposition(
+        "pin", "datasheet", "static effect absorbed by tuning; dynamic folds into jitter"),
+    "temperature_injection_point": Disposition("pin", "circuit topology"),
+    "thermal_tempco": Disposition("pin", "datasheet", "kit has no temperature-controlled captures"),
+    "noise_slew_split": Disposition(
+        "pin", "-", "only the quotient (= jitter RMS) is observable; the split is degenerate"),
+    "reference_hz": Disposition("pin", "nominal converter constant", "not a departure-from-ideal"),
+    "volts_per_octave": Disposition("pin", "nominal converter constant", "not a departure-from-ideal"),
+    # Cut permanently (§5) — the signal does not determine these.
+    "injection_locking": Disposition("cut", "-", "needs controlled multi-oscillator experiments"),
+    "psu_sag": Disposition("cut", "-", "not in the measurement kit"),
+    "drift_exponent": Disposition("cut", "-", "single capture cannot fit the process color"),
+    "interaction_effects": Disposition("cut", "-"),
+}
+
+
+class NotIdentifiableError(ValueError):
+    """Raised when the tool is asked to fit a pinned or cut parameter (Gate 3).
+
+    The message points at the identifiability table — refusing is the whole point
+    of §2: it is the bound that keeps the tool from walking a flat cost ridge.
+    """
+
+
+def assert_fittable(name: str) -> None:
+    """Gate 3: refuse to optimize anything the identifiability table does not
+    classify as ``fit``. Unknown names are refused too (nothing invents a
+    parameter the header/table does not define)."""
+    disp = IDENTIFIABILITY.get(name)
+    if disp is None:
+        raise NotIdentifiableError(
+            f"'{name}' is not an OSC-VCO profile parameter — see the identifiability "
+            f"table in planning/2026-07-16-wp4-fitting-tool-scope-bound.md §2")
+    if disp.klass != "fit":
+        kind = {"pin": "PINNED (not identifiable from audio; a data input)",
+                "cut": "CUT (permanently out of scope; the signal cannot determine it)"}[disp.klass]
+        raise NotIdentifiableError(
+            f"refusing to fit '{name}': it is {kind}. Measurement/basis: "
+            f"{disp.measurement}. {disp.note} "
+            f"(identifiability table §2; F1 fits only the identifiable subspace).")
+
+
+# ── Fit result containers ─────────────────────────────────────────────────────
+
+
+@dataclass
+class FitParam:
+    """One fitted parameter: estimate, 95% CI, and which measurement produced it.
+    ``disposition`` is 'measured' or 'pinned' — a pinned row is NEVER presented as
+    measured (§3)."""
+
+    name: str
+    estimate: float
+    ci_low: float
+    ci_high: float
+    measurement: str
+    disposition: str = "measured"   # "measured" | "pinned"
+    note: str = ""
+    stage: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "estimate": self.estimate,
+            "ci": [self.ci_low, self.ci_high],
+            "measurement": self.measurement,
+            "disposition": self.disposition,
+            "stage": self.stage,
+            "note": self.note,
+        }
+
+
+@dataclass
+class FittedProfile:
+    """The tool's output — a fitted profile as an ordered list of parameter rows."""
+
+    params: list[FitParam] = field(default_factory=list)
+
+    def add(self, p: FitParam) -> None:
+        self.params.append(p)
+
+    def get(self, name: str) -> FitParam:
+        for p in self.params:
+            if p.name == name:
+                return p
+        raise KeyError(name)
+
+    def to_dict(self) -> dict:
+        return {"parameters": [p.to_dict() for p in self.params]}
+
+    def to_profile(self) -> VcoProfile:
+        """Reconstruct a ``VcoProfile`` from the fitted + pinned rows, so the fit
+        can be re-rendered (Gate 1's recovery check, Gate 2's re-render)."""
+        prof = VcoProfile()
+
+        def val(name, default):
+            try:
+                return self.get(name).estimate
+            except KeyError:
+                return default
+
+        prof.tuning.tune_offset_cents = val("tune_offset_cents", 0.0)
+        prof.tuning.scale_error = val("scale_error", 1.0)
+        prof.tuning.hf_compression = val("hf_compression", 0.0)
+        prof.tuning.hf_knee_octaves = val("hf_knee_octaves", 3.0)
+        prof.bow = val("bow", 0.0)
+        prof.level_tilt_db_per_octave = val("level_tilt_db_per_octave", 0.0)
+        prof.core_reset_seconds = val("core_reset_seconds", 0.0)
+        prof.ac_corner_hz = val("ac_corner_hz", 0.0)
+        prof.pulse_width = val("pulse_width", 0.5)
+        prof.drift_depth = val("drift_depth", 0.0)
+        prof.drift_rate_hz = val("drift_rate_hz", 0.4)
+        prof.jitter_depth = val("jitter_depth", 0.0)
+        for s in Shape:
+            for field_name in ("amount", "drive", "asymmetry"):
+                key = f"shaper_{s.name}_{field_name}"
+                try:
+                    setattr(prof.shapers[s], field_name, self.get(key).estimate)
+                except KeyError:
+                    pass
+        return prof
+
+
+# ── The one authorized new estimator: Levenberg–Marquardt least squares ───────
+
+
+def _lm(residual, p0, lower, upper, max_iter: int = 300):
+    """Bounded Levenberg–Marquardt over a small parameter vector, numeric Jacobian.
+
+    Returns ``(p, cov, ssr)``. ``cov`` is the parameter covariance
+    ``s^2 (J^T J)^-1`` at the solution (``s^2 = SSR/dof``), from which the report's
+    confidence intervals come. Dependency-free (numpy only) by design — the venv
+    carries numpy/soundfile/pytest and nothing else.
+    """
+    p = np.array(p0, dtype=np.float64)
+    lower = np.array(lower, dtype=np.float64)
+    upper = np.array(upper, dtype=np.float64)
+
+    def clip(x):
+        return np.minimum(np.maximum(x, lower), upper)
+
+    def jac(p, r):
+        m, n = len(r), len(p)
+        J = np.zeros((m, n))
+        for k in range(n):
+            step = 1e-6 * max(abs(p[k]), 1e-6)
+            pk = p[k]
+            # Step inward when pinned against a bound.
+            if pk + step > upper[k]:
+                step = -step
+            pp = p.copy()
+            pp[k] = pk + step
+            J[:, k] = (residual(pp) - r) / step
+        return J
+
+    p = clip(p)
+    r = residual(p)
+    ssr = float(r @ r)
+    lam = 1e-3
+    for _ in range(max_iter):
+        J = jac(p, r)
+        JtJ = J.T @ J
+        Jtr = J.T @ r
+        improved = False
+        for _ in range(40):
+            A = JtJ + lam * np.diag(np.diag(JtJ) + 1e-15)
+            try:
+                dp = np.linalg.solve(A, -Jtr)
+            except np.linalg.LinAlgError:
+                lam *= 10.0
+                continue
+            pn = clip(p + dp)
+            rn = residual(pn)
+            cn = float(rn @ rn)
+            if cn < ssr:
+                improved = True
+                rel = (ssr - cn) / max(ssr, 1e-300)
+                p, r, ssr = pn, rn, cn
+                lam = max(lam * 0.4, 1e-12)
+                break
+            lam *= 4.0
+        if not improved or rel < 1e-12:
+            break
+
+    # Covariance at the solution.
+    J = jac(p, r)
+    m, n = len(r), len(p)
+    dof = max(m - n, 1)
+    s2 = ssr / dof
+    try:
+        cov = s2 * np.linalg.inv(J.T @ J)
+    except np.linalg.LinAlgError:
+        cov = np.full((n, n), np.nan)
+    return p, cov, ssr
+
+
+def _ci(estimate: float, cov_diag: float) -> tuple[float, float]:
+    """95% CI from a covariance diagonal (±1.96 sigma). NaN/negative → open CI."""
+    if not (cov_diag >= 0.0) or not math.isfinite(cov_diag):
+        return (float("nan"), float("nan"))
+    half = 1.96 * math.sqrt(cov_diag)
+    return (estimate - half, estimate + half)
+
+
+# ── Shared measurement helper ─────────────────────────────────────────────────
+
+
+def estimate_fundamental(y: np.ndarray, sample_rate: float) -> float:
+    """Fundamental via QIFFT — Hann-windowed rFFT peak, parabolically interpolated
+    on log-magnitude. Sub-cent accurate on a clean single tone at these durations
+    (the pitch stage's ±1-cent tolerance depends on it)."""
+    y = np.asarray(y, dtype=np.float64)
+    y = y - np.mean(y)
+    win = np.hanning(len(y))
+    mag = np.abs(np.fft.rfft(y * win))
+    k = int(np.argmax(mag[1:]) + 1)
+    if 1 <= k < len(mag) - 1:
+        a = math.log(mag[k - 1] + 1e-300)
+        b = math.log(mag[k] + 1e-300)
+        c = math.log(mag[k + 1] + 1e-300)
+        offset = 0.5 * (a - c) / (a - 2 * b + c + 1e-300)
+    else:
+        offset = 0.0
+    bin_hz = sample_rate / len(y)
+    return (k + offset) * bin_hz
+
+
+def _sine_amplitude(y: np.ndarray, settle: int) -> float:
+    """Amplitude of a steady sine: sqrt(2)*RMS over the post-transient tail. A pure
+    sine through the linear AC blocker stays a pure sine, so RMS is exact."""
+    tail = y[settle:]
+    return math.sqrt(2.0) * math.sqrt(float(np.mean(tail * tail)))
+
+
+def _ac_filter(x: np.ndarray, corner_hz: float, sample_rate: float) -> np.ndarray:
+    """Run the ``DcBlocker`` over ``x`` from zero state, so a candidate core/shaper
+    waveform in a time-domain fit passes through the SAME already-fit AC stage the
+    engine applied. Bypass (identity) when the corner is off."""
+    if not (corner_hz > 0.0):
+        return x
+    blocker = fw.DcBlocker(fw.ac_pole(corner_hz, sample_rate))
+    return np.array([blocker.process(float(v)) for v in x])
+
+
+# ── Measurement kit (Gate 1 renders it from a known profile) ──────────────────
+
+
+@dataclass
+class MeasurementKit:
+    """The rendered measurement kit the tool consumes — the ONLY input to a fit
+    besides the pinned-parameter set. Mirrors the proposal's kit: pitch-vs-note,
+    single cycles, a level curve, a PWM/duty capture."""
+
+    sample_rate: float
+    pitch: list[tuple[float, np.ndarray]]                 # (control_volts, wav).
+    saw_cycle: tuple[float, np.ndarray]                    # (freq, wav).
+    shaper_cycles: dict[Shape, tuple[float, np.ndarray]]   # shape -> (freq, wav).
+    level_curve: list[tuple[float, np.ndarray]]            # (freq, wav).
+    level_settle: int                                      # samples to skip (transient).
+    pwm: tuple[float, np.ndarray]                          # (freq, wav).
+
+
+def build_measurement_kit(profile: VcoProfile, *, sample_rate: float = 96000.0,
+                          shaper_shapes: tuple[Shape, ...] = (Shape.triangle,)
+                          ) -> MeasurementKit:
+    """Render the full measurement kit from ``profile`` (Gate 1's target).
+
+    Rendered at 96 kHz: the level curve reaches 40 kHz, where the finite-reset sag
+    ``(1 - reset*f)`` carries enough leverage to identify ``core_reset_seconds``,
+    and the low end reaches 15 Hz where the AC roll-off is a clean corner probe.
+    """
+    # Pitch: clean sine tones across control voltages spanning the keyboard and
+    # the HF knee. The fundamental is what the tuning stage sets, independent of
+    # every other stage, so a clean sine is the faithful probe.
+    control_volts = np.arange(-2.0, 4.51, 0.25)
+    pitch = []
+    for v in control_volts:
+        f = profile.tuning.frequency_hz(float(v))
+        n = int(round(sample_rate * 0.5))               # 0.5 s — sub-cent QIFFT.
+        pitch.append((float(v), fw.render_sine(profile, f, sample_rate, n)))
+
+    # Core single cycles at a mid pitch, several cycles rendered so the fit skips
+    # the AC transient and reads steady state. The time-domain fits model the AC
+    # stage explicitly (it distorts a saw's rich low harmonics), so the pitch need
+    # not be high enough for AC to be negligible.
+    cyc_freq = 220.0
+    cyc_n = int(round(sample_rate / cyc_freq * 8))
+    saw_cycle = (cyc_freq, fw.render(profile, Shape.saw, cyc_freq, sample_rate, cyc_n))
+    shaper_cycles = {
+        s: (cyc_freq, fw.render(profile, s, cyc_freq, sample_rate, cyc_n))
+        for s in shaper_shapes
+    }
+
+    # Level curve: sine amplitude across log-spaced pitches (AC low end, tilt
+    # across the range, reset sag at the top). Skip the AC transient.
+    freqs = np.geomspace(15.0, 40000.0, 56)
+    lvl_n = int(round(sample_rate * 0.2))
+    settle = int(round(sample_rate * 0.09))
+    level_curve = [(float(f), fw.render_sine(profile, float(f), sample_rate, lvl_n))
+                   for f in freqs]
+
+    # PWM: a square at a mid pitch; duty is read from the sign fraction.
+    pwm_freq = 500.0
+    pwm_n = int(round(sample_rate / pwm_freq * 16))
+    pwm = (pwm_freq, fw.render(profile, Shape.square, pwm_freq, sample_rate, pwm_n))
+
+    return MeasurementKit(sample_rate, pitch, saw_cycle, shaper_cycles,
+                          level_curve, settle, pwm)
+
+
+# ── Stage 1 — pitch ───────────────────────────────────────────────────────────
+
+
+def fit_pitch(kit: MeasurementKit, profile_ref: VcoProfile) -> list[FitParam]:
+    """Fit tune_offset, scale_error, hf_compression, hf_knee from pitch-vs-note.
+
+    ``profile_ref`` supplies only the PINNED nominal converter constants
+    (reference_hz, volts_per_octave) — those are data inputs, not fit (§2)."""
+    for name in ("tune_offset_cents", "scale_error", "hf_compression", "hf_knee_octaves"):
+        assert_fittable(name)
+
+    ref_hz = profile_ref.tuning.reference_hz
+    vpo = profile_ref.tuning.volts_per_octave
+    v = np.array([cv for cv, _ in kit.pitch])
+    meas_oct = np.array([math.log2(estimate_fundamental(w, kit.sample_rate) / ref_hz)
+                         for _, w in kit.pitch])
+
+    def model_oct(p):
+        scale, off_cents, hf_comp, knee = p
+        o = (v / vpo) * scale + off_cents / 1200.0
+        comp = np.where((hf_comp > 0.0) & (o > knee), hf_comp * (o - knee), 0.0)
+        return o - comp
+
+    def residual(p):
+        return model_oct(p) - meas_oct
+
+    p0 = [1.0, 0.0, 0.02, 3.0]
+    lower = [0.9, -200.0, 0.0, 0.5]
+    upper = [1.1, 200.0, 0.5, 6.0]
+    p, cov, _ = _lm(residual, p0, lower, upper)
+    names = ["scale_error", "tune_offset_cents", "hf_compression", "hf_knee_octaves"]
+    out = []
+    for i, name in enumerate(names):
+        lo, hi = _ci(p[i], cov[i, i])
+        out.append(FitParam(name, float(p[i]), lo, hi,
+                            IDENTIFIABILITY[name].measurement,
+                            note=IDENTIFIABILITY[name].note, stage="1-pitch"))
+    return out
+
+
+# ── Stage 3 — core: bow ───────────────────────────────────────────────────────
+
+
+def _cycle_phase(freq: float, sample_rate: float, n: int) -> np.ndarray:
+    return (fw.DEFAULT_START_PHASE + freq / sample_rate * np.arange(n)) % 1.0
+
+
+def _steady_interior_mask(phase: np.ndarray, samples_per_cycle: float,
+                          excludes: tuple[float, ...], guard: float = 0.03) -> np.ndarray:
+    """Samples in a shape's smooth interior: past the first cycle (AC transient)
+    and clear of the wrap (phase 0/1) and any internal discontinuity in
+    ``excludes`` (e.g. the triangle apex at 0.5). The polyBLEP/BLAMP ripple lives
+    exactly at those points and the ideal-core model does not — so the fit reads
+    the smooth curve, not the correction."""
+    mask = (phase > guard) & (phase < 1.0 - guard)
+    for e in excludes:
+        mask &= np.abs(phase - e) > guard
+    mask[: int(round(samples_per_cycle))] = False
+    return mask
+
+
+def fit_bow(kit: MeasurementKit, ac_corner_hz: float) -> FitParam:
+    """Fit the saw integrator-leak bow from a single-cycle time-domain capture.
+
+    The saw core value at phase p is 2p-1, so the bow output is a pure function of
+    phase. The candidate is passed through the already-fit AC stage (the DC blocker
+    materially tilts a saw's rich low harmonics), then a scalar gain g and DC term
+    dc absorb the level stage and any residual offset."""
+    assert_fittable("bow")
+    freq, y = kit.saw_cycle
+    n = len(y)
+    p = _cycle_phase(freq, kit.sample_rate, n)
+    y = np.asarray(y, dtype=np.float64)
+    mask = _steady_interior_mask(p, kit.sample_rate / freq, excludes=())
+
+    def bow_shape(k):
+        # 2*(1-e^{-k p})/(1-e^{-k}) - 1, guarding k -> 0.
+        if abs(k) < 1e-9:
+            return 2.0 * p - 1.0
+        return 2.0 * (1.0 - np.exp(-k * p)) / (1.0 - math.exp(-k)) - 1.0
+
+    def residual(params):
+        k, g, dc = params
+        model = g * _ac_filter(bow_shape(k), ac_corner_hz, kit.sample_rate) + dc
+        return (model - y)[mask]
+
+    amp = 0.5 * (y.max() - y.min())
+    pfit, cov, _ = _lm(residual, [1.0, amp, 0.0], [1e-3, 1e-6, -2.0], [20.0, 10.0, 2.0])
+    lo, hi = _ci(pfit[0], cov[0, 0])
+    return FitParam("bow", float(pfit[0]), lo, hi, IDENTIFIABILITY["bow"].measurement,
+                    stage="3-core")
+
+
+# ── Stage 4 — per-shape shaper ────────────────────────────────────────────────
+
+
+def _core_values(shape: Shape, phase: np.ndarray, pulse_width: float) -> np.ndarray:
+    """Ideal (pre-BLEP) core value at each phase — the known shaper input."""
+    if shape == Shape.triangle:
+        return np.where(phase < 0.5, 4.0 * phase - 1.0, 3.0 - 4.0 * phase)
+    if shape == Shape.saw:
+        return 2.0 * phase - 1.0
+    if shape == Shape.sine:
+        return np.sin(2.0 * math.pi * phase)
+    return np.where(phase < pulse_width, 1.0, -1.0)   # square (2-valued).
+
+
+def fit_shaper(kit: MeasurementKit, shape: Shape, pulse_width: float,
+               ac_corner_hz: float) -> list[FitParam]:
+    """Fit a shape's lumped nonlinearity from a phase-aligned single cycle, using
+    the fixed core as the known input (§3 sequencing: core before shaper) and
+    passing the candidate through the already-fit AC stage.
+
+    Reports honestly where a shape cannot identify a shaper: the square is
+    2-valued (any memoryless map is absorbed into two levels), so its shaper is
+    left neutral and labeled insensitive rather than fit to noise."""
+    assert_fittable("shaper")
+    freq, y = kit.shaper_cycles[shape]
+    n = len(y)
+    phase = _cycle_phase(freq, kit.sample_rate, n)
+    core = _core_values(shape, phase, pulse_width)
+    y = np.asarray(y, dtype=np.float64)
+    # Exclude the shape's internal discontinuities (triangle apex at 0.5) plus the
+    # wrap and the AC transient.
+    excludes = (0.5,) if shape == Shape.triangle else ()
+    mask = _steady_interior_mask(phase, kit.sample_rate / freq, excludes)
+
+    distinct = np.unique(np.round(core, 6))
+    if len(distinct) < 8:
+        # Not enough distinct input values to identify a memoryless curve.
+        return [FitParam(f"shaper_{shape.name}_{f}", 0.0 if f != "drive" else 1.0,
+                         float("nan"), float("nan"),
+                         IDENTIFIABILITY["shaper"].measurement, disposition="pinned",
+                         note="insensitive — input is not full-range; pin recommended",
+                         stage="4-shaper")
+                for f in ("amount", "drive", "asymmetry")]
+
+    def model(params):
+        amount, drive, asym, g, dc = params
+        w = fw.WaveshaperParams(amount=amount, drive=drive, asymmetry=asym)
+        shaped = fw.apply_waveshaper_array(w, core)
+        return g * _ac_filter(shaped, ac_corner_hz, kit.sample_rate) + dc
+
+    def residual(params):
+        return (model(params) - y)[mask]
+
+    amp = 0.5 * (y.max() - y.min())
+    p0 = [0.5, 1.5, 0.0, amp, 0.0]
+    lower = [0.0, 0.05, -3.0, 1e-6, -2.0]
+    upper = [1.0, 8.0, 3.0, 10.0, 2.0]
+    pfit, cov, _ = _lm(residual, p0, lower, upper)
+    out = []
+    for i, fname in enumerate(("amount", "drive", "asymmetry")):
+        lo, hi = _ci(pfit[i], cov[i, i])
+        out.append(FitParam(f"shaper_{shape.name}_{fname}", float(pfit[i]), lo, hi,
+                            IDENTIFIABILITY["shaper"].measurement, stage="4-shaper"))
+    return out
+
+
+# ── Stage 5 — output: level curve (AC + tilt + reset) and PWM duty ─────────────
+
+
+def fit_level_curve(kit: MeasurementKit) -> list[FitParam]:
+    """Joint fit of ac_corner, level_tilt, core_reset over the sine level curve.
+
+    The three own distinct frequency regimes — AC rolls off the low end (+6 dB/oct
+    below its corner), the tilt is log-linear across the range, the finite-reset
+    sag ``(1 - reset*f)`` bites at the top — so a single joint least-squares over
+    dB-vs-log-f separates them without a global optimizer (§3)."""
+    for name in ("ac_corner_hz", "level_tilt_db_per_octave", "core_reset_seconds"):
+        assert_fittable(name)
+    sr = kit.sample_rate
+    freqs = np.array([f for f, _ in kit.level_curve])
+    amps = np.array([_sine_amplitude(w, kit.level_settle) for _, w in kit.level_curve])
+    meas_db = 20.0 * np.log10(np.maximum(amps, 1e-12))
+
+    def model_db(p):
+        corner, tilt, reset = p
+        ac = np.array([fw.ac_magnitude(corner, sr, float(f)) for f in freqs])
+        ac_db = 20.0 * np.log10(np.maximum(ac, 1e-12))
+        tilt_db = -tilt * np.log2(freqs / fw.LEVEL_REFERENCE_HZ)
+        sag = np.maximum(1.0 - reset * freqs, 1e-6)
+        return ac_db + tilt_db + 20.0 * np.log10(sag)
+
+    def residual(p):
+        return model_db(p) - meas_db
+
+    p0 = [10.0, 0.0, 0.0]
+    lower = [0.5, -12.0, 0.0]
+    upper = [200.0, 12.0, 5e-5]
+    pfit, cov, _ = _lm(residual, p0, lower, upper)
+    names = ["ac_corner_hz", "level_tilt_db_per_octave", "core_reset_seconds"]
+    # ac_corner is the core stage's AC row (§2/§3); tilt + reset are the output
+    # stage. All three come from this one joint fit — they own distinct regimes.
+    stages = {"ac_corner_hz": "3-core"}
+    out = []
+    for i, name in enumerate(names):
+        lo, hi = _ci(pfit[i], cov[i, i])
+        out.append(FitParam(name, float(pfit[i]), lo, hi,
+                            IDENTIFIABILITY[name].measurement,
+                            note=IDENTIFIABILITY[name].note,
+                            stage=stages.get(name, "5-output")))
+    return out
+
+
+def fit_pulse_width(kit: MeasurementKit) -> FitParam:
+    """Duty cycle → pulse_width. After AC removes the square's DC, the high plateau
+    sits above zero and the low below, so the sign fraction is the duty directly.
+
+    (The generic §5 "PWM CV→duty mapping" and "comparator slew" are NOT modeled by
+    this engine — vco.hpp exposes only ``pulse_width`` — so only it is fit; the CV
+    map is not invented.)"""
+    assert_fittable("pulse_width")
+    _, y = kit.pwm
+    y = np.asarray(y, dtype=np.float64)
+    y = y - np.mean(y)                       # belt-and-suspenders DC removal.
+    duty = float(np.mean(y > 0.0))
+    return FitParam("pulse_width", duty, float("nan"), float("nan"),
+                    IDENTIFIABILITY["pulse_width"].measurement, stage="5-output")
+
+
+# ── Orchestrator — the fixed sequence, plus the pinned/deferred rows ──────────
+
+
+def fit_profile(kit: MeasurementKit, profile_ref: VcoProfile, *,
+                pinned: dict[str, float] | None = None,
+                shaper_shapes: tuple[Shape, ...] = (Shape.triangle,)) -> FittedProfile:
+    """Run the F1 fixed sequence (stages 1, 3, 4, 5) and assemble the fitted
+    profile. ``pinned`` supplies the hand-set drift/jitter (stage-2) values and any
+    other pinned data inputs; they are recorded as ``disposition='pinned'`` — never
+    presented as measured (§3)."""
+    pinned = dict(pinned or {})
+    result = FittedProfile()
+
+    # Stage 1 — pitch.
+    for fp in fit_pitch(kit, profile_ref):
+        result.add(fp)
+
+    # Stage 3/5 — the level curve is fit first because it identifies the AC corner
+    # cleanly (the sine roll-off is independent of bow/shaper), and the corner is
+    # then an INPUT to the time-domain core/shaper fits, which model the AC stage.
+    # This is the §3 "each fit against the measurement that identifies it" order;
+    # the AC row is labeled core, tilt/reset output.
+    level_params = fit_level_curve(kit)
+    ac_corner = next(p.estimate for p in level_params if p.name == "ac_corner_hz")
+
+    # Stage 3 — core (bow), through the now-known AC. The finite reset is a level
+    # term in this engine, fit above in the level curve.
+    result.add(fit_bow(kit, ac_corner))
+
+    # Stage 4 — shaper (per requested full-range shape), through core + AC.
+    for s in shaper_shapes:
+        for fp in fit_shaper(kit, s, profile_ref.pulse_width, ac_corner):
+            result.add(fp)
+
+    # Stage 5 — output.
+    for fp in level_params:
+        result.add(fp)
+    result.add(fit_pulse_width(kit))
+
+    # Stage 2 — DEFERRED: drift/jitter are hand-set, labeled pinned.
+    for name, default in (("drift_depth", 0.0), ("drift_rate_hz", 0.4),
+                          ("jitter_depth", 0.0)):
+        disp = IDENTIFIABILITY[name]
+        result.add(FitParam(name, float(pinned.get(name, default)),
+                            float("nan"), float("nan"), disp.measurement,
+                            disposition="pinned", note=disp.note, stage="2-deferred"))
+    return result

--- a/tools/audio/quality-lab/quality_lab/osc_fixtures.py
+++ b/tools/audio/quality-lab/quality_lab/osc_fixtures.py
@@ -278,3 +278,102 @@ def zipper(y: np.ndarray, delta: float, block: int = 64) -> np.ndarray:
     out = np.array(y, dtype=np.float64, copy=True)
     steps = np.arange(len(out)) // block
     return out + delta * (steps % 2).astype(np.float64)
+
+
+# ── Corpus families (§ oscillator golden corpus) ────────────────────────────
+#
+# The fixtures above are click-detector building blocks. The functions below
+# concatenate them into whole, license-clean CORPUS RENDERS — registered as
+# generator-backed sources in `corpus.py` — so the quality-lab's alias/HF
+# regression axis (`compare.py`'s `added-hf`, backed by the `hf_fizz`
+# detector) has oscillator material to gate on, not just drum/tonal stimuli.
+
+
+def sine(sr: int, f0: float, dur_s: float, amp: float = 0.7, phase: float = 0.0) -> np.ndarray:
+    """A pure sine — the trivial static-shape family member and the exact null
+    case for any harmonic-content axis: a sine has no harmonics of its own, so
+    any measured HF energy or aliasing in a render is unambiguously a property
+    of the render path, not the waveform."""
+    n = int(round(dur_s * sr))
+    t = np.arange(n) / sr
+    return amp * np.sin(2 * np.pi * f0 * t + phase)
+
+
+def bandlimited_triangle(
+    sr: int, f0: float, dur_s: float, amp: float = 0.7, phase: float = 0.0
+) -> np.ndarray:
+    """Additive triangle: odd harmonics only, amplitude 1/k^2 with alternating
+    sign — the fourth static shape, and the smoothest of the four (the faster
+    1/k^2 rolloff vs. saw/square's 1/k means less high-frequency content to
+    begin with, the useful contrast in a static-shape sweep)."""
+    n = int(round(dur_s * sr))
+    t = np.arange(n) / sr
+    y = np.zeros(n, dtype=np.float64)
+    sign = 1.0
+    for k in range(1, _harmonic_count(sr, f0) + 1, 2):
+        y += sign * np.sin(2 * np.pi * k * f0 * t + phase) / (k * k)
+        sign = -sign
+    return (amp * (8.0 / (np.pi ** 2))) * y
+
+
+_STATIC_SHAPES = {
+    "sine": sine,
+    "saw": bandlimited_saw,
+    "square": bandlimited_square,
+    "triangle": bandlimited_triangle,
+}
+
+
+def render_static_shapes(
+    sr: int, dur_s: float, pitches: list[float], shapes: list[str] | None = None,
+    gap_s: float = 0.05,
+) -> np.ndarray:
+    """The static-shape corpus family: every (shape, pitch) combination in
+    `shapes x pitches` order, concatenated with a short silence gap between
+    segments so a windowed axis never straddles two different waveforms.
+    `shapes` defaults to all four in `_STATIC_SHAPES` (sine — the null case —
+    plus saw/square/triangle). Peak-normalized like the other corpus
+    generators (`generate.render_drum_break`, `generate.render_tonal`)."""
+    shapes = shapes or list(_STATIC_SHAPES)
+    gap = np.zeros(int(round(gap_s * sr)), dtype=np.float64)
+    segments: list[np.ndarray] = []
+    for shape in shapes:
+        gen = _STATIC_SHAPES[shape]
+        for f0 in pitches:
+            segments.append(gen(sr, f0, dur_s))
+            segments.append(gap)
+    y = np.concatenate(segments) if segments else np.zeros(0, dtype=np.float64)
+    return y / (np.max(np.abs(y)) + 1e-12) * 0.7
+
+
+def render_sync_sweep(
+    sr: int, dur_s: float, f_master_list: list[float], f_slave_ratio: float = 2.5,
+    gap_s: float = 0.05,
+) -> np.ndarray:
+    """The sync-sweep corpus family: `hard_synced_saw` at each master frequency
+    in `f_master_list` (a fixed slave/master ratio), concatenated with a short
+    silence gap — the reset-seam case a naive click/alias rule gets wrong,
+    swept across the range rather than measured at one frequency."""
+    gap = np.zeros(int(round(gap_s * sr)), dtype=np.float64)
+    segments: list[np.ndarray] = []
+    for f_master in f_master_list:
+        segments.append(hard_synced_saw(sr, f_master, f_master * f_slave_ratio, dur_s))
+        segments.append(gap)
+    y = np.concatenate(segments) if segments else np.zeros(0, dtype=np.float64)
+    return y / (np.max(np.abs(y)) + 1e-12) * 0.7
+
+
+def render_tzfm_grid(
+    sr: int, dur_s: float, f_carrier: float, mod_grid: list[list[float]], gap_s: float = 0.05,
+) -> np.ndarray:
+    """The TZFM corpus family: `tzfm_sine` at each `(f_mod, index)` pair in
+    `mod_grid`, concatenated with a short silence gap — through-zero FM
+    sideband content across a grid of modulation rates and indices rather
+    than one fixed operating point."""
+    gap = np.zeros(int(round(gap_s * sr)), dtype=np.float64)
+    segments: list[np.ndarray] = []
+    for f_mod, index in mod_grid:
+        segments.append(tzfm_sine(sr, f_carrier, f_mod, index, dur_s))
+        segments.append(gap)
+    y = np.concatenate(segments) if segments else np.zeros(0, dtype=np.float64)
+    return y / (np.max(np.abs(y)) + 1e-12) * 0.7

--- a/tools/audio/quality-lab/quality_lab/osc_forward.py
+++ b/tools/audio/quality-lab/quality_lab/osc_forward.py
@@ -1,0 +1,422 @@
+"""Faithful Python port of the OSC-VCO forward model (``core/signal/include/pulp/signal/osc/vco.hpp``).
+
+WP-4 F1 fits parameters of the in-tree ``VcoOscillator``. The render bridge
+(``pulp-osc-render-wav``) only exposes shape/freq/drift/jitter, so it cannot reach
+the deterministic character parameters the fitting tool recovers (bow, waveshaper,
+level tilt, reset, AC corner, tuning, pulse width). Per
+``planning/2026-07-16-wp4-fitting-tool-scope-bound.md`` §4, when the render tool
+cannot hit the parameters, Gate 1 renders from a Python re-implementation of the
+forward model that MATCHES the header. This module is that re-implementation.
+
+It ports, line-for-line with the C++ where it matters:
+
+* ``VcoTuning`` — the exponential pitch converter (``frequency_hz``).
+* ``VaOscillator`` — the bandlimited core: ``PhaseAccumulator`` + polyBLEP/BLAMP
+  (``phase.hpp`` + ``blep.hpp`` + ``va.hpp``). This is the only non-trivial part;
+  it reproduces the wrap/threshold discontinuity correction so a rendered saw or
+  triangle carries the same two-sample BLEP ripple the engine produces.
+* ``VcoOscillator``'s deterministic character stages — bow, per-shape waveshaper,
+  level-vs-pitch (tilt + finite reset), AC coupling (``DcBlocker``).
+
+F1 renders the measurement kit with drift and jitter OFF (they are the stage-2
+stochastic tail, deferred), so ``pitch_noise_factor()`` is exactly 1.0 and the
+seeded RNG is intentionally NOT ported here — a neutral-noise VCO is bit-for-bit
+the deterministic path, which is all F1 measures.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field, replace
+from enum import IntEnum
+
+import numpy as np
+
+# ── Shapes (mirror VaShape's enum ORDER — it indexes the shaper array) ────────
+
+
+class Shape(IntEnum):
+    sine = 0
+    saw = 1
+    square = 2
+    triangle = 3
+
+
+SHAPE_NAMES = {"sine": Shape.sine, "saw": Shape.saw,
+               "square": Shape.square, "triangle": Shape.triangle}
+
+
+# ── Parameter containers (mirror the C++ structs) ─────────────────────────────
+
+
+@dataclass
+class VcoTuning:
+    """The analog exponential pitch converter — ``VcoTuning`` in vco.hpp."""
+
+    reference_hz: float = 261.625565           # C4.
+    volts_per_octave: float = 1.0
+    tune_offset_cents: float = 0.0
+    scale_error: float = 1.0
+    hf_compression: float = 0.0
+    hf_knee_octaves: float = 3.0
+
+    def frequency_hz(self, control_volts: float) -> float:
+        octaves = (control_volts / self.volts_per_octave) * self.scale_error \
+            + self.tune_offset_cents / 1200.0
+        if self.hf_compression > 0.0 and octaves > self.hf_knee_octaves:
+            octaves -= self.hf_compression * (octaves - self.hf_knee_octaves)
+        return self.reference_hz * (2.0 ** octaves)
+
+
+@dataclass
+class WaveshaperParams:
+    """A per-shape lumped memoryless nonlinearity — ``WaveshaperParams``."""
+
+    amount: float = 0.0
+    drive: float = 1.0
+    asymmetry: float = 0.0
+
+
+@dataclass
+class VcoProfile:
+    """Everything a fitted OSC-VCO profile holds (deterministic path).
+
+    Field defaults are the engine's neutral defaults, so a default profile is
+    bit-for-bit a ``VaOscillator``. ``shapers`` is indexed by ``Shape``.
+    """
+
+    tuning: VcoTuning = field(default_factory=VcoTuning)
+    bow: float = 0.0
+    shapers: dict[Shape, WaveshaperParams] = field(
+        default_factory=lambda: {s: WaveshaperParams() for s in Shape})
+    level_tilt_db_per_octave: float = 0.0
+    core_reset_seconds: float = 0.0
+    ac_corner_hz: float = 0.0
+    pulse_width: float = 0.5
+    # Stochastic tail — hand-set in F1 (stage 2 deferred); never fit here.
+    drift_depth: float = 0.0
+    drift_rate_hz: float = 0.4
+    jitter_depth: float = 0.0
+
+    def copy(self) -> "VcoProfile":
+        return replace(self, tuning=replace(self.tuning),
+                       shapers={s: replace(p) for s, p in self.shapers.items()})
+
+
+LEVEL_REFERENCE_HZ = 1000.0  # VcoOscillator::kLevelReferenceHz.
+
+
+# ── Deterministic character stages (memoryless / scalar) ──────────────────────
+
+
+def apply_bow(bow: float, v: float, shape: Shape) -> float:
+    """``VcoOscillator::apply_bow`` — the saw-only integrator-leak reshape."""
+    if bow == 0.0 or shape != Shape.saw:
+        return v
+    p = 0.5 * (v + 1.0)
+    p = 0.0 if p < 0.0 else (1.0 if p > 1.0 else p)
+    charged = (1.0 - math.exp(-bow * p)) / (1.0 - math.exp(-bow))
+    return 2.0 * charged - 1.0
+
+
+def apply_waveshaper(w: WaveshaperParams, v: float) -> float:
+    """``VcoOscillator::apply_waveshaper`` — endpoint-anchored, DC-free tanh."""
+    amount = min(max(w.amount, 0.0), 1.0)
+    if amount == 0.0:
+        return v
+    lo = math.tanh(-w.drive + w.asymmetry)
+    hi = math.tanh(w.drive + w.asymmetry)
+    mid = 0.5 * (hi + lo)
+    half = 0.5 * (hi - lo)
+    shaped = (math.tanh(w.drive * v + w.asymmetry) - mid) / half if half != 0.0 else v
+    return (1.0 - amount) * v + amount * shaped
+
+
+def apply_waveshaper_array(w: WaveshaperParams, v: np.ndarray) -> np.ndarray:
+    """Vectorized ``apply_waveshaper`` — same math over an array of core values."""
+    amount = min(max(w.amount, 0.0), 1.0)
+    if amount == 0.0:
+        return v
+    lo = math.tanh(-w.drive + w.asymmetry)
+    hi = math.tanh(w.drive + w.asymmetry)
+    mid = 0.5 * (hi + lo)
+    half = 0.5 * (hi - lo)
+    if half == 0.0:
+        return v
+    shaped = (np.tanh(w.drive * v + w.asymmetry) - mid) / half
+    return (1.0 - amount) * v + amount * shaped
+
+
+def level_for(profile: VcoProfile, frequency: float, sample_rate: float) -> float:
+    """``VcoOscillator::level_for`` — level-vs-pitch tilt + finite-reset sag."""
+    tilt = profile.level_tilt_db_per_octave
+    reset = profile.core_reset_seconds
+    if tilt == 0.0 and reset == 0.0:
+        return 1.0
+    if not (frequency > 0.0):
+        return 1.0
+    gain = 1.0
+    if tilt != 0.0:
+        octaves = math.log2(frequency / LEVEL_REFERENCE_HZ)
+        gain *= 10.0 ** (-tilt * octaves / 20.0)
+    if reset != 0.0:
+        eaten = reset * frequency
+        gain *= (1.0 - eaten) if eaten < 1.0 else 0.0
+    return gain
+
+
+def ac_pole(corner_hz: float, sample_rate: float) -> float:
+    """``VcoOscillator::update_ac_pole`` — realized DC-blocker pole (1.0 = bypass)."""
+    if corner_hz > 0.0:
+        return math.exp(-2.0 * math.pi * corner_hz / sample_rate)
+    return 1.0
+
+
+def ac_magnitude(corner_hz: float, sample_rate: float, frequency: float) -> float:
+    """|H(f)| of the ``DcBlocker`` high-pass ``H(z)=(1-z^-1)/(1-p z^-1)``.
+
+    Exact steady-state gain the engine applies to a sine at ``frequency`` — a pure
+    sine through the linear DC blocker stays a pure sine, scaled by this. Used by
+    the level-curve fit; the time-domain path runs the recurrence instead.
+    """
+    if not (corner_hz > 0.0):
+        return 1.0
+    p = ac_pole(corner_hz, sample_rate)
+    w = 2.0 * math.pi * frequency / sample_rate
+    num = 2.0 - 2.0 * math.cos(w)                      # |1 - e^{-jw}|^2.
+    den = 1.0 - 2.0 * p * math.cos(w) + p * p          # |1 - p e^{-jw}|^2.
+    return math.sqrt(num / den)
+
+
+class DcBlocker:
+    """Scalar port of ``pulp::signal::DcBlocker`` — ``y = x - x_1 + p*y_1``."""
+
+    def __init__(self, pole: float) -> None:
+        self.pole = pole
+        self.last_in = 0.0
+        self.last_out = 0.0
+
+    def process(self, x: float) -> float:
+        y = x - self.last_in + self.pole * self.last_out
+        if abs(y) < 1e-15:   # snap_to_zero (denormal flush); no-op at our levels.
+            y = 0.0
+        self.last_in = x
+        self.last_out = y
+        return y
+
+
+# ── Bandlimited core: PhaseAccumulator + polyBLEP/BLAMP (va.hpp) ───────────────
+
+
+def _blamp_residual(x: float) -> float:
+    if x < -1.0 or x >= 1.0:
+        return 0.0
+    if x < 0.0:
+        return x * x * x / 6.0 + 0.5 * x * x + 0.5 * x + 1.0 / 6.0
+    return 0.5 * x * x - x * x * x / 6.0 - 0.5 * x + 1.0 / 6.0
+
+
+def _poly_blep(d: float, height: float) -> tuple[float, float]:
+    if not (0.0 <= d <= 1.0):
+        return 0.0, 0.0
+    before = 0.5 * d * d - d + 0.5
+    x = 1.0 - d
+    after = x - 0.5 * x * x - 0.5
+    return height * before, height * after
+
+
+def _poly_blamp(d: float, slope_change: float) -> tuple[float, float]:
+    if not (0.0 <= d <= 1.0):
+        return 0.0, 0.0
+    return slope_change * _blamp_residual(-d), slope_change * _blamp_residual(1.0 - d)
+
+
+def _threshold_crossings(phase_before: float, increment: float, threshold: float,
+                         capacity: int = 8) -> list[float]:
+    """Port of ``threshold_crossings`` — sub-sample fractions crossing a level."""
+    if not math.isfinite(increment) or increment == 0.0:
+        return []
+    q0 = phase_before - threshold
+    first = math.floor(q0)
+    last = math.floor(q0 + increment)
+    if not (math.isfinite(first) and math.isfinite(last)):
+        return []
+    forward = increment > 0.0
+    magnitude = (last - first) if forward else (first - last)
+    if not (magnitude >= 1.0):
+        return []
+    count = capacity if magnitude > capacity else int(magnitude)
+    out = []
+    for k in range(count):
+        level = first + 1.0 + k if forward else first - k
+        out.append((level - q0) / increment)
+    return out
+
+
+class VaCore:
+    """Virtual-analog core — ``VaOscillator`` (no sync path; F1 renders never sync)."""
+
+    _TWO_PI = 2.0 * math.pi
+
+    def __init__(self, shape: Shape = Shape.saw, pulse_width: float = 0.5) -> None:
+        self.shape = shape
+        self.pulse_width = min(max(pulse_width, 0.0), 1.0)
+        self._phase = 0.0
+        self._carry = 0.0
+
+    def reset(self, phase: float = 0.0) -> None:
+        w = phase - math.floor(phase)
+        self._phase = w if 0.0 <= w < 1.0 else 0.0
+        self._carry = 0.0
+
+    # value() — the trivial shape, matching the header's limit-at-1 invariants.
+    def _value(self, p: float) -> float:
+        s = self.shape
+        if s == Shape.sine:
+            return 0.0 if p >= 1.0 else math.sin(self._TWO_PI * p)
+        if s == Shape.saw:
+            return 2.0 * p - 1.0
+        if s == Shape.square:
+            return 1.0 if (self.pulse_width >= 1.0 or p < self.pulse_width) else -1.0
+        # triangle.
+        return (4.0 * p - 1.0) if p < 0.5 else (3.0 - 4.0 * p)
+
+    def _slope_per_cycle(self, p: float) -> float:
+        s = self.shape
+        if s == Shape.sine:
+            return self._TWO_PI * math.cos(self._TWO_PI * p)
+        if s == Shape.saw:
+            return 2.0
+        if s == Shape.triangle:
+            return 4.0 if p < 0.5 else -4.0
+        return 0.0  # square.
+
+    def _internal_threshold(self):
+        """(phase, value_below, value_above, slope_below, slope_above) or None."""
+        s = self.shape
+        if s == Shape.square:
+            if not (0.0 < self.pulse_width < 1.0):
+                return None
+            return (self.pulse_width, 1.0, -1.0, 0.0, 0.0)
+        if s == Shape.triangle:
+            return (0.5, 1.0, 1.0, 4.0, -4.0)
+        return None
+
+    def _advance_phase(self, increment: float) -> list[tuple[float, float, float]]:
+        """Port of ``PhaseAccumulator::scan`` — returns (frac, before, after)."""
+        if not math.isfinite(increment):
+            self._phase = 0.0
+            return []
+        p0 = self._phase
+        raw = p0 + increment
+        n = math.floor(raw)
+        wrapped = raw - n
+        if not (0.0 <= wrapped < 1.0):
+            wrapped = 0.0
+        magnitude = abs(n)
+        if magnitude > 8:
+            events_n = 8
+        elif magnitude >= 1.0:
+            events_n = int(magnitude)
+        else:
+            events_n = 0
+        forward = n > 0.0
+        events = []
+        for k in range(events_n):
+            level = (k + 1) if forward else -k
+            t = (level - p0) / increment
+            events.append((t, 1.0 if forward else 0.0, 0.0 if forward else 1.0))
+        self._phase = wrapped
+        return events
+
+    def _add_break(self, frac: float, value_step: float, slope_step: float,
+                   out: float) -> float:
+        if value_step != 0.0:
+            before, after = _poly_blep(frac, value_step)
+            out += before
+            self._carry += after
+        if slope_step != 0.0:
+            before, after = _poly_blamp(frac, slope_step)
+            out += before
+            self._carry += after
+        return out
+
+    def _scan_threshold(self, start_phase: float, delta: float, rate: float,
+                        t0: float, span: float, out: float) -> float:
+        t = self._internal_threshold()
+        if t is None:
+            return out
+        phase_t, value_below, value_above, slope_below, slope_above = t
+        fracs = _threshold_crossings(start_phase, delta, phase_t)
+        if not fracs:
+            return out
+        forward = delta > 0.0
+        value_step = (value_above - value_below) if forward else (value_below - value_above)
+        slope_step = ((slope_above - slope_below) if forward
+                      else (slope_below - slope_above)) * rate
+        for f in fracs:
+            out = self._add_break(t0 + f * span, value_step, slope_step, out)
+        return out
+
+    def next(self, increment: float) -> float:
+        entry_phase = self._phase
+        out = self._value(entry_phase) + self._carry
+        self._carry = 0.0
+        events = self._advance_phase(increment)
+        for frac, before, after in events:
+            value_step = self._value(after) - self._value(before)
+            slope_step = (self._slope_per_cycle(after) - self._slope_per_cycle(before)) * increment
+            out = self._add_break(frac, value_step, slope_step, out)
+        out = self._scan_threshold(entry_phase, increment, increment, 0.0, 1.0, out)
+        return out
+
+
+# ── Full VcoOscillator render ─────────────────────────────────────────────────
+
+DEFAULT_START_PHASE = 0.13   # matches OscSourceProcessor::kStartPhase.
+
+
+def render(profile: VcoProfile, shape: Shape, frequency_hz: float,
+           sample_rate: float, num_samples: int,
+           start_phase: float = DEFAULT_START_PHASE) -> np.ndarray:
+    """Render ``num_samples`` of the OSC-VCO deterministic path, faithfully.
+
+    Drift/jitter are off (F1), so the per-sample increment is constant and
+    ``pitch_noise_factor()`` is exactly 1.0.
+    """
+    core = VaCore(shape, profile.pulse_width)
+    core.reset(start_phase)
+    increment = frequency_hz / sample_rate
+    shaper = profile.shapers[shape]
+    reset = profile.core_reset_seconds
+    tilt = profile.level_tilt_db_per_octave
+    ac_on = profile.ac_corner_hz > 0.0
+    blocker = DcBlocker(ac_pole(profile.ac_corner_hz, sample_rate)) if ac_on else None
+    # level_for depends only on |increment|*sr, constant here — compute once.
+    gain = level_for(profile, abs(increment) * sample_rate, sample_rate)
+
+    out = np.empty(num_samples, dtype=np.float64)
+    for i in range(num_samples):
+        v = core.next(increment)
+        v = apply_bow(profile.bow, v, shape)
+        v = apply_waveshaper(shaper, v)
+        v *= gain
+        out[i] = blocker.process(v) if ac_on else v
+    return out
+
+
+def render_sine(profile: VcoProfile, frequency_hz: float, sample_rate: float,
+                num_samples: int) -> np.ndarray:
+    """Fast vectorized sine render (pitch/level/AC only) — the sine core is a pure
+    ``sin`` and needs no per-sample BLEP loop. Used for the pitch + level kits."""
+    n = np.arange(num_samples)
+    phase = (DEFAULT_START_PHASE + frequency_hz / sample_rate * n)
+    v = np.sin(2.0 * math.pi * phase)
+    v = apply_waveshaper_array(profile.shapers[Shape.sine], v)
+    v *= level_for(profile, frequency_hz, sample_rate)
+    if profile.ac_corner_hz > 0.0:
+        blocker = DcBlocker(ac_pole(profile.ac_corner_hz, sample_rate))
+        out = np.empty(num_samples, dtype=np.float64)
+        for i in range(num_samples):
+            out[i] = blocker.process(float(v[i]))
+        return out
+    return v

--- a/tools/audio/quality-lab/quality_lab/osc_forward.py
+++ b/tools/audio/quality-lab/quality_lab/osc_forward.py
@@ -372,7 +372,7 @@ class VaCore:
 
 # ── Full VcoOscillator render ─────────────────────────────────────────────────
 
-DEFAULT_START_PHASE = 0.13   # matches OscSourceProcessor::kStartPhase.
+DEFAULT_START_PHASE = 0.13   # matches VcoSourceProcessor::kStartPhase.
 
 
 def render(profile: VcoProfile, shape: Shape, frequency_hz: float,

--- a/tools/audio/quality-lab/tests/test_click.py
+++ b/tools/audio/quality-lab/tests/test_click.py
@@ -631,15 +631,83 @@ def test_the_edge_smear_guard_not_the_drift_guard_is_what_refuses_a_steady_blep(
         assert not r.fired and r.low_coverage, "the edge-smear guard turns that into a refusal"
 
 
+# The render lengths the length-independence contract is pinned over. 0.3 s is the rest of
+# the suite's default; 3.0 s is ten times that — long enough that a GLOBAL smear statistic
+# would have drifted a near-floor seam's verdict across it (the N3 bug this section pins as
+# fixed). 1.0 s sits between so the sweep is not just its two endpoints.
+DUR_SWEEP = [0.3, 1.0, 3.0]
+
+
+@pytest.mark.parametrize("dur", DUR_SWEEP)
 @pytest.mark.parametrize("db", [-12, -20, -30])
-def test_a_seam_above_the_blep_smear_floor_still_fires(db):
-    """The refusal is regime-scoped, not a blanket 'ignore this oscillator': a seam louder
-    than the smear is a localized, off-edge outlier, so it fires despite the smear."""
+def test_a_seam_above_the_blep_smear_floor_fires_at_every_render_length(dur, db):
+    """Tier B: the refusal is regime-scoped AND render-length-independent. A seam louder than
+    the smear is the one period whose residual does not match the recurring per-period
+    template — a large novelty outlier — so it fires despite the smear, and because the
+    discriminator is a per-period RATIO it fires at 0.3 s and at 3.0 s alike.
+
+    The old global `edge_concentration` statistic drifted with the period count, so the SAME
+    near-floor seam fired on a short clip and was REFUSED on a multi-second one (N3). This
+    parametrizes the seam over an order of magnitude of render length to pin that gone.
+    """
     sr, f0 = 48000, 440.0
-    y = fx.polyblep_square(sr, f0, DUR)
+    y = fx.polyblep_square(sr, f0, dur)
     peak = float(np.max(np.abs(y - np.mean(y))))
-    seam = fx.inject_step(y, int(0.15 * sr), peak * 10 ** (db / 20.0))
-    assert click.detect(seam, sr, f0_hint=f0).fired, f"missed a {db} dB seam on a polyBLEP square"
+    seam = fx.inject_step(y, int(0.5 * dur * sr), peak * 10 ** (db / 20.0))
+    assert click.detect(seam, sr, f0_hint=f0).fired, f"missed a {db} dB seam at dur={dur}s"
+
+
+def test_the_near_floor_seam_verdict_no_longer_depends_on_render_length():
+    """The N3 fix, asserted at the level where the bug actually bit. A seam only ~5 dB above
+    the BLEP smear floor is close enough that the earlier global statistic crossed its
+    threshold as the render lengthened: it FIRED on a 0.3 s clip and was REFUSED on a 1-3 s
+    one. It must now yield the SAME verdict at every length, and the per-period novelty that
+    drives that verdict must barely move with length — that ratio invariance IS the fix.
+
+    Placed near the floor deliberately: a comfortably-loud seam fired under the old statistic
+    too, so it would not exercise the bug. Before this change the dur=1.0 and dur=3.0 branches
+    of this test failed (refused); after it, all three fire and the novelty spread is < 2 dB.
+    """
+    sr, f0 = 48000, 440.0
+    verdicts, novelties = [], []
+    for dur in DUR_SWEEP:
+        y = fx.polyblep_square(sr, f0, dur)
+        peak = float(np.max(np.abs(y - np.mean(y))))
+        seam = fx.inject_step(y, int(0.5 * dur * sr), peak * 10 ** (-25 / 20.0))
+        verdicts.append(click.detect(seam, sr, f0_hint=f0).fired)
+        novelties.append(click.analyze(seam, sr, f0_hint=f0).template_novelty_db)
+    assert all(verdicts), f"a near-floor seam's verdict flipped with length: fired={verdicts}"
+    assert max(novelties) - min(novelties) < 2.0, (
+        f"template novelty must be render-length-independent, got {novelties}"
+    )
+
+
+@pytest.mark.parametrize("dur", DUR_SWEEP)
+@pytest.mark.parametrize("wave", ["saw", "square"])
+def test_a_clean_blep_render_stays_refused_at_every_render_length(dur, wave):
+    """The other half of the length-independence contract: a pure-smear render (no seam)
+    must stay REFUSED at 0.3 s and 3.0 s alike. Length-independence has to cut both ways —
+    a discriminator that fixed the seam side by quietly starting to PASS a clean oscillator
+    on a long render would be a worse bug than the one it replaced."""
+    sr, f0 = 48000, 440.0
+    y = getattr(fx, f"polyblep_{wave}")(sr, f0, dur)
+    r = click.detect(y, sr, f0_hint=f0)
+    assert not r.fired and r.low_coverage, f"clean polyBLEP {wave} at dur={dur}s not refused: {r.notes}"
+
+
+@pytest.mark.parametrize("dur", DUR_SWEEP)
+def test_template_novelty_is_low_and_stable_for_pure_smear(dur):
+    """The mechanism behind the refusal, isolated and pinned. A pure BLEP smear repeats the
+    same shape every period, so after period-synchronous alignment every frame matches the
+    median-frame template and the per-period novelty stays a small ratio — well under the
+    `_TEMPLATE_NOVELTY_DB` outlier threshold — at every length. Pinned to the measured worst
+    (~4.5 dB across the grid) with margin, so a regression that lets the smear read as an
+    outlier (and thus a real seam read as smear) fails here."""
+    sr, f0 = 48000, 440.0
+    for wave in ("saw", "square"):
+        nov = click.analyze(getattr(fx, f"polyblep_{wave}")(sr, f0, dur), sr, f0_hint=f0).template_novelty_db
+        assert nov < 8.0, f"pure {wave} smear at dur={dur}s read as an outlier: {nov:.1f} dB"
+        assert nov < click._TEMPLATE_NOVELTY_DB, "smear must sit below the refusal threshold"
 
 
 def test_a_seam_below_the_blep_smear_floor_is_refused_never_passed():

--- a/tools/audio/quality-lab/tests/test_corpus_osc.py
+++ b/tools/audio/quality-lab/tests/test_corpus_osc.py
@@ -1,0 +1,124 @@
+"""Oscillator corpus families (static shapes, hard-sync sweep, TZFM grid).
+
+Extends the versioned, license-guarded corpus (`corpus.py`) with three synthetic,
+regenerable oscillator families, wired through the SAME `add_source` /
+`register_generated` / `materialize` machinery as the stretch-oriented families
+(`synthetic_drumbreak`, `synthetic_tonalpad`) — see `test_corpus.py`. Gated with the
+EXISTING `regression_net` ratchet (exit 1 = `regression_suspected`, exit 2 =
+unmeasurable) — no hand-rolled ratchet here.
+
+Two stats per family, both already-wired lab primitives:
+
+- **determinism / null-residual** — re-materializing a generator-backed source into a
+  fresh corpus dir must reproduce it bit-for-bit: exact array equality, AND
+  `dsp.null_residual_db` reading the bit-identical clamp (-160 dB).
+- **alias floor** — the `added-hf` compare axis (`quality_lab.compare`, backed by the
+  `hf_fizz` detector) as a golden-vs-candidate regression gate: an identity render
+  passes clean, and an injected HF defect (`generate.add_fizz`, a controlled stand-in
+  for the alias energy a real regression would add) trips `regression_suspected`.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from quality_lab import audio_io, corpus, dsp, generate, regression_net
+
+OSC_FAMILIES = ("synthetic_osc_static_shapes", "synthetic_osc_sync_sweep", "synthetic_osc_tzfm_grid")
+
+
+def _write(tmp_path, name, y, sr):
+    p = str(tmp_path / name)
+    audio_io.save_wav(p, y, sr)
+    return p
+
+
+def test_seed_registers_oscillator_families(tmp_path):
+    m = corpus.seed(str(tmp_path))
+    names = {s["name"] for s in m["sources"]}
+    assert set(OSC_FAMILIES) <= names
+    osc_entries = {s["name"]: s for s in m["sources"] if s["name"] in OSC_FAMILIES}
+    assert all(e["license"] == "synthetic" for e in osc_entries.values())
+    assert all(e["family"] == "oscillator" for e in osc_entries.values())
+    assert all(e["material_class"] == "synth" for e in osc_entries.values())
+
+
+def test_committed_corpus_has_oscillator_families():
+    """The committed corpus (not a tmp_path fixture) ships all three oscillator
+    families — the ratchet must see them without a re-seed step."""
+    m = corpus.load_manifest(corpus.default_corpus_dir())
+    names = {s["name"] for s in m["sources"]}
+    assert set(OSC_FAMILIES) <= names
+
+
+def test_osc_families_materialize_to_valid_audio(tmp_path):
+    corpus.seed(str(tmp_path))
+    for name in OSC_FAMILIES:
+        path = corpus.materialize(str(tmp_path), name)
+        y, sr = audio_io.load_wav(path)
+        assert sr == 48000
+        assert len(y) > 1000
+        assert np.all(np.isfinite(y))
+        assert np.max(np.abs(y)) <= 1.0 + 1e-6
+
+
+def test_osc_family_materialize_is_deterministic(tmp_path):
+    """Regenerating a generator-backed oscillator source twice reproduces it
+    bit-for-bit: the corpus's regenerable-not-committed contract depends on this,
+    and it is the determinism/null-residual stat the ratchet leans on."""
+    name = "synthetic_osc_static_shapes"
+    first = tmp_path / "first"
+    corpus.seed(str(first))
+    y_a, sr_a = audio_io.load_wav(corpus.materialize(str(first), name))
+
+    # A SEPARATE corpus dir for the second materialize, so this can't just be
+    # re-reading the first render's file untouched.
+    second = tmp_path / "second"
+    corpus.seed(str(second))
+    y_b, sr_b = audio_io.load_wav(corpus.materialize(str(second), name))
+
+    assert sr_a == sr_b == 48000
+    assert np.array_equal(y_a, y_b)
+    nr = dsp.null_residual_db(y_a, y_b)
+    assert nr.residual_db == -160.0  # dsp.null_residual_db's bit-identical clamp
+
+
+def test_osc_family_clean_render_passes_the_added_hf_axis(tmp_path):
+    """An identity golden-vs-candidate pair on the static-shape family must NOT trip
+    the alias/HF regression axis — the clean-pass half of the ratchet."""
+    corpus.seed(str(tmp_path))
+    y, sr = audio_io.load_wav(corpus.materialize(str(tmp_path), "synthetic_osc_static_shapes"))
+    golden = _write(tmp_path, "golden.wav", y, sr)
+    candidate = _write(tmp_path, "candidate.wav", y.copy(), sr)
+
+    rows = regression_net.run_net([("osc-static-shapes", golden, candidate)], profiles=("added-hf",))
+    assert regression_net.net_failed(rows) is False
+    assert regression_net.net_errored(rows) is False
+    assert regression_net.status(rows) == "CLEAN"
+
+
+def test_osc_family_degraded_render_trips_the_added_hf_regression(tmp_path):
+    """A deliberately-degraded candidate (injected HF fizz — a controlled stand-in for
+    real alias energy) MUST trip `regression_suspected` on the added-hf axis — the
+    exit-1 half of the ratchet, exercised on oscillator material."""
+    corpus.seed(str(tmp_path))
+    y, sr = audio_io.load_wav(corpus.materialize(str(tmp_path), "synthetic_osc_static_shapes"))
+    golden = _write(tmp_path, "golden.wav", y, sr)
+    degraded = generate.add_fizz(y, sr, amount=0.25)
+    candidate = _write(tmp_path, "candidate.wav", degraded, sr)
+
+    rows = regression_net.run_net([("osc-static-shapes", golden, candidate)], profiles=("added-hf",))
+    assert regression_net.net_failed(rows) is True
+    assert any(r.is_regression for r in rows)
+    assert regression_net.status(rows) == "REGRESSION"
+
+
+def test_osc_family_sync_sweep_and_tzfm_grid_also_gate_clean(tmp_path):
+    """Sanity: the other two oscillator families run through the SAME
+    golden-vs-identity clean-pass path, not just static shapes."""
+    corpus.seed(str(tmp_path))
+    for name in ("synthetic_osc_sync_sweep", "synthetic_osc_tzfm_grid"):
+        y, sr = audio_io.load_wav(corpus.materialize(str(tmp_path), name))
+        golden = _write(tmp_path, f"{name}.golden.wav", y, sr)
+        candidate = _write(tmp_path, f"{name}.candidate.wav", y.copy(), sr)
+        rows = regression_net.run_net([(name, golden, candidate)], profiles=("added-hf",))
+        assert regression_net.net_failed(rows) is False, name

--- a/tools/audio/quality-lab/tests/test_dsp.py
+++ b/tools/audio/quality-lab/tests/test_dsp.py
@@ -1,0 +1,58 @@
+"""Shared DSP primitives — the pieces with a ground truth known by construction.
+
+Each test here builds an input whose expected answer is a theorem, not a pinned run of the
+code, so a regression fails against math rather than against a golden number nobody can
+re-derive.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quality_lab.dsp import overlapping_allan_deviation
+
+
+def test_allan_slope_sign_separates_drift_from_jitter():
+    """The whole point of Allan deviation over a plain standard deviation: the SIGN of its
+    log-log slope tells analog drift from clock jitter, which no single-tau statistic can.
+
+    White frequency noise (independent per-sample jitter) averages DOWN with the averaging
+    time as tau^(-1/2) — a NEGATIVE slope. Random-walk frequency noise (drift, the running sum
+    of independent kicks) grows as tau^(+1/2) — a POSITIVE slope. Built from exactly those two
+    processes — white noise and its cumulative sum — so the expected sign is a theorem, and the
+    magnitudes land near the textbook ±1/2.
+    """
+    rng = np.random.default_rng(0)
+    n = 4096
+    jitter_series = rng.standard_normal(n)                 # white FM  → clock jitter
+    drift_series = np.cumsum(rng.standard_normal(n))       # random-walk FM → analog drift
+
+    jitter = overlapping_allan_deviation(jitter_series)
+    drift = overlapping_allan_deviation(drift_series)
+
+    assert jitter.slope < 0.0 < drift.slope, (
+        f"the slope sign must separate the two noise types: "
+        f"jitter={jitter.slope:.3f}, drift={drift.slope:.3f}"
+    )
+    assert jitter.slope == pytest.approx(-0.5, abs=0.2), f"white FM slope off tau^(-1/2): {jitter.slope:.3f}"
+    assert drift.slope == pytest.approx(0.5, abs=0.25), f"random-walk FM slope off tau^(+1/2): {drift.slope:.3f}"
+
+
+def test_allan_reports_octave_spaced_taus_over_the_record():
+    """The estimator must actually sweep a range of averaging times — a single tau cannot show
+    a slope. Octave spacing up to ~half the record gives ~log2(N) points, all positive."""
+    dev = overlapping_allan_deviation(np.random.default_rng(1).standard_normal(1024))
+    assert dev.taus.size >= 4 and np.all(dev.deviations > 0.0)
+    assert np.array_equal(dev.taus, np.asarray([1 << k for k in range(dev.taus.size)], dtype=float)), (
+        "averaging factors must be octave-spaced 1, 2, 4, …"
+    )
+
+
+def test_allan_is_flat_for_a_too_short_series():
+    """Degenerate guard: a series too short to form two averaging factors cannot define a
+    slope, so it returns a 0.0 slope rather than raising or extrapolating from one point."""
+    for series in (np.array([]), np.array([1.0]), np.array([1.0, 2.0, 3.0])):
+        r = overlapping_allan_deviation(series)
+        assert r.slope == 0.0
+        assert r.taus.size == r.deviations.size
+        assert r.taus.size < 2

--- a/tools/audio/quality-lab/tests/test_fit.py
+++ b/tools/audio/quality-lab/tests/test_fit.py
@@ -1,0 +1,242 @@
+"""WP-4 F1 acceptance suite for the OSC-VCO fitting tool
+(``planning/2026-07-16-wp4-fitting-tool-scope-bound.md`` §4).
+
+* **Gate 1 — synthetic round-trip** (the estimator-works gate; deterministic,
+  public-CI-able per D6). Render a measurement kit from a KNOWN profile through
+  the OSC-VCO forward model, feed the tool only the kit plus the pinned set, and
+  recover every DETERMINISTIC Fit-column parameter within the doc's tolerance:
+  pitch-curve points ±1 cent; reset time ±10%; bow time-constant ±10%; shaper
+  harmonic signature ±1 dB up to the 10th harmonic; AC corner ±10%.
+
+* **Gate 3 — refusal.** The tool errors, with a pointer to the identifiability
+  table, when asked to fit any pinned (drift/jitter, nominal converter constants)
+  or cut (injection locking, PSU sag, …) parameter. F1 fits only the identifiable
+  subspace.
+
+* **Forward-model fidelity.** The Gate-1 renders come from a Python
+  re-implementation of ``vco.hpp`` (the render bridge cannot reach the
+  deterministic character parameters — §4). This test cross-checks that model
+  against the REAL C++ engine (``pulp-osc-render-wav``) for the neutral shapes,
+  so Gate 1 is a round-trip through a model proven to match the header. Skips
+  (never silently passes) when the tool is not built.
+"""
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from quality_lab import fit
+from quality_lab import osc_forward as fw
+from quality_lab.osc_forward import Shape, VcoProfile, VcoTuning, WaveshaperParams
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+# ── Known profiles for Gate 1 ─────────────────────────────────────────────────
+
+
+def _profile_a() -> VcoProfile:
+    p = VcoProfile()
+    p.tuning = VcoTuning(tune_offset_cents=7.0, scale_error=1.0025,
+                         hf_compression=0.03, hf_knee_octaves=3.0)
+    p.bow = 2.5
+    p.shapers[Shape.triangle] = WaveshaperParams(amount=0.7, drive=2.2, asymmetry=0.35)
+    p.level_tilt_db_per_octave = 2.5
+    p.core_reset_seconds = 3.0e-6
+    p.ac_corner_hz = 8.0
+    p.pulse_width = 0.42
+    return p
+
+
+def _profile_b() -> VcoProfile:
+    # A second point in parameter space, incl. hf_compression = 0 (the HF knee is
+    # then unidentifiable — the fit must still reproduce the pitch curve and not
+    # blow up), negative tilt, a gentler bow, a stronger/asymmetric shaper.
+    p = VcoProfile()
+    p.tuning = VcoTuning(tune_offset_cents=-11.0, scale_error=0.9985,
+                         hf_compression=0.0, hf_knee_octaves=3.0)
+    p.bow = 1.2
+    p.shapers[Shape.triangle] = WaveshaperParams(amount=0.9, drive=3.0, asymmetry=-0.2)
+    p.level_tilt_db_per_octave = -1.5
+    p.core_reset_seconds = 8.0e-6
+    p.ac_corner_hz = 20.0
+    p.pulse_width = 0.6
+    return p
+
+
+def _shaper_harmonic_db_error(true_shaper: WaveshaperParams,
+                              fit_shaper: WaveshaperParams) -> float:
+    """Max |ΔdB| over harmonics 1..10 of the two shapers' output on the SAME
+    triangle core input — the doc's shaper-signature tolerance. An integer number
+    of cycles fills the buffer so harmonics land exactly on FFT bins (no window)."""
+    phase = np.linspace(0.0, 1.0, 8192, endpoint=False)
+    core = np.where(phase < 0.5, 4.0 * phase - 1.0, 3.0 - 4.0 * phase)
+    yt = fw.apply_waveshaper_array(true_shaper, core)
+    yf = fw.apply_waveshaper_array(fit_shaper, core)
+    mt = np.abs(np.fft.rfft(yt))
+    mf = np.abs(np.fft.rfft(yf))
+    floor = 1e-4 * mt.max()
+    worst = 0.0
+    for h in range(1, 11):
+        if mt[h] < floor:            # skip harmonics the true shaper barely excites.
+            continue
+        worst = max(worst, abs(20.0 * math.log10(mt[h]) - 20.0 * math.log10(mf[h] + 1e-300)))
+    return worst
+
+
+@pytest.mark.parametrize("make_profile", [_profile_a, _profile_b])
+def test_gate1_synthetic_round_trip(make_profile):
+    true = make_profile()
+    kit = fit.build_measurement_kit(true)
+    fitted = fit.fit_profile(kit, VcoProfile(),
+                             pinned={"drift_depth": 4.0, "jitter_depth": 0.5})
+    rp = fitted.to_profile()
+
+    # Pitch curve — recovered tuning must reproduce every note within ±1 cent.
+    max_cents = max(
+        abs(1200.0 * math.log2(rp.tuning.frequency_hz(v) / true.tuning.frequency_hz(v)))
+        for v in np.arange(-2.0, 4.51, 0.25))
+    assert max_cents <= 1.0, f"pitch curve off by {max_cents:.3f} cents"
+
+    # Bow time-constant ±10%.
+    assert fitted.get("bow").estimate == pytest.approx(true.bow, rel=0.10)
+
+    # AC corner ±10%.
+    assert fitted.get("ac_corner_hz").estimate == pytest.approx(true.ac_corner_hz, rel=0.10)
+
+    # Reset time ±10%.
+    assert fitted.get("core_reset_seconds").estimate == pytest.approx(
+        true.core_reset_seconds, rel=0.10)
+
+    # Level tilt — not given an explicit tolerance in the doc; hold it tight since
+    # the curve fit is clean (a loose tilt would mean the level curve is mis-fit).
+    assert fitted.get("level_tilt_db_per_octave").estimate == pytest.approx(
+        true.level_tilt_db_per_octave, abs=0.15)
+
+    # Shaper harmonic signature ±1 dB up to the 10th harmonic.
+    fit_shaper = rp.shapers[Shape.triangle]
+    assert _shaper_harmonic_db_error(true.shapers[Shape.triangle], fit_shaper) <= 1.0
+
+    # Pulse width (duty) — the engine has no CV→duty map, so pulse_width is fit
+    # directly; a duty read to ~1 sample of the period.
+    assert fitted.get("pulse_width").estimate == pytest.approx(true.pulse_width, abs=0.01)
+
+
+def test_gate1_pinned_rows_labelled_not_measured():
+    """Stage-2 drift/jitter are hand-set placeholders in F1: they must appear in the
+    profile labeled ``pinned`` with their hand-set value, never as ``measured``."""
+    true = _profile_a()
+    kit = fit.build_measurement_kit(true)
+    fitted = fit.fit_profile(kit, VcoProfile(),
+                             pinned={"drift_depth": 4.0, "drift_rate_hz": 0.4,
+                                     "jitter_depth": 0.5})
+    for name in ("drift_depth", "drift_rate_hz", "jitter_depth"):
+        row = fitted.get(name)
+        assert row.disposition == "pinned"
+        assert row.stage == "2-deferred"
+    assert fitted.get("drift_depth").estimate == 4.0
+    assert fitted.get("jitter_depth").estimate == 0.5
+    # And every deterministic row IS measured — the two dispositions never blur.
+    for name in ("bow", "ac_corner_hz", "core_reset_seconds", "pulse_width"):
+        assert fitted.get(name).disposition == "measured"
+
+
+# ── Gate 3 — refusal ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", [
+    "drift_depth", "drift_rate_hz", "jitter_depth",     # stage-2 deferred / pinned.
+    "drift_family", "jitter_color", "comparator_hysteresis",
+    "temperature_injection_point", "thermal_tempco", "noise_slew_split",
+    "reference_hz", "volts_per_octave",                 # nominal converter constants.
+])
+def test_gate3_refuses_pinned(name):
+    with pytest.raises(fit.NotIdentifiableError) as exc:
+        fit.assert_fittable(name)
+    # The error points at the identifiability table (§2) — a test, not documentation.
+    assert "identifiability table" in str(exc.value)
+
+
+@pytest.mark.parametrize("name", [
+    "injection_locking", "psu_sag", "drift_exponent", "interaction_effects",
+])
+def test_gate3_refuses_cut(name):
+    with pytest.raises(fit.NotIdentifiableError) as exc:
+        fit.assert_fittable(name)
+    assert "CUT" in str(exc.value)
+
+
+def test_gate3_refuses_unknown_parameter():
+    # An unfamiliar name is refused too — the tool never invents a parameter the
+    # header/table does not define.
+    with pytest.raises(fit.NotIdentifiableError):
+        fit.assert_fittable("mystery_knob")
+
+
+def test_gate3_allows_fit_parameters():
+    for name in ("tune_offset_cents", "scale_error", "hf_compression",
+                 "hf_knee_octaves", "bow", "ac_corner_hz",
+                 "level_tilt_db_per_octave", "core_reset_seconds",
+                 "shaper", "pulse_width"):
+        fit.assert_fittable(name)   # must not raise.
+
+
+def test_gate3_pipeline_stages_call_the_gate():
+    """The refusal is not just a standalone check — the stage fitters invoke it, so
+    a pipeline can never fit a non-identifiable parameter by another path."""
+    saved = fit.IDENTIFIABILITY["bow"]
+    fit.IDENTIFIABILITY["bow"] = fit.Disposition("pin", "-", "temporarily pinned for the test")
+    try:
+        kit = fit.build_measurement_kit(_profile_a())
+        with pytest.raises(fit.NotIdentifiableError):
+            fit.fit_bow(kit, ac_corner_hz=8.0)
+    finally:
+        fit.IDENTIFIABILITY["bow"] = saved
+
+
+# ── Forward-model fidelity vs the real C++ engine ─────────────────────────────
+
+
+def _find_render_tool() -> Path | None:
+    override = os.environ.get("PULP_OSC_RENDER_WAV")
+    if override:
+        p = Path(override)
+        return p if p.exists() else None
+    for build in sorted(REPO_ROOT.glob("build*")):
+        cand = build / "test" / "pulp-osc-render-wav"
+        if cand.exists():
+            return cand
+    return None
+
+
+TOOL = _find_render_tool()
+
+
+@pytest.mark.skipif(TOOL is None,
+                    reason="pulp-osc-render-wav not built (set PULP_OSC_RENDER_WAV or build it)")
+@pytest.mark.parametrize("shape_name,shape", [
+    ("sine", Shape.sine), ("saw", Shape.saw),
+    ("square", Shape.square), ("triangle", Shape.triangle),
+])
+def test_forward_model_matches_engine(tmp_path, shape_name, shape):
+    """The Python OSC-VCO core must match the real engine on the neutral shapes —
+    the Gate-1 forward model is only as trustworthy as this cross-check."""
+    import soundfile as sf
+
+    out = tmp_path / f"{shape_name}.wav"
+    proc = subprocess.run(
+        [str(TOOL), "--out", str(out), "--shape", shape_name,
+         "--freq", "220", "--sr", "48000", "--dur-ms", "100", "--bits", "float"],
+        capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, f"render tool failed: {proc.stderr}\n{proc.stdout}"
+
+    cxx, _ = sf.read(str(out))
+    cxx = np.asarray(cxx, dtype=np.float64)
+    py = fw.render(VcoProfile(), shape, 220.0, 48000.0, len(cxx))
+    # float32 WAV quantization is ~1e-7; the models agree well inside that.
+    assert np.max(np.abs(py - cxx)) < 1e-6

--- a/tools/audio/quality-lab/tests/test_osc_wav_bridge.py
+++ b/tools/audio/quality-lab/tests/test_osc_wav_bridge.py
@@ -116,3 +116,86 @@ def test_bridge_int24_path_is_readable(tmp_path):
     assert sr == 48000
     assert channels == 1
     assert abs(_fundamental_hz(y, sr) - 440.0) < 2.0
+
+
+@requires_tool
+@pytest.mark.parametrize("engine", ["vco", "dco", "wt"])
+def test_bridge_engine_renders_on_pitch(tmp_path, engine):
+    """Each oscillator engine (`--engine vco|dco|wt`) renders a readable,
+    on-pitch WAV. `vco`/`dco` share the classical-shape parameter; `wt` has
+    none (it always plays its own bandlimited saw table), so this exercises
+    the engine-selection path end to end for all three."""
+    freq = 440.0
+    kwargs = dict(engine=engine, freq=freq, sr=48000, dur_ms=500)
+    if engine != "wt":
+        kwargs["shape"] = "saw"
+    wav = _render(tmp_path, **kwargs)
+
+    y, sr, channels = load_wav_info(str(wav))
+    assert sr == 48000
+    assert channels == 1
+    assert len(y) == 24000  # 500 ms at 48 kHz.
+    assert np.max(np.abs(y)) > 0.05  # not silence.
+
+    est = _fundamental_hz(y, sr)
+    # dco's pitch is quantized (not exact) by design, but at 440 Hz against
+    # the tool's 1 MHz default master clock the worst-case error is well
+    # under a cent — far inside this 2 Hz bin-spacing tolerance.
+    assert abs(est - freq) < 2.0, f"{engine}@{freq}Hz read back as {est:.2f} Hz"
+
+
+@requires_tool
+def test_bridge_seed_selects_vco_jitter_realization(tmp_path):
+    """`--seed` only has an audible effect on `vco` with nonzero drift/jitter
+    (the noise streams it seeds); it picks which pseudo-random realization
+    plays. The same seed must render byte-identical output (the tool's own
+    determinism contract — see osc_render_wav.cpp's usage doc); a different
+    seed must render a different one."""
+    common = dict(engine="vco", freq=440.0, sr=48000, dur_ms=100,
+                  jitter_cents=20.0)
+
+    dir_a1 = tmp_path / "seed-a1"
+    dir_a2 = tmp_path / "seed-a2"
+    dir_b = tmp_path / "seed-b"
+    for d in (dir_a1, dir_a2, dir_b):
+        d.mkdir()
+
+    wav_a1 = _render(dir_a1, seed=111, **common)
+    wav_a2 = _render(dir_a2, seed=111, **common)
+    wav_b = _render(dir_b, seed=222, **common)
+
+    assert wav_a1.read_bytes() == wav_a2.read_bytes(), (
+        "same --seed must render byte-identical output"
+    )
+    assert wav_a1.read_bytes() != wav_b.read_bytes(), (
+        "different --seed must render a different noise realization"
+    )
+
+
+@requires_tool
+@pytest.mark.parametrize("engine,flag", [
+    ("dco", "--seed"),
+    ("dco", "--drift-cents"),
+    ("wt", "--seed"),
+    ("wt", "--jitter-cents"),
+])
+def test_bridge_rejects_vco_only_flags_on_other_engines(tmp_path, engine, flag):
+    """`--seed`/`--drift-cents`/`--jitter-cents` apply only to `--engine vco`;
+    the tool must reject them on `dco`/`wt` with a clear message rather than
+    silently ignoring them."""
+    out = tmp_path / "osc.wav"
+    args = [str(TOOL), "--out", str(out), "--engine", engine, flag, "5"]
+    proc = subprocess.run(args, capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 2, f"expected rejection, got: {proc.stdout}{proc.stderr}"
+    assert not out.exists()
+
+
+@requires_tool
+def test_bridge_rejects_shape_on_wt_engine(tmp_path):
+    """`--shape` does not apply to `--engine wt` (it plays a fixed wavetable
+    set, not a classical shape)."""
+    out = tmp_path / "osc.wav"
+    args = [str(TOOL), "--out", str(out), "--engine", "wt", "--shape", "saw"]
+    proc = subprocess.run(args, capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 2, f"expected rejection, got: {proc.stdout}{proc.stderr}"
+    assert not out.exists()


### PR DESCRIPTION
Oscillator-suite §4 tail + the N3 Tier B redesign, built by a five-agent swarm and integrated + verified together (581 Python tests, C++ compile + 3 C++ tests, check-docs + US-English + skill-sync clean).

- **render** — `pulp-osc-render-wav` gains `--seed` and `--engine vco|dco|wt` (per-engine source processors; DCO's arg-less next(), WT's table setup handled).
- **Tier B click** — the edge-smear refusal is now render-length INDEPENDENT: a per-period `template_novelty_db` (worst period's departure from the recurring residual template) replaces the length-sensitive global localization; `edge_concentration` kept only for the smear-vs-zipper split. Independently confirmed: a −25 dB near-floor seam that the old code DROPPED at 3.0s now fires at every length. Plus an overlapping-Allan drift-vs-jitter helper in `dsp.py`.
- **WP-4 F1** — offline OSC-VCO profile fitter (deterministic stages 1/3/4/5; Python forward model cross-checked against the real engine to <1e-6; Gate 1 round-trip + Gate 3 refuses pinned/cut).
- **corpus + perf** — 3 synthetic oscillator corpus families with a `regression_net` ratchet; an advisory `PULP_BENCHMARK`-gated osc `next()` perf rig emitting the `bench_diff.py` schema (never reddens CI).
- **docs** — user guide for the VA/VCO/DCO/WT suite + status-manifest updates (kept off the OSC-networking `osc` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013a8ooKij63U6tet8FTvFJe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the oscillator-suite tail plus a render-length-independent click detector: new `--engine`/`--seed` options for `pulp-osc-render-wav`, an offline VCO fitting tool, new oscillator corpus and advisory perf bench, and a full guide for the VA/VCO/DCO/WT suite.

- **New Features**
  - `pulp-osc-render-wav`: add `--engine vco|dco|wt` and `--seed`; reject incompatible flags on `dco`/`wt`; add CLI shell-out smoke tests.
  - WP-4 F1: offline OSC‑VCO profile fitter in Quality Lab (`quality_lab.fit`) with a faithful forward model (`osc_forward.py`); deterministic stages only; cross‑checked against the C++ engine.
  - Oscillator corpus: three synthetic families (static shapes, hard‑sync sweep, TZFM grid) gated by the existing `regression_net` ratchet.
  - Advisory oscillator throughput bench: gated by `PULP_BENCHMARK`, reuses the existing `bench_diff.py` JSON schema.
  - DSP helper: add overlapping Allan deviation to separate drift from jitter.
  - Docs: new guide for `pulp::signal::osc` (VA/VCO/DCO/WT), cross‑links from legacy oscillator docs, and status index updates.

- **Bug Fixes**
  - Tier B click detector: replace length‑sensitive localization with per‑period template‑novelty, making seam detection render‑length independent; keep `edge_concentration` only for the smear‑vs‑zipper split.

<sup>Written for commit 6c36cf2908b07a501e188b5e723a8d6c41755ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

