### PR TITLE
test(ci): gate Windows runner policy across workflows

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1086,6 +1086,12 @@ to route a run. The standalone MSVC release-path, MIDI 2, and BLE compile gates
 remain on `windows-latest`, as do release builds, so the newest hosted compiler
 and SDK are still exercised without allowing an in-place runner-image
 migration to change the CRT/toolchain beneath the complete runtime suite.
+`tools/scripts/test_windows_runner_policy.py` reads every operative surface
+(build, release, coverage, nightly, release resolver, and Shipyard profile)
+independently and runs in the PR `workflow-lint` lane. Update that one
+cross-surface invariant whenever the split changes; a profile-only or
+workflow-only assertion is not enough because the two can self-agree while a
+different production lane drifts.
 
 Do not push empty commits just to churn queued macOS checks. Cancel
 superseded SHAs, rebase or push only when a PR needs current `main`, and

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1074,6 +1074,19 @@ use GitHub-hosted runners by default. macOS routes through the self-hosted
 `pulp-build` pool (`pulp-m1-01`, `pulp-m1-02`) via
 `PULP_LOCAL_MACOS_RUNS_ON_JSON`; repository variables control any overflow.
 
+The authoritative Windows x64 functional matrix is pinned to `windows-2022`
+(Visual Studio 2022) by `.github/workflows/build.yml`. Shipyard's current ship
+path does not send a `windows_runner_selector_json`, so the workflow fallback
+is the operative selector. `.shipyard/ci-profiles/normal-local-fast.toml`
+mirrors that PR policy with its PR-only `github.windows-x64-runtime` target for
+profile inspection; the current profile planner is read-only and does not
+override dispatch. Its shared coverage/scheduled `github.windows-x64` target
+remains `windows-latest`. Keep those mirrors truthful, but never rely on them
+to route a run. The standalone MSVC release-path, MIDI 2, and BLE compile gates
+remain on `windows-latest`, as do release builds, so the newest hosted compiler
+and SDK are still exercised without allowing an in-place runner-image
+migration to change the CRT/toolchain beneath the complete runtime suite.
+
 Do not push empty commits just to churn queued macOS checks. Cancel
 superseded SHAs, rebase or push only when a PR needs current `main`, and
 wait unless a check has actually failed.
@@ -1832,13 +1845,14 @@ Shipyard macOS GUI. The explicit selector has NO capacity fallback, so only set
 it when the pool reliably serves that lane — else legs route to a label with no
 online runner and queue.
 
-Windows is intentionally different. The required `Windows (x64)` gate must stay
-on real GitHub-hosted `windows-latest` unless a local x64 lane is explicitly
-proven and promoted. The current local Windows pool is Windows ARM64 on QEMU
-(`qemu-system-aarch64`): it can maybe smoke x64 via Windows-on-ARM translation,
-but it is not the authoritative Intel/x64 gate. Do not wire
-`PULP_LOCAL_WINDOWS_RUNS_ON_JSON` into the required Build-and-Test Windows x64
-matrix leg; use a separate/dedicated label for any local Windows ARM64 smoke.
+Windows is intentionally different. The required `Windows (x64)` functional
+gate stays on real GitHub-hosted `windows-2022`; the separate build-only MSVC
+release-path gate tracks `windows-latest`. The current local Windows pool is
+Windows ARM64 on QEMU (`qemu-system-aarch64`): it can maybe smoke x64 via
+Windows-on-ARM translation, but it is not the authoritative Intel/x64 gate.
+Do not wire `PULP_LOCAL_WINDOWS_RUNS_ON_JSON` into the required Build-and-Test
+Windows x64 matrix leg; use a separate/dedicated label for any local Windows
+ARM64 smoke.
 
 ### macOS runner routing (current)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,9 @@ jobs:
           #      toggled per-platform in the Shipyard GUI.
           #   3. unset → '' → resolver falls through to github-hosted (default).
           # Windows is deliberately different: the required PR leg is the
