### PR TITLE
fix(osc): Fable-review follow-ups — click half-integer novelty, WP-4 knee pin, nits

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -821,9 +821,16 @@ Durable "why / watch-out-for" notes so this isn't re-litigated (rationale, not w
   period, builds the median-frame TEMPLATE, and scores the worst period's departure from it over
   the median period's — a one-off seam is the single period that does NOT match the recurring
   template (a large outlier), while the smear repeats the same per-edge shape every period so it
-  barely departs. It is a per-period RATIO, so it is **render-length INDEPENDENT** (a longer clip
-  only adds more template-matching periods — it moves neither the worst nor the median): the same
-  near-floor seam that a global statistic dropped on a multi-second render now fires at any length.
+  barely departs. The departure is scored against a HIGH percentile (90th) of the per-period
+  departures, NOT the median — because at a HALF-INTEGER period (`sr/f0` frac ~0.5) the BLEP edge
+  alternates sub-sample phase A/B/A/B (true residual period 2P), so HALF the periods depart from
+  the per-P template: a median denominator reads that recurring half as a lone outlier and
+  FALSE-FIRES on a clean oscillator, flipping with period-count parity (render length). A high
+  percentile puts any recurring cluster over ~10% of periods (2P halves, 3P thirds) INTO the
+  denominator, so only a genuine one-off seam stays a large ratio. It is a per-period RATIO, so it
+  is **render-length INDEPENDENT** (a longer clip only adds more template-matching periods — it
+  moves neither the worst nor the percentile): the same near-floor seam that a global statistic
+  dropped on a multi-second render now fires at any length, at integer AND half-integer periods.
   `edge_concentration` (cosine similarity of `|residual|` to `|diff(y)|`) is kept, but ONLY to
   split smear (rides the waveform's own edges) from a block-rate zipper (off the edges) — novelty
   alone reads a stationary zipper as low-novelty and would wrongly refuse it. A refusal is NOT a pass:

--- a/test/osc_render_wav.cpp
+++ b/test/osc_render_wav.cpp
@@ -95,6 +95,10 @@ int main(int argc, char** argv) {
         } else if (std::strcmp(arg, "--freq") == 0) {
             const char* v = value_for(argc, argv, i, "--freq");
             if (!v) return 2;
+            // Note: the frequency reaches the oscillator through a float32 StateStore
+            // parameter, so a non-float32-exact value renders at float32(freq) — up to
+            // ~3e-4 Hz off the double parsed here. Harmless for musical use; pick a
+            // float32-exact frequency when cross-checking a double-math model bit-for-bit.
             spec.frequency_hz = std::atof(v);
         } else if (std::strcmp(arg, "--sr") == 0) {
             const char* v = value_for(argc, argv, i, "--sr");

--- a/tools/audio/quality-lab/quality_lab/detectors/click.py
+++ b/tools/audio/quality-lab/quality_lab/detectors/click.py
@@ -557,9 +557,21 @@ def _template_novelty_db(residual: np.ndarray, period: float, guard: int) -> flo
     frames = synchronous[: n_periods * m].reshape(n_periods, m)
     template = np.median(frames, axis=0)
     novelty = np.sqrt(np.mean((frames - template) ** 2, axis=1))  # per-period residual-of-residual
-    median = float(np.median(novelty))
+    # Denominator is a HIGH percentile of the per-period novelty, NOT the median. The median
+    # is a lone-outlier test only when the recurring background is unimodal. At a HALF-integer
+    # period (`sr/f0` fractional part ~0.5) the BLEP edge's sub-sample phase alternates A/B/A/B,
+    # so the true residual period is 2P: framed at P, half the periods match the median-frame
+    # template and half do NOT — a BIMODAL novelty. The median then sits in the low cluster and
+    # a recurring, half-of-all-periods departure reads as a lone outlier, false-firing on a CLEAN
+    # oscillator (and flipping with the parity of the period count, i.e. render length — the very
+    # N3 failure this axis exists to prevent). A high percentile puts any recurring cluster that
+    # occupies more than ~10% of periods (2P halves, 3P thirds, 4P quarters) INTO the denominator,
+    # so only a genuine one-off seam — a single period, far under 10% for any render long enough
+    # to clear the >= 4-period guard — stays a large ratio. Real seams keep a >50 dB margin over
+    # the refusal threshold, so the tighter denominator does not cost sensitivity.
+    background = float(np.percentile(novelty, 90.0))
     worst = float(novelty.max())
-    return 20.0 * np.log10(worst / median) if median > 0.0 else np.inf
+    return 20.0 * np.log10(worst / background) if background > 0.0 else np.inf
 
 
 def _edge_smear_signature(
@@ -738,6 +750,11 @@ def detect(
     )
     if not np.isfinite(a.click_db) or a.period_confidence < min_period_confidence:
         note += " — no stable period found; reading not trustworthy"
+    elif np.isnan(a.period_drift):
+        # Too few periods to split the render in two and measure drift at all — NOT a
+        # measured drift. `steady` is False here (NaN <= x is False), so the reading is
+        # correctly not-trustworthy, but the note must not claim a drift it never saw.
+        note += " — render too short to establish period stability; reading not trustworthy"
     elif not steady:
         note += " — pitch drifts during the render; the periodicity premise does not hold"
     elif edge_smear:

--- a/tools/audio/quality-lab/quality_lab/fit.py
+++ b/tools/audio/quality-lab/quality_lab/fit.py
@@ -442,8 +442,24 @@ def fit_pitch(kit: MeasurementKit, profile_ref: VcoProfile) -> list[FitParam]:
     upper = [1.1, 200.0, 0.5, 6.0]
     p, cov, _ = _lm(residual, p0, lower, upper)
     names = ["scale_error", "tune_offset_cents", "hf_compression", "hf_knee_octaves"]
+    # The knee only bends the curve where hf_compression multiplies it (`comp = hf_comp *
+    # (o - knee)` for o > knee). If compression fits ~0 the knee is INERT — unidentifiable —
+    # and the solver leaves it at a search-box value whose CI excludes the truth. Report it
+    # PINNED to nominal with an insensitive note rather than present that as measured (the
+    # shaper fitter does the same for a 2-valued square). Threshold is one order of magnitude
+    # below the smallest compression the pitch curve resolves.
+    kInsensitiveCompression = 1.0e-3
+    hf_comp_val = float(p[names.index("hf_compression")])
     out = []
     for i, name in enumerate(names):
+        if name == "hf_knee_octaves" and hf_comp_val < kInsensitiveCompression:
+            nominal = profile_ref.tuning.hf_knee_octaves
+            out.append(FitParam(name, float(nominal), float(nominal), float(nominal),
+                                IDENTIFIABILITY[name].measurement, disposition="pinned",
+                                note="insensitive — high-end compression fit ~0, so the knee "
+                                     "has no effect on the curve; pinned to nominal",
+                                stage="1-pitch"))
+            continue
         lo, hi = _ci(p[i], cov[i, i])
         out.append(FitParam(name, float(p[i]), lo, hi,
                             IDENTIFIABILITY[name].measurement,

--- a/tools/audio/quality-lab/tests/test_click.py
+++ b/tools/audio/quality-lab/tests/test_click.py
@@ -695,6 +695,41 @@ def test_a_clean_blep_render_stays_refused_at_every_render_length(dur, wave):
     assert not r.fired and r.low_coverage, f"clean polyBLEP {wave} at dur={dur}s not refused: {r.notes}"
 
 
+# HALF-INTEGER periods (`sr/f0` fractional part ~0.5) are the adversarial case for the
+# per-period template: the BLEP edge's sub-sample phase alternates A/B/A/B, so the true
+# residual period is 2P. Framed at P, half the periods depart from the median-frame template
+# — a BIMODAL novelty a lone-outlier (median-denominator) test misreads as a seam, false-firing
+# on a CLEAN oscillator with a verdict that flips with the parity of the period count (render
+# length). The high-percentile denominator puts that recurring half-of-all-periods cluster INTO
+# the background so it cannot read as an outlier.
+_HALF_INTEGER_F0 = [48000 / 109.5, 48000 / 96.5, 48000 / 217.5]
+
+
+@pytest.mark.parametrize("dur", DUR_SWEEP)
+@pytest.mark.parametrize("f0", _HALF_INTEGER_F0)
+def test_a_clean_half_integer_period_never_false_fires(dur, f0):
+    """A clean polyBLEP square at a half-integer period must REFUSE at every render length —
+    never fire on a correct oscillator, and never let the verdict depend on period-count parity
+    (the render-length flip a lone-outlier median denominator produced here)."""
+    y = fx.polyblep_square(48000, f0, dur)
+    r = click.detect(y, 48000, f0_hint=f0)
+    assert not r.fired, f"false fire on a clean half-integer oscillator f0={f0:.3f} dur={dur}s"
+
+
+@pytest.mark.parametrize("dur", DUR_SWEEP)
+@pytest.mark.parametrize("f0", _HALF_INTEGER_F0)
+def test_a_seam_at_a_half_integer_period_still_fires(dur, f0):
+    """The bimodal-smear fix must not blind the detector: a clear seam on a half-integer-period
+    oscillator is still the one period that departs beyond the (now elevated) recurring
+    background, so it fires at every render length."""
+    y = fx.bandlimited_square(48000, f0, dur)
+    peak = float(np.max(np.abs(y - np.mean(y))))
+    seam = fx.inject_step(y, int(0.5 * dur * 48000), peak * 10 ** (-20 / 20.0))
+    assert click.detect(seam, 48000, f0_hint=f0).fired, (
+        f"missed a -20 dB seam on a half-integer oscillator f0={f0:.3f} dur={dur}s"
+    )
+
+
 @pytest.mark.parametrize("dur", DUR_SWEEP)
 def test_template_novelty_is_low_and_stable_for_pure_smear(dur):
     """The mechanism behind the refusal, isolated and pinned. A pure BLEP smear repeats the


### PR DESCRIPTION
Second adversarial (Fable) pass over the merged oscillator tail (#6265). Confirmed 4/5 workstreams sound; fixed a real must-fix it found:

- **Click Tier B (MUST-FIX)** — the template-novelty refusal still had the N3 bug class at HALF-INTEGER periods (BLEP edge alternates A/B, true residual period 2P, so half the periods depart the per-P template): the worst/median ratio false-fired on a CLEAN oscillator with a verdict flipping with render-length parity. Fixed by scoring against a high percentile (90th), not the median; also recovers near-floor seam detection at half-integer periods. Regression tests added across the length sweep. Plus a drift-NaN refusal-note fix.
- **WP-4 fit (should-fix)** — pins hf_knee_octaves as insensitive when high-end compression fits ~0 (was reported 'measured' with a CI excluding truth).
- **render (nit)** — documents the float32-backed --freq parameter.

Verified: full quality-lab suite 599 passed / 3 skipped; US-English + skill-sync clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013a8ooKij63U6tet8FTvFJe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the oscillator click detector by using a high-percentile background, eliminating false positives and render-length flips at half-integer periods. Pins `hf_knee_octaves` when `hf_compression` ≈ 0, and clarifies the float32-backed `--freq` parameter.

- **Bug Fixes**
  - Click detector: score template novelty against the 90th percentile instead of the median to avoid half-integer false fires and parity flips; restores near-floor seam detection; fixes the refusal note for too-short renders; adds regression tests across the length sweep.
  - WP-4 fit: pin `hf_knee_octaves` to nominal with an “insensitive” note when `hf_compression` < 1e-3, preventing misleading “measured” knees.
  - Docs: document that `--freq` is applied via a float32 parameter.

- **Dependencies**
  - Bump `planning` subproject.

<sup>Written for commit 0548394c14146565af13823fed517921689f1987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