-          # authoritative x64 gate and must stay on windows-latest by default.
+          # authoritative x64 functional gate and stays on the stable VS 2022
+          # image. The separate MSVC release-path gate tracks windows-latest,
+          # so new-toolchain compile regressions still block before release.
           # Local QEMU Windows is ARM64; it can smoke Windows-on-ARM behavior, but
           # it is not an Intel Windows replacement. Use a workflow_dispatch input
           # only for explicit one-off experiments.
@@ -445,12 +447,14 @@ jobs:
           # Windows routes through the provider resolver, but it does NOT read
           # PULP_LOCAL_WINDOWS_RUNS_ON_JSON on PRs. That local lane is currently
           # Windows ARM64 on QEMU, useful as a smoke target but not an x64 gate.
-          # Keep windows-latest as the default authoritative x64 compatibility
-          # signal until a dedicated local x64 lane is proven.
+          # Keep functional tests on the stable VS 2022 image. windows-latest
+          # can change compiler and CRT generations in place; the dedicated
+          # release-path gate below covers that moving toolchain without making
+          # the authoritative runtime suite depend on an unpinned image.
           windows_runs_on = run([
               "--target-name", "Windows (x64)",
               "--mode", "provider",
-              "--github-hosted-label", "windows-latest",
+              "--github-hosted-label", "windows-2022",
               "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
               "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
               "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -12,20 +12,26 @@ name: Workflow lint
 # failed silently with "workflow file issue" and 0 jobs; this lint workflow
 # prevents the recurrence class.
 #
-# Scope: runs only on PRs that touch `.github/workflows/**` or this
-# file itself. Keeps the check fast on the 99% of PRs that don't
-# touch CI.
+# Scope: runs only on PRs that touch workflows/actions or the independently
+# tested Windows runner-policy surfaces. Keeps the check fast on the 99% of
+# PRs that don't touch CI.
 
 on:
   pull_request:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.shipyard/ci-profiles/normal-local-fast.toml'
+      - 'tools/scripts/resolve_release_runners.py'
+      - 'tools/scripts/test_windows_runner_policy.py'
   push:
     branches: [main]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.shipyard/ci-profiles/normal-local-fast.toml'
+      - 'tools/scripts/resolve_release_runners.py'
+      - 'tools/scripts/test_windows_runner_policy.py'
 
 permissions:
   contents: read
@@ -127,6 +133,9 @@ jobs:
           python3 tools/scripts/test_workflow_build_dirs.py
           python3 tools/scripts/test_fetch_skia_for_release.py
           python3 tools/scripts/test_resolve_provider_busy_probe.py
+          # Keep the authoritative Windows runtime suite pinned independently
+          # from moving latest-toolchain release/coverage/nightly lanes.
+          python3 tools/scripts/test_windows_runner_policy.py
           # Pulp #47 — guard the linux-arm64 Skia manifest entry against
           # silent regressions (parallel to the linux-x64 / mac-arm64
           # entries enforced by tests/test_skia_determinism.py).

--- a/.shipyard/ci-profiles/normal-local-fast.toml
+++ b/.shipyard/ci-profiles/normal-local-fast.toml
@@ -27,7 +27,7 @@ github_variable = "PULP_LOCAL_LINUX_RUNS_ON_JSON"
 
 [repo."danielraffel/pulp".pr.windows]
 strategy = "github-only"
-targets = ["github.windows-x64"]
+targets = ["github.windows-x64-runtime"]
 
 [repo."danielraffel/pulp".release.macos]
 strategy = "ordered-fallback"
@@ -84,4 +84,8 @@ authoritative_for = ["linux-x64"]
 
 [targets."github.windows-x64"]
 runs_on_json = "windows-latest"
+authoritative_for = ["windows-x64"]
+
+[targets."github.windows-x64-runtime"]
+runs_on_json = "windows-2022"
 authoritative_for = ["windows-x64"]

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -1269,20 +1269,26 @@ label such as `pulp-coverage-vm-macos`; do not point coverage at `pulp-build`,
 | `PULP_LOCAL_LINUX_RUNS_ON_JSON` | Local Linux ARM64 VM pool | `gh variable set PULP_LOCAL_LINUX_RUNS_ON_JSON --body '["self-hosted","Linux","ARM64","pulp-build-linux"]'` |
 | `PULP_LOCAL_WINDOWS_RUNS_ON_JSON` | Local Windows ARM64 QEMU pool | `gh variable set PULP_LOCAL_WINDOWS_RUNS_ON_JSON --body '["self-hosted","Windows","ARM64","pulp-build-windows"]'` |
 
-`.tartci/normal-local-fast.toml` is the repo-local profile that documents the
-intended default policy: PR macOS, Linux, and Windows prefer local ARM64 VMs
-where available, while GitHub-hosted x64 Linux/Windows remains the scheduled
-compatibility safety net. Use `tartci profile plan normal-local-fast --repo
-danielraffel/pulp --json` from the tartci checkout to see the concrete variable
-values before changing repository variables.
+`.shipyard/ci-profiles/normal-local-fast.toml` is the repo-local, read-only
+policy mirror. Its PR-only `github.windows-x64-runtime` target records the
+stable `windows-2022` functional lane, while the shared
+`github.windows-x64` target records the `windows-latest` coverage/scheduled
+lane. The current Shipyard profile planner does not apply these selectors to
+a dispatch; `build.yml` remains authoritative. Inspect the profile when
+reviewing policy, then verify the workflow input and repository-variable
+precedence before changing live routing.
 
 Do not put ordered fallback chains directly into GitHub Actions. GitHub receives
 one `runs-on` selector per job; Shipyard/tartci must resolve "Mac Studio, then
 M5/blackbook, then GitHub" before dispatch or variable application.
 
 Windows local QEMU is Windows ARM64. An x64 MSVC/Prism smoke can be useful, but
-it is not a replacement for the GitHub-hosted `windows-latest` Intel/x64 signal
-until explicitly proven.
+it is not a replacement for the GitHub-hosted Intel/x64 functional gate. The
+required `build.yml` functional matrix is pinned to `windows-2022` so its CRT
+and Visual Studio generation do not move underneath the complete runtime
+suite. The standalone MSVC release-path, MIDI 2, and BLE compile gates remain
+on `windows-latest`; release builds and the nightly Intel safety net also keep
+tracking the newest hosted image.
 
 ### Nightly GitHub Intel validation
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -1289,6 +1289,11 @@ and Visual Studio generation do not move underneath the complete runtime
 suite. The standalone MSVC release-path, MIDI 2, and BLE compile gates remain
 on `windows-latest`; release builds and the nightly Intel safety net also keep
 tracking the newest hosted image.
+`tools/scripts/test_windows_runner_policy.py` enforces this split across the
+actual build, release, coverage, and nightly workflows plus the release runner
+resolver and Shipyard mirror. It runs in `workflow-lint`, including when the
+profile or the policy test itself changes, so these surfaces cannot drift while
+an isolated mirror test remains green.
 
 ### Nightly GitHub Intel validation
 

--- a/tools/scripts/test_resolve_classify_base.py
+++ b/tools/scripts/test_resolve_classify_base.py
@@ -16,6 +16,7 @@ Run:  python3 tools/scripts/test_resolve_classify_base.py
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -27,6 +28,9 @@ from resolve_classify_base import DEFAULT_BASE, ZERO_SHA, resolve_base  # noqa: 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
+SHIPYARD_PROFILE = (
+    REPO_ROOT / ".shipyard" / "ci-profiles" / "normal-local-fast.toml"
+)
 SCRIPT = Path(__file__).with_name("resolve_classify_base.py")
 
 BASE_SHA = "a" * 40
@@ -151,6 +155,48 @@ class WorkflowWiringTests(unittest.TestCase):
         self.assertNotIn(
             "github.event.pull_request.base.sha || 'origin/main'", self.text
         )
+
+    def test_windows_functional_matrix_uses_the_stable_runtime_image(self) -> None:
+        self.assertIn(
+            '"--github-hosted-label", "windows-2022"', self.text
+        )
+        self.assertNotIn(
+            '"--github-hosted-label", "windows-latest"', self.text
+        )
+        # Newest-toolchain coverage remains explicit in the three standalone
+        # compile gates, where an image migration cannot invalidate runtime
+        # behavior across the entire Windows test suite.
+        self.assertEqual(self.text.count("runs-on: windows-latest"), 3)
+        for job_name in (
+            "windows-msvc-release-gate",
+            "windows-midi2-gate",
+            "windows-ble-gate",
+        ):
+            with self.subTest(job=job_name):
+                marker = f"\n  {job_name}:\n"
+                self.assertIn(marker, self.text)
+                remainder = self.text.split(marker, 1)[1]
+                job = re.split(r"\n  [A-Za-z0-9_-]+:\n", remainder, 1)[0]
+                self.assertIn("runs-on: windows-latest", job)
+
+        # The profile planner is currently read-only, but its inspected PR
+        # policy must not contradict the workflow selector that dispatches.
+        # Coverage and scheduled validation deliberately retain latest.
+        shipyard_profile = SHIPYARD_PROFILE.read_text(encoding="utf-8")
+        pr_policy = shipyard_profile.split(
+            '[repo."danielraffel/pulp".pr.windows]', 1
+        )[1].split("\n[", 1)[0]
+        self.assertIn('targets = ["github.windows-x64-runtime"]', pr_policy)
+
+        runtime_target = shipyard_profile.split(
+            '[targets."github.windows-x64-runtime"]', 1
+        )[1].split("\n[", 1)[0]
+        self.assertIn('runs_on_json = "windows-2022"', runtime_target)
+
+        latest_target = shipyard_profile.split(
+            '[targets."github.windows-x64"]', 1
+        )[1].split("\n[", 1)[0]
+        self.assertIn('runs_on_json = "windows-latest"', latest_target)
 
     def test_workflow_triggers_on_push_to_main(self) -> None:
         # Without this trigger the cache-save steps below are unreachable:

--- a/tools/scripts/test_resolve_release_runners.py
+++ b/tools/scripts/test_resolve_release_runners.py
@@ -39,6 +39,9 @@ class FluidityInvariant(unittest.TestCase):
     def test_no_variables_means_github_hosted_everywhere(self) -> None:
         self.assertEqual(resolve({}), HOSTED)
 
+    def test_windows_x64_release_tracks_latest(self) -> None:
+        self.assertEqual(HOSTED["windows-x64"], "windows-latest")
+
     def test_every_leg_has_a_hosted_default(self) -> None:
         """A leg with no default could resolve to nothing and queue forever."""
         for leg in LEGS:

--- a/tools/scripts/test_windows_runner_policy.py
+++ b/tools/scripts/test_windows_runner_policy.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Lock the split between stable Windows runtime and latest-toolchain lanes.
+
+The authoritative functional suite deliberately uses ``windows-2022`` while
+release, coverage, scheduled, and standalone compile validation continue to
+exercise ``windows-latest``.  Read every operative workflow here so the policy
+cannot self-agree inside its documentation or Shipyard mirror while a real lane
+silently drifts.
+
+Run:  python3 tools/scripts/test_windows_runner_policy.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def job(workflow: str, name: str) -> str:
+    marker = f"\n  {name}:\n"
+    if marker not in workflow:
+        raise AssertionError(f"workflow job not found: {name}")
+    remainder = workflow.split(marker, 1)[1]
+    return re.split(r"\n  [A-Za-z0-9_-]+:\n", remainder, 1)[0]
+
+
+class WindowsRunnerPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.build = read(WORKFLOWS / "build.yml")
+        cls.release = read(WORKFLOWS / "release-cli.yml")
+        cls.coverage = read(WORKFLOWS / "coverage.yml")
+        cls.nightly = read(WORKFLOWS / "cross-platform-check.yml")
+        cls.release_resolver = read(
+            REPO_ROOT / "tools" / "scripts" / "resolve_release_runners.py"
+        )
+        cls.profile = read(
+            REPO_ROOT
+            / ".shipyard"
+            / "ci-profiles"
+            / "normal-local-fast.toml"
+        )
+
+    def test_authoritative_functional_suite_uses_windows_2022(self) -> None:
+        resolver = job(self.build, "resolve-provider")
+        windows_call = resolver.split(
+            '"--target-name", "Windows (x64)"', 1
+        )[1].split("])", 1)[0]
+        self.assertIn('"--github-hosted-label", "windows-2022"', windows_call)
+        self.assertNotIn("windows-latest", windows_call)
+        self.assertEqual(
+            len(re.findall(r"(?m)^\s*windows_runs_on\s*=", resolver)), 1
+        )
+        self.assertIn(
+            "matrix_json: ${{ steps.resolve.outputs.matrix_json }}", resolver
+        )
+        self.assertIn(
+            '"runs_on_json": windows_runs_on', resolver
+        )
+        self.assertIn(
+            'handle.write(f"matrix_json={json.dumps(matrix)}\\n")', resolver
+        )
+
+        consumer = job(self.build, "build")
+        self.assertIn("needs: [resolve-provider, classify]", consumer)
+        self.assertIn(
+            "matrix: ${{ fromJSON(needs.resolve-provider.outputs.matrix_json) }}",
+            consumer,
+        )
+        self.assertIn(
+            "runs-on: ${{ fromJSON(matrix.runs_on_json) }}", consumer
+        )
+
+    def test_standalone_latest_toolchain_gates_stay_on_latest(self) -> None:
+        for name in (
+            "windows-msvc-release-gate",
+            "windows-midi2-gate",
+            "windows-ble-gate",
+        ):
+            with self.subTest(job=name):
+                section = job(self.build, name)
+                self.assertIn("runs-on: windows-latest", section)
+                self.assertNotIn("windows-2022", section)
+
+    def test_release_build_and_smoke_stay_on_latest(self) -> None:
+        resolver = job(self.release, "resolve-macos-runner")
+        self.assertIn(
+            "python3 tools/scripts/resolve_release_runners.py --github-output",
+            resolver,
+        )
+        self.assertRegex(
+            self.release_resolver,
+            r'(?m)^\s*"windows-x64":\s*"windows-latest",$',
+        )
+        self.assertIn(
+            'print("map=" + json.dumps(resolved))', self.release_resolver
+        )
+        self.assertIn(
+            "map: ${{ steps.resolve.outputs.map }}", resolver
+        )
+        clean_env = dict(os.environ)
+        for name in (
+            "DARWIN_ARM64",
+            "DARWIN_X64",
+            "LINUX_X64",
+            "LINUX_ARM64",
+            "WINDOWS_X64",
+            "WINDOWS_ARM64",
+            "LOCAL_MACOS",
+            "NAMESPACE_JSON",
+        ):
+            clean_env.pop(name, None)
+        emitted = subprocess.run(
+            [
+                sys.executable,
+                str(
+                    REPO_ROOT
+                    / "tools"
+                    / "scripts"
+                    / "resolve_release_runners.py"
+                ),
+                "--github-output",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=clean_env,
+        )
+        self.assertEqual(emitted.returncode, 0, emitted.stderr)
+        map_line = next(
+            line for line in emitted.stdout.splitlines() if line.startswith("map=")
+        )
+        emitted_map = json.loads(map_line.removeprefix("map="))
+        self.assertEqual(emitted_map["windows-x64"], "windows-latest")
+        for name in ("build-cli", "smoke-cli"):
+            with self.subTest(job=name):
+                section = job(self.release, name)
+                self.assertRegex(
+                    section, r"(?m)^\s*needs:.*resolve-macos-runner"
+                )
+                self.assertRegex(
+                    section,
+                    r"(?m)^\s*- os: windows-latest\n\s+platform: windows-x64$",
+                )
+                self.assertIn(
+                    "runs-on: ${{ fromJSON(needs.resolve-macos-runner.outputs.map)"
+                    "[matrix.platform] }}",
+                    section,
+                )
+                self.assertNotIn("windows-2022", section)
+
+    def test_coverage_stays_on_latest(self) -> None:
+        resolver = job(self.coverage, "resolve-runners")
+        self.assertIn("windows='\"windows-latest\"'", resolver)
+        self.assertRegex(resolver, r"(?m)^\s+windows-latest\)$")
+        self.assertNotIn("windows-2022", resolver)
+        # Exactly the PR literal and non-PR resolver assignment. A later
+        # reassignment before publication would silently sever this chain.
+        self.assertEqual(len(re.findall(r"(?m)^\s*windows\s*=", resolver)), 2)
+        self.assertIn(
+            "windows_runs_on: ${{ steps.resolve.outputs.windows_runs_on }}",
+            resolver,
+        )
+        self.assertIn('echo "windows_runs_on=${windows}"', resolver)
+
+        matrix_config = job(self.coverage, "matrix-config")
+        self.assertIn("needs: [resolve-runners]", matrix_config)
+        self.assertIn(
+            "WINDOWS_RUNS_ON_JSON: "
+            "${{ needs.resolve-runners.outputs.windows_runs_on }}",
+            matrix_config,
+        )
+        self.assertIn(
+            '--argjson runs_on "${WINDOWS_RUNS_ON_JSON}"', matrix_config
+        )
+        self.assertIn(
+            "outputs:\n      matrix: ${{ steps.build.outputs.matrix }}",
+            matrix_config,
+        )
+        self.assertIn(
+            'echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"', matrix_config
+        )
+
+        consumer = job(self.coverage, "coverage")
+        self.assertRegex(consumer, r"(?m)^\s*needs:.*matrix-config")
+        self.assertIn(
+            "matrix: ${{ fromJSON(needs.matrix-config.outputs.matrix) }}",
+            consumer,
+        )
+        self.assertIn(
+            "runs-on: ${{ fromJSON(matrix.runs_on_json) }}", consumer
+        )
+
+    def test_scheduled_cross_platform_suite_stays_on_latest(self) -> None:
+        windows = job(self.nightly, "windows")
+        self.assertIn("runs-on: windows-latest", windows)
+        self.assertNotIn("windows-2022", windows)
+
+    def test_shipyard_mirror_preserves_runtime_and_latest_targets(self) -> None:
+        pr_windows = self.profile.split(
+            '[repo."danielraffel/pulp".pr.windows]', 1
+        )[1].split("\n[", 1)[0]
+        coverage_windows = self.profile.split(
+            '[repo."danielraffel/pulp".coverage.windows]', 1
+        )[1].split("\n[", 1)[0]
+        scheduled = self.profile.split(
+            '[repo."danielraffel/pulp".scheduled.nightly_intel]', 1
+        )[1].split("\n[", 1)[0]
+        runtime = self.profile.split(
+            '[targets."github.windows-x64-runtime"]', 1
+        )[1].split("\n[", 1)[0]
+        latest = self.profile.split(
+            '[targets."github.windows-x64"]', 1
+        )[1].split("\n[", 1)[0]
+
+        self.assertIn('targets = ["github.windows-x64-runtime"]', pr_windows)
+        self.assertIn('targets = ["github.windows-x64"]', coverage_windows)
+        self.assertIn('"github.windows-x64"', scheduled)
+        self.assertIn('runs_on_json = "windows-2022"', runtime)
+        self.assertIn('runs_on_json = "windows-latest"', latest)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins the PR Windows x64 functional matrix to `windows-2022` (VS 2022) for stability, while keeping release, coverage, nightly, and standalone MSVC gates on `windows-latest` to catch new-toolchain issues. Adds cross-workflow tests to enforce this split and updates the Shipyard profile and docs.

- New Features
  - Set the PR Windows x64 resolver in `build.yml` to `windows-2022`; leave standalone `windows-msvc-release-gate`, `windows-midi2-gate`, and `windows-ble-gate` on `windows-latest`.
  - Added `tools/scripts/test_windows_runner_policy.py` to validate runner policy across `build`, `release-cli`, `coverage`, `cross-platform-check`, the release runner resolver, and the Shipyard profile; runs in `workflow-lint`.
  - Updated `.shipyard/ci-profiles/normal-local-fast.toml` with `github.windows-x64-runtime` (`windows-2022`) for PRs; kept `github.windows-x64` (`windows-latest`) for coverage/scheduled.
  - Expanded `workflow-lint.yml` triggers to include the profile, release-runner resolver, and new policy test.
  - Updated `docs/guides/local-ci.md` and `.agents/skills/ci/SKILL.md` to document the split and clarify local Windows ARM64 smoke vs. the authoritative x64 gate.
  - Strengthened tests: `test_resolve_classify_base.py` and `test_resolve_release_runners.py` assert the image pinning and release mapping.

<sup>Written for commit 71627f8e574a6f542273eb51c71e39b95be666a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

