### PR TITLE
test(host): pin MIDI sidecar drain resumes

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -660,9 +660,17 @@ does not contain crashes in deeper plug-in code.
   pointer.
 - `SignalGraph::inject_midi()` and `extract_midi()` cross the
   control/audio-thread boundary through per-node mailboxes, not by mutating
-  audio-thread scratch directly. Keep mailbox snapshots and writer scratch
-  preallocated by `prepare()`; constructing a fresh MIDI snapshot in
-  `inject_midi()` reintroduces realtime-path allocation.
+  audio-thread scratch directly. After `prepare()`, injection is `noexcept`,
+  fixed-capacity, lock-free, and allocation-free, so it may run on the audio
+  callback immediately before `process()`. Each MidiInput has exactly one
+  writer — audio or control, never concurrent. A `false` return means the live
+  node is unavailable or the source was truncated; any retained prefix is
+  still published. Publications are latest-wins and one-shot, and sequence
+  wrap skips zero. A gap-free `prepare_swap()` shares the ingress mailbox and
+  consumed sequence for a stable MidiInput NodeId, preserving unconsumed MIDI
+  across the swap. MidiOutput egress remains snapshot-local: when
+  `prepare_swap()` returns `NeedsEagerPrepare`, the old live snapshot remains
+  valid, so drain it with `extract_midi()` before eager `prepare()` replaces it.
 - `SignalGraph::inject_parameter_events()` uses a separate prepared per-node
   mailbox with one control-side writer. Publications are latest-wins and
   one-shot: the next successful serial, routed, parallel, or anticipation

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -668,7 +668,9 @@ does not contain crashes in deeper plug-in code.
   still published. Publications are latest-wins and one-shot, and sequence
   wrap skips zero. A gap-free `prepare_swap()` shares the ingress mailbox and
   consumed sequence for a stable MidiInput NodeId, preserving unconsumed MIDI
-  across the swap. MidiOutput egress remains snapshot-local: when
+  across the swap. MidiOutput egress remains snapshot-local but uses an ordered,
+  fixed four-block SPSC queue: empty blocks cannot overwrite pending output;
+  overflow retains the earliest blocks and makes extraction incomplete. When
   `prepare_swap()` returns `NeedsEagerPrepare`, the old live snapshot remains
   valid, so drain it with `extract_midi()` before eager `prepare()` replaces it.
 - `SignalGraph::inject_parameter_events()` uses a separate prepared per-node

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -671,6 +671,10 @@ does not contain crashes in deeper plug-in code.
   across the swap. MidiOutput egress remains snapshot-local but uses an ordered,
   fixed four-block SPSC queue: empty blocks cannot overwrite pending output;
   overflow retains the earliest blocks and makes extraction incomplete. When
+  the destination lacks short-event, SysEx, or attached UMP-sidecar capacity,
+  extraction returns false and retains the undelivered suffix. Provide storage
+  and call `extract_midi()` again; it resumes without replaying the delivered
+  prefix. When
   `prepare_swap()` returns `NeedsEagerPrepare`, the old live snapshot remains
   valid, so drain it with `extract_midi()` before eager `prepare()` replaces it.
 - `SignalGraph::inject_parameter_events()` uses a separate prepared per-node

--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -138,6 +138,16 @@ Patterns that are easy to get wrong:
    public surface free of CHOC types. Format with `choc::json::toString`
    on the way in and `choc::json::parse` on the way out if you need
    structured access.
+5. **Interrupt a WebSocket reader before releasing its socket.**
+   `WebSocketChannel::close()` uses `TcpStream::shutdown()` to wake blocking
+   reads. Destruction then joins the reader before closing the socket handle.
+   Preserve that order; closing the handle while the reader is inside
+   `receive()` races with descriptor invalidation.
+6. **Do not destroy a WebSocket channel from an inline callback.** With no
+   executor, callbacks run on the reader thread. They may call `close()`, but
+   must defer destruction until after the callback returns; otherwise the
+   destructor would attempt to join its own reader. Use an executor when the
+   callback needs to own channel lifetime.
 
 ## References
 

--- a/core/audio/include/pulp/audio/rt_safety_contract.hpp
+++ b/core/audio/include/pulp/audio/rt_safety_contract.hpp
@@ -598,6 +598,19 @@ inline constexpr std::array kCoreRuntimeRtSafetyContracts{
         "guard (deliberately not atomic<shared_ptr>), then walks ordered_runtime "
         "single-threaded; topology mutation happens off the callback."),
     detail::make_rt_safety_contract(
+        "SignalGraph",
+        "inject_midi",
+        RtSafetyClass::AudioCallbackSafeAfterPrepare,
+        true,
+        false,
+        false,
+        false,
+        true,
+        "exactly one writer per MidiInput node; audio-thread snapshot consumer",
+        "Publishes a latest-wins, one-shot fixed-capacity mailbox batch. A "
+        "preserved node ID shares the mailbox across a gap-free graph swap; "
+        "concurrent writers are unsupported."),
+    detail::make_rt_safety_contract(
         "Processor",
         "process",
         RtSafetyClass::AudioCallbackSafeAfterPrepare,

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -497,8 +497,11 @@ public:
                                  const state::ParameterEventQueue& events);
 
     // Drain queued nonempty MIDI blocks from a MidiOutput sink node in process
-    // order. Appends to `out`; returns false if bounded egress overflowed or a
-    // queued block was already incomplete.
+    // order. Appends to `out`; returns false if bounded egress overflowed, a
+    // queued block was already incomplete, or `out` lacks capacity/UMP sidecar
+    // storage. A destination-copy failure retains the undelivered suffix;
+    // provide more storage and call again to resume without replaying the
+    // delivered prefix.
     bool extract_midi(NodeId midi_output_node, midi::MidiBuffer& out) const;
 
     // Disconnect

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -523,7 +523,9 @@ public:
         Staged,            // a replacement instance is staged for prepare_swap().
         NeedsEagerPrepare, // not reinit-free (or a latency change) — caller must
                            // call prepare() under the usual no-process/no-pump
-                           // contract; the live snapshot has been invalidated.
+                           // contract. Ordinary failures invalidate the live
+                           // snapshot; the MidiOutput pending-egress refusal keeps
+                           // it live for extraction until that eager prepare.
         NotInSwapEdit,     // prepare_swap called without a matching begin_swap_edit.
     };
     // Begin a transactional topology edit that MAY publish with no silence. Between
@@ -537,7 +539,9 @@ public:
     void begin_swap_edit();
     // Publish the staged topology with no silent block if it is reinit-free (same
     // instances, no re-init, unchanged latency, no per-snapshot state to glitch);
-    // otherwise invalidate + return NeedsEagerPrepare so the caller eager-prepares.
+    // otherwise return NeedsEagerPrepare so the caller eager-prepares. Ordinary
+    // refusals invalidate the live snapshot. The MidiOutput pending-egress refusal
+    // deliberately leaves it live so the caller can drain extract_midi() first.
     SwapResult prepare_swap(double sample_rate, int max_block_size);
     // Abandon the no-silence attempt: invalidate the live snapshot (the staged
     // edits remain in the graph and take effect on the next prepare()).
@@ -1548,9 +1552,12 @@ private:
     // Reinit-free-swap predicate (PRE-compile half). True iff a live topology
     // swap to the current nodes_/connections_ needs NO plugin/custom re-init and
     // carries no per-snapshot mutable state a fresh snapshot would glitch: same
-    // sr/block; unchanged custom registry; anticipation off both sides; no MIDI
-    // edge; no smoothed sparse-automation edge; identical node set + plugin/custom
-    // instance identity; every resolved plugin node has a cached-metadata entry.
+    // sr/block; unchanged custom registry; anticipation off both sides; no
+    // MidiOutput in either the candidate or live snapshot; no smoothed sparse-
+    // automation edge; identical node set + plugin/custom instance identity; every
+    // resolved plugin node has a cached-metadata entry. Ingress-only MIDI is
+    // eligible because a stable MidiInput shares its mailbox and consumed-sequence
+    // state across snapshots.
     // The latency-equality gate is checked POST-compile in prepare_swap(). Pure
     // const read; caller holds the mutation mutex.
     bool snapshot_is_plugin_reinit_free_locked_(const CompiledGraph& old_cg,

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -565,6 +565,13 @@ public:
         std::function<std::unique_ptr<PluginSlot>(const PluginInfo&)>;
     void set_live_swap_plugin_loader_for_test(PluginLoaderForTest loader);
 
+    // Test seam for the non-zero MIDI-ingress publication sequence. The value
+    // becomes the predecessor consumed by the next inject_midi() call.
+    bool seed_midi_input_sequence_for_test(NodeId midi_input_node,
+                                           std::uint64_t predecessor) noexcept;
+    std::uint64_t midi_input_sequence_for_test(
+        NodeId midi_input_node) const noexcept;
+
     // Prepare-time topology bounds. Hosts that accept generated or user-built
     // graphs can lower these before prepare() so oversized graphs fail before
     // snapshot allocation or plugin prepare.

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -27,6 +27,7 @@
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/ump_buffer.hpp>
 #include <pulp/runtime/budget_policy.hpp>
+#include <pulp/runtime/spsc_queue.hpp>
 #include <pulp/runtime/triple_buffer.hpp>
 #include <pulp/state/modulation_lane.hpp>
 #include <atomic>
@@ -495,8 +496,9 @@ public:
     bool inject_parameter_events(NodeId plugin_node,
                                  const state::ParameterEventQueue& events);
 
-    // Drain the MIDI events that arrived at a MidiOutput sink node during
-    // the last process() call. Appends to `out`.
+    // Drain queued nonempty MIDI blocks from a MidiOutput sink node in process
+    // order. Appends to `out`; returns false if bounded egress overflowed or a
+    // queued block was already incomplete.
     bool extract_midi(NodeId midi_output_node, midi::MidiBuffer& out) const;
 
     // Disconnect
@@ -885,6 +887,7 @@ private:
                            uint64_t new_sequence,
                            bool source_incomplete = false) noexcept;
         bool copy_to_midi(midi::MidiBuffer& dst) const noexcept;
+        bool has_payload() const noexcept;
 
         midi::MidiBuffer events;
         midi::UmpBuffer ump;
@@ -900,6 +903,17 @@ private:
         MidiBlockSnapshot writer_scratch;
         std::atomic<uint64_t> next_sequence{0};
         std::atomic<uint64_t> sequence_seen{0};
+    };
+
+    struct MidiOutputMailbox {
+        static constexpr std::size_t kBlockCapacity = 4;
+        static_assert(std::atomic<bool>::is_always_lock_free,
+                      "MIDI egress overflow state must be lock-free");
+
+        runtime::SpscQueue<MidiBlockSnapshot, kBlockCapacity> pending;
+        std::atomic<bool> incomplete{false};
+        MidiBlockSnapshot consumer_scratch;
+        bool consumer_has_retry = false;
     };
 
     struct ParameterBlockSnapshot {
@@ -979,7 +993,9 @@ private:
         // control-thread egress use the mailboxes below so inject_midi()/
         // extract_midi() do not race process() scratch mutation. The shared
         // ingress mailbox preserves an unconsumed publication when a stable
-        // MidiInput node crosses a gap-free snapshot swap.
+        // MidiInput node crosses a gap-free snapshot swap. Egress is an ordered
+        // bounded drain queue so later blocks cannot overwrite a pending
+        // note-off before the control thread extracts it.
         midi::MidiBuffer midi_in;
         midi::MidiBuffer midi_out;
         midi::UmpBuffer midi_in_ump;
@@ -987,7 +1003,7 @@ private:
         bool midi_in_incomplete = false;
         bool midi_out_incomplete = false;
         std::shared_ptr<MidiInputMailbox> midi_input_mailbox;
-        std::unique_ptr<runtime::TripleBuffer<MidiBlockSnapshot>> midi_output_mailbox;
+        std::unique_ptr<MidiOutputMailbox> midi_output_mailbox;
 
         // Control/audio-thread parameter-event ingress for Plugin nodes. The
         // mailbox is single-writer/latest-wins like MIDI ingress; the sequence

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -887,6 +887,10 @@ private:
                            uint64_t new_sequence,
                            bool source_incomplete = false) noexcept;
         bool copy_to_midi(midi::MidiBuffer& dst) const noexcept;
+        bool append_to_midi(midi::MidiBuffer& dst,
+                            std::size_t& event_index,
+                            std::size_t& sysex_index,
+                            std::size_t& ump_index) const noexcept;
         bool has_payload() const noexcept;
 
         midi::MidiBuffer events;
@@ -914,6 +918,10 @@ private:
         std::atomic<bool> incomplete{false};
         MidiBlockSnapshot consumer_scratch;
         bool consumer_has_retry = false;
+        bool consumer_incomplete = false;
+        std::size_t consumer_event_index = 0;
+        std::size_t consumer_sysex_index = 0;
+        std::size_t consumer_ump_index = 0;
     };
 
     struct ParameterBlockSnapshot {

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -472,9 +472,17 @@ public:
     bool audio_rate_modulation_lane(const Connection& connection,
                                     state::ModulationLane& lane) const;
 
-    // Inject a MIDI buffer into a MidiInput source node. Call before
-    // process(); the events become that node's MIDI output this block.
-    bool inject_midi(NodeId midi_input_node, const midi::MidiBuffer& events);
+    // Inject a MIDI buffer into a MidiInput source node. Call before process();
+    // the latest published events become that node's MIDI output exactly once.
+    // Audio-callback-safe after prepare(): the mailbox is fixed-capacity and the
+    // call never allocates or locks. Exactly one thread may inject into a given
+    // MidiInput node; it may be the audio thread immediately before process(), or
+    // a control-side producer, but never concurrent writers. A false return means
+    // the live node is unavailable or the bounded mailbox retained only a prefix;
+    // that retained prefix is still published. A preserved MidiInput NodeId keeps
+    // its unconsumed publication across a gap-free prepare_swap().
+    bool inject_midi(NodeId midi_input_node,
+                     const midi::MidiBuffer& events) noexcept;
 
     // Inject sample-accurate parameter events into a Plugin node. Call before
     // process(); the latest published batch is consumed exactly once by that
@@ -861,11 +869,11 @@ private:
     struct MidiBlockSnapshot {
         MidiBlockSnapshot();
         MidiBlockSnapshot(const MidiBlockSnapshot& other);
-        MidiBlockSnapshot& operator=(const MidiBlockSnapshot& other);
+        MidiBlockSnapshot& operator=(const MidiBlockSnapshot& other) noexcept;
         bool set_from_midi(const midi::MidiBuffer& src,
                            uint64_t new_sequence,
-                           bool source_incomplete = false);
-        bool copy_to_midi(midi::MidiBuffer& dst) const;
+                           bool source_incomplete = false) noexcept;
+        bool copy_to_midi(midi::MidiBuffer& dst) const noexcept;
 
         midi::MidiBuffer events;
         midi::UmpBuffer ump;
@@ -874,9 +882,13 @@ private:
     };
 
     struct MidiInputMailbox {
+        static_assert(std::atomic<uint64_t>::is_always_lock_free,
+                      "MIDI ingress sequence atomics must be lock-free");
+
         runtime::TripleBuffer<MidiBlockSnapshot> published;
         MidiBlockSnapshot writer_scratch;
         std::atomic<uint64_t> next_sequence{0};
+        std::atomic<uint64_t> sequence_seen{0};
     };
 
     struct ParameterBlockSnapshot {
@@ -952,18 +964,19 @@ private:
         std::vector<uint32_t> sparse_automation_param_ids;
         std::vector<SparseAutomationAccum> sparse_automation_accum;
 
-        // MIDI scratch is audio-thread-owned. Control-thread ingress and
-        // egress use the mailboxes below so inject_midi()/extract_midi() do
-        // not race process() scratch mutation.
+        // MIDI scratch is audio-thread-owned. Single-writer ingress and
+        // control-thread egress use the mailboxes below so inject_midi()/
+        // extract_midi() do not race process() scratch mutation. The shared
+        // ingress mailbox preserves an unconsumed publication when a stable
+        // MidiInput node crosses a gap-free snapshot swap.
         midi::MidiBuffer midi_in;
         midi::MidiBuffer midi_out;
         midi::UmpBuffer midi_in_ump;
         midi::UmpBuffer midi_out_ump;
         bool midi_in_incomplete = false;
         bool midi_out_incomplete = false;
-        std::unique_ptr<MidiInputMailbox> midi_input_mailbox;
+        std::shared_ptr<MidiInputMailbox> midi_input_mailbox;
         std::unique_ptr<runtime::TripleBuffer<MidiBlockSnapshot>> midi_output_mailbox;
-        uint64_t midi_input_sequence_seen = 0;
 
         // Control/audio-thread parameter-event ingress for Plugin nodes. The
         // mailbox is single-writer/latest-wins like MIDI ingress; the sequence
@@ -1115,7 +1128,7 @@ private:
 
         // `pending_seq` is audio-thread scratch: the mailbox sequence a MidiInput
         // would consume this block, captured during the ingress pre-fill and
-        // committed to midi_input_sequence_seen only after the routed dispatch
+        // committed to the shared mailbox's sequence_seen only after routed dispatch
         // succeeds (so a fallback to the legacy walk re-consumes the same block).
         struct RoutedMidiNode { std::uint32_t plan_index; NodeId id; std::uint64_t pending_seq = 0; };
 

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -136,7 +136,7 @@ SignalGraph::MidiBlockSnapshot::MidiBlockSnapshot(
 }
 
 SignalGraph::MidiBlockSnapshot&
-SignalGraph::MidiBlockSnapshot::operator=(const MidiBlockSnapshot& other) {
+SignalGraph::MidiBlockSnapshot::operator=(const MidiBlockSnapshot& other) noexcept {
     if (this == &other) return *this;
     set_from_midi(other.events, other.sequence, other.incomplete);
     return *this;
@@ -145,7 +145,7 @@ SignalGraph::MidiBlockSnapshot::operator=(const MidiBlockSnapshot& other) {
 bool SignalGraph::MidiBlockSnapshot::set_from_midi(
     const midi::MidiBuffer& src,
     uint64_t new_sequence,
-    bool source_incomplete) {
+    bool source_incomplete) noexcept {
     clear_midi_block(events);
     sequence = new_sequence;
     const bool copied_all = copy_midi_block(src, events);
@@ -154,7 +154,7 @@ bool SignalGraph::MidiBlockSnapshot::set_from_midi(
 }
 
 bool SignalGraph::MidiBlockSnapshot::copy_to_midi(
-    midi::MidiBuffer& dst) const {
+    midi::MidiBuffer& dst) const noexcept {
     const bool copied_all = copy_midi_block(events, dst);
     return copied_all && !incomplete;
 }
@@ -640,10 +640,10 @@ bool SignalGraph::audio_rate_modulation_lane_locked_(const Connection& connectio
     return false;
 }
 
-bool SignalGraph::inject_midi(NodeId id, const midi::MidiBuffer& events) {
-    // Pin the live snapshot for the whole dereference: this control-thread API
-    // is not the prepare/release thread, so without the guard a concurrent
-    // prepare()/release()/invalidate could retire+free `cg` mid-use.
+bool SignalGraph::inject_midi(NodeId id,
+                              const midi::MidiBuffer& events) noexcept {
+    // Pin the live snapshot for the whole dereference. Without the guard a
+    // concurrent prepare()/release()/invalidate could retire+free `cg` mid-use.
     auto read_guard = live_slot_.read();
     auto* cg = read_guard.get();
     if (!cg) return false;
@@ -1330,8 +1330,21 @@ SignalGraph::compile_(double sample_rate, int max_block_size, CompileMode mode) 
         prepare_midi_block_storage(runtime_it->second.midi_out,
                                    runtime_it->second.midi_out_ump);
         if (n.type == NodeType::MidiInput) {
-            runtime_it->second.midi_input_mailbox =
-                std::make_unique<MidiInputMailbox>();
+            // Keep mailbox identity across a live snapshot recompile so an
+            // injection published between its build and publication cannot fall
+            // between the old and new snapshots. Normal eager prepare has no live
+            // snapshot here and allocates a fresh mailbox.
+            if (const auto live = live_slot_.live()) {
+                auto old_it = live->runtime.find(n.id);
+                if (old_it != live->runtime.end()) {
+                    runtime_it->second.midi_input_mailbox =
+                        old_it->second.midi_input_mailbox;
+                }
+            }
+            if (!runtime_it->second.midi_input_mailbox) {
+                runtime_it->second.midi_input_mailbox =
+                    std::make_shared<MidiInputMailbox>();
+            }
         }
         if (n.type == NodeType::MidiOutput) {
             runtime_it->second.midi_output_mailbox =
@@ -2276,7 +2289,9 @@ void SignalGraph::process_impl(audio::BufferView<float>& output,
                         const auto& injected =
                             rt_it->second.midi_input_mailbox->published.read();
                         if (injected.sequence != 0 &&
-                            injected.sequence != rt_it->second.midi_input_sequence_seen) {
+                            injected.sequence !=
+                                rt_it->second.midi_input_mailbox->sequence_seen.load(
+                                    std::memory_order_relaxed)) {
                             cg->routed.midi.set_out_incomplete(
                                 mi.plan_index, !injected.copy_to_midi(*out_buf));
                             mi.pending_seq = injected.sequence;
@@ -2292,7 +2307,8 @@ void SignalGraph::process_impl(audio::BufferView<float>& output,
                         if (mi.pending_seq == 0) continue;
                         auto rt_it = cg->runtime.find(mi.id);
                         if (rt_it != cg->runtime.end()) {
-                            rt_it->second.midi_input_sequence_seen = mi.pending_seq;
+                            rt_it->second.midi_input_mailbox->sequence_seen.store(
+                                mi.pending_seq, std::memory_order_relaxed);
                         }
                     }
                     for (const auto& mo : cg->routed.midi_outputs) {

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -178,6 +178,11 @@ bool SignalGraph::MidiBlockSnapshot::copy_to_midi(
     return copied_all && !incomplete;
 }
 
+bool SignalGraph::MidiBlockSnapshot::has_payload() const noexcept {
+    return !events.empty() || events.sysex_size() != 0 || !ump.empty()
+        || incomplete;
+}
+
 bool SignalGraph::ParameterBlockSnapshot::set_from_queue(
     const state::ParameterEventQueue& src,
     std::uint64_t new_sequence) noexcept {
@@ -774,8 +779,24 @@ bool SignalGraph::extract_midi(NodeId id, midi::MidiBuffer& out) const {
         return false;
     }
 
-    const auto& snapshot = it->second.midi_output_mailbox->read();
-    return snapshot.copy_to_midi(out);
+    auto& mailbox = *it->second.midi_output_mailbox;
+    bool complete = !mailbox.incomplete.exchange(false,
+                                                  std::memory_order_relaxed);
+    if (mailbox.consumer_has_retry) {
+        if (!copy_midi_block(mailbox.consumer_scratch.events, out)) {
+            return false;
+        }
+        complete = !mailbox.consumer_scratch.incomplete && complete;
+        mailbox.consumer_has_retry = false;
+    }
+    while (mailbox.pending.try_pop(mailbox.consumer_scratch)) {
+        if (!copy_midi_block(mailbox.consumer_scratch.events, out)) {
+            mailbox.consumer_has_retry = true;
+            return false;
+        }
+        complete = !mailbox.consumer_scratch.incomplete && complete;
+    }
+    return complete;
 }
 
 bool SignalGraph::connect_feedback(NodeId source, PortIndex source_port,
@@ -1396,7 +1417,7 @@ SignalGraph::compile_(double sample_rate, int max_block_size, CompileMode mode) 
         }
         if (n.type == NodeType::MidiOutput) {
             runtime_it->second.midi_output_mailbox =
-                std::make_unique<runtime::TripleBuffer<MidiBlockSnapshot>>();
+                std::make_unique<MidiOutputMailbox>();
         }
         if (n.type == NodeType::Plugin && n.plugin) {
             // Keep mailbox identity across a live snapshot recompile so a
@@ -2368,7 +2389,12 @@ void SignalGraph::process_impl(audio::BufferView<float>& output,
                         }
                         cg->midi_publish_scratch.set_from_midi(
                             *in_buf, 0, cg->routed.midi.in_incomplete(mo.plan_index));
-                        rt_it->second.midi_output_mailbox->write(cg->midi_publish_scratch);
+                        if (cg->midi_publish_scratch.has_payload()
+                            && !rt_it->second.midi_output_mailbox->pending.try_push(
+                                cg->midi_publish_scratch)) {
+                            rt_it->second.midi_output_mailbox->incomplete.store(
+                                true, std::memory_order_relaxed);
+                        }
                     }
                 }
                 return true;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -31,6 +31,25 @@
 namespace pulp::host {
 namespace {
 
+std::uint64_t next_nonzero_mailbox_sequence(
+    std::atomic<std::uint64_t>& counter) noexcept {
+    auto current = counter.load(std::memory_order_relaxed);
+    for (;;) {
+        const auto next = current == std::numeric_limits<std::uint64_t>::max()
+                              ? std::uint64_t{1}
+                              : current + 1;
+        // The mailbox's single-writer contract means contention is not expected;
+        // CAS keeps the test seam and any accidental observer from losing an
+        // update. Relaxed is sufficient because this atomic carries identity
+        // only; TripleBuffer's release/acquire flag publishes the payload.
+        if (counter.compare_exchange_weak(current, next,
+                                          std::memory_order_relaxed,
+                                          std::memory_order_relaxed)) {
+            return next;
+        }
+    }
+}
+
 bool parameter_allows_modulation(const HostParamInfo& p,
                                  uint32_t param_id,
                                  state::ParamRate required_rate,
@@ -657,8 +676,7 @@ bool SignalGraph::inject_midi(NodeId id,
     }
 
     auto& mailbox = *it->second.midi_input_mailbox;
-    const uint64_t sequence =
-        mailbox.next_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    const uint64_t sequence = next_nonzero_mailbox_sequence(mailbox.next_sequence);
     const bool copied_all = mailbox.writer_scratch.set_from_midi(events, sequence);
     mailbox.published.write(mailbox.writer_scratch);
     return copied_all;
@@ -685,11 +703,41 @@ bool SignalGraph::inject_parameter_events(
 
     auto& mailbox = *runtime_it->second.parameter_input_mailbox;
     const std::uint64_t sequence =
-        mailbox.next_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+        next_nonzero_mailbox_sequence(mailbox.next_sequence);
     const bool copied_all =
         mailbox.writer_scratch.set_from_queue(events, sequence);
     mailbox.published.write(mailbox.writer_scratch);
     return copied_all;
+}
+
+bool SignalGraph::seed_midi_input_sequence_for_test(
+    NodeId id, std::uint64_t predecessor) noexcept {
+    auto read_guard = live_slot_.read();
+    auto* cg = read_guard.get();
+    if (!cg) return false;
+    auto runtime_it = cg->runtime.find(id);
+    const auto shape_it = cg->shapes.find(id);
+    if (runtime_it == cg->runtime.end() || shape_it == cg->shapes.end()
+        || shape_it->second.type != NodeType::MidiInput
+        || !runtime_it->second.midi_input_mailbox) {
+        return false;
+    }
+    runtime_it->second.midi_input_mailbox->next_sequence.store(
+        predecessor, std::memory_order_relaxed);
+    return true;
+}
+
+std::uint64_t SignalGraph::midi_input_sequence_for_test(NodeId id) const noexcept {
+    auto read_guard = live_slot_.read();
+    auto* cg = read_guard.get();
+    if (!cg) return 0;
+    const auto runtime_it = cg->runtime.find(id);
+    if (runtime_it == cg->runtime.end()
+        || !runtime_it->second.midi_input_mailbox) {
+        return 0;
+    }
+    return runtime_it->second.midi_input_mailbox->next_sequence.load(
+        std::memory_order_relaxed);
 }
 
 std::uint64_t SignalGraph::append_parameter_mailbox_events_(

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -178,6 +178,36 @@ bool SignalGraph::MidiBlockSnapshot::copy_to_midi(
     return copied_all && !incomplete;
 }
 
+bool SignalGraph::MidiBlockSnapshot::append_to_midi(
+    midi::MidiBuffer& dst,
+    std::size_t& event_index,
+    std::size_t& sysex_index,
+    std::size_t& ump_index) const noexcept {
+    while (event_index < events.size()) {
+        if (!dst.add(events[event_index])) return false;
+        ++event_index;
+    }
+    const auto& source_sysex = events.sysex();
+    while (sysex_index < source_sysex.size()) {
+        const auto& source = source_sysex[sysex_index];
+        const bool added = source.data.empty()
+            ? dst.add_sysex({}, source.sample_offset, source.timestamp)
+            : dst.add_sysex_copy(source.data.data(), source.data.size(),
+                                 source.sample_offset, source.timestamp);
+        if (!added) return false;
+        ++sysex_index;
+    }
+    auto* destination_ump = dst.ump();
+    while (ump_index < ump.size()) {
+        if (destination_ump == nullptr
+            || !destination_ump->add(ump[ump_index])) {
+            return false;
+        }
+        ++ump_index;
+    }
+    return true;
+}
+
 bool SignalGraph::MidiBlockSnapshot::has_payload() const noexcept {
     return !events.empty() || events.sysex_size() != 0 || !ump.empty()
         || incomplete;
@@ -780,22 +810,38 @@ bool SignalGraph::extract_midi(NodeId id, midi::MidiBuffer& out) const {
     }
 
     auto& mailbox = *it->second.midi_output_mailbox;
-    bool complete = !mailbox.incomplete.exchange(false,
-                                                  std::memory_order_relaxed);
+    mailbox.consumer_incomplete =
+        mailbox.incomplete.exchange(false, std::memory_order_relaxed)
+        || mailbox.consumer_incomplete;
     if (mailbox.consumer_has_retry) {
-        if (!copy_midi_block(mailbox.consumer_scratch.events, out)) {
+        if (!mailbox.consumer_scratch.append_to_midi(
+                out,
+                mailbox.consumer_event_index,
+                mailbox.consumer_sysex_index,
+                mailbox.consumer_ump_index)) {
             return false;
         }
-        complete = !mailbox.consumer_scratch.incomplete && complete;
+        mailbox.consumer_incomplete = mailbox.consumer_scratch.incomplete
+            || mailbox.consumer_incomplete;
         mailbox.consumer_has_retry = false;
     }
     while (mailbox.pending.try_pop(mailbox.consumer_scratch)) {
-        if (!copy_midi_block(mailbox.consumer_scratch.events, out)) {
+        mailbox.consumer_event_index = 0;
+        mailbox.consumer_sysex_index = 0;
+        mailbox.consumer_ump_index = 0;
+        mailbox.consumer_incomplete = mailbox.consumer_scratch.incomplete
+            || mailbox.consumer_incomplete;
+        if (!mailbox.consumer_scratch.append_to_midi(
+                out,
+                mailbox.consumer_event_index,
+                mailbox.consumer_sysex_index,
+                mailbox.consumer_ump_index)) {
             mailbox.consumer_has_retry = true;
             return false;
         }
-        complete = !mailbox.consumer_scratch.incomplete && complete;
     }
+    const bool complete = !mailbox.consumer_incomplete;
+    mailbox.consumer_incomplete = false;
     return complete;
 }
 

--- a/core/host/src/signal_graph_live_swap.cpp
+++ b/core/host/src/signal_graph_live_swap.cpp
@@ -597,6 +597,24 @@ SignalGraph::SwapResult SignalGraph::prepare_swap(double sample_rate,
 
     GraphMutationLock lock(*this);
     if (!in_swap_edit_) return SwapResult::NotInSwapEdit;
+
+    // MidiOutput publication is still owned by the live snapshot. Refuse this
+    // lane before the generic failure path invalidates that snapshot: callers
+    // must be able to drain a pending note-off with extract_midi() and then use
+    // eager prepare(). The authoring edits remain in nodes_/connections_; only
+    // the old compiled snapshot stays live until that eager replacement.
+    const bool has_midi_output = std::any_of(
+        nodes_.begin(), nodes_.end(),
+        [](const GraphNode& node) { return node.type == NodeType::MidiOutput; });
+    if (has_midi_output) {
+        set_live_swap_diagnostics_locked_(
+            LiveSwapFallbackReason::PredicateExcluded,
+            0,
+            "MIDI output has snapshot-local pending egress");
+        cancel_swap_edit_locked_();
+        return SwapResult::NeedsEagerPrepare;
+    }
+
     auto fail = [&](LiveSwapFallbackReason reason,
                     NodeId node,
                     std::string message) {
@@ -897,21 +915,29 @@ bool SignalGraph::snapshot_is_plugin_reinit_free_locked_(const CompiledGraph& ol
         old_cg.anticipation.valid) {
         return false;
     }
-    // (4) MIDI edges carry per-snapshot mailbox state (a dropped note-off = stuck
-    // note) and (5) a smoothed sparse-automation edge would snap its destination
-    // mid-ramp when the fresh snapshot re-primes the slew.
+    // (4) A smoothed sparse-automation edge would snap its destination mid-ramp
+    // when the fresh snapshot re-primes the slew. Ingress-only MIDI needs no
+    // exclusion: routing scratch is block-local, while a stable MidiInput's
+    // mailbox and consumed-sequence state are shared. MidiOutput remains
+    // snapshot-local, however, so swapping could discard an already-published
+    // note-off before extract_midi() observes it; keep output-bearing topologies
+    // on eager prepare until their egress mailbox can also be shared safely.
+    for (const auto& n : nodes_) {
+        if (n.type == NodeType::MidiOutput) return false;
+    }
+    for (const auto& [_, shape] : old_cg.shapes) {
+        if (shape.type == NodeType::MidiOutput) return false;
+    }
     for (const auto& c : connections_) {
         if (c.feedback) return false;
-        if (c.midi) return false;
         if (c.automation && c.automation_smoothing_ms > 0.0f) return false;
     }
     for (const auto& c : old_cg.connections) {
         if (c.feedback) return false;
-        if (c.midi) return false;  // defensive: the live snapshot itself had MIDI
     }
-    // (6) Identical node SET (no node added / removed / re-typed since this
+    // (5) Identical node SET (no node added / removed / re-typed since this
     // snapshot compiled; cg->shapes holds every node id) plus per-node plugin /
-    // custom instance identity, and (7) release-mode cache coverage.
+    // custom instance identity, and (6) release-mode cache coverage.
     if (nodes_.size() != old_cg.shapes.size()) return false;
     for (const auto& n : nodes_) {
         if (old_cg.shapes.find(n.id) == old_cg.shapes.end()) return false;

--- a/core/host/src/signal_graph_live_swap.cpp
+++ b/core/host/src/signal_graph_live_swap.cpp
@@ -603,10 +603,14 @@ SignalGraph::SwapResult SignalGraph::prepare_swap(double sample_rate,
     // must be able to drain a pending note-off with extract_midi() and then use
     // eager prepare(). The authoring edits remain in nodes_/connections_; only
     // the old compiled snapshot stays live until that eager replacement.
-    const bool has_midi_output = std::any_of(
+    const bool candidate_has_midi_output = std::any_of(
         nodes_.begin(), nodes_.end(),
         [](const GraphNode& node) { return node.type == NodeType::MidiOutput; });
-    if (has_midi_output) {
+    const auto& live = live_slot_.live();
+    const bool live_has_midi_output = live != nullptr && std::any_of(
+        live->shapes.begin(), live->shapes.end(),
+        [](const auto& entry) { return entry.second.type == NodeType::MidiOutput; });
+    if (candidate_has_midi_output || live_has_midi_output) {
         set_live_swap_diagnostics_locked_(
             LiveSwapFallbackReason::PredicateExcluded,
             0,

--- a/core/host/src/signal_graph_reference_walk.cpp
+++ b/core/host/src/signal_graph_reference_walk.cpp
@@ -514,7 +514,12 @@ void SignalGraph::run_reference_walk_(
                         rt.midi_in,
                         0,
                         rt.midi_in_incomplete);
-                    rt.midi_output_mailbox->write(cg->midi_publish_scratch);
+                    if (cg->midi_publish_scratch.has_payload()
+                        && !rt.midi_output_mailbox->pending.try_push(
+                            cg->midi_publish_scratch)) {
+                        rt.midi_output_mailbox->incomplete.store(
+                            true, std::memory_order_relaxed);
+                    }
                 }
                 break;
             case NodeType::Custom:

--- a/core/host/src/signal_graph_reference_walk.cpp
+++ b/core/host/src/signal_graph_reference_walk.cpp
@@ -93,8 +93,11 @@ void SignalGraph::run_reference_walk_(
         if (shape.type == NodeType::MidiInput && rt.midi_input_mailbox) {
             const auto& injected = rt.midi_input_mailbox->published.read();
             if (injected.sequence != 0
-                && injected.sequence != rt.midi_input_sequence_seen) {
-                rt.midi_input_sequence_seen = injected.sequence;
+                && injected.sequence !=
+                    rt.midi_input_mailbox->sequence_seen.load(
+                        std::memory_order_relaxed)) {
+                rt.midi_input_mailbox->sequence_seen.store(
+                    injected.sequence, std::memory_order_relaxed);
                 if (!injected.copy_to_midi(rt.midi_out)) {
                     rt.midi_out_incomplete = true;
                 }

--- a/core/runtime/include/pulp/runtime/network_stream.hpp
+++ b/core/runtime/include/pulp/runtime/network_stream.hpp
@@ -11,6 +11,7 @@
 #include <pulp/runtime/socket.hpp>
 #include <pulp/runtime/http.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -39,15 +40,17 @@ public:
 
     StreamResult read(std::uint8_t* buffer, std::size_t size) override;
     StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    /// Interrupt blocking I/O without closing or invalidating the socket handle.
+    void shutdown();
     void close() override;
-    bool is_open() const override { return open_; }
+    bool is_open() const override { return open_.load(); }
 
     /// Access the underlying socket (advanced use: set options, inspect fd).
     Socket& socket() { return socket_; }
 
 private:
     Socket socket_;
-    bool open_ = false;
+    std::atomic<bool> open_{false};
 };
 
 /// HTTP response as a readable Stream. The request is issued eagerly in the

--- a/core/runtime/include/pulp/runtime/spsc_queue.hpp
+++ b/core/runtime/include/pulp/runtime/spsc_queue.hpp
@@ -40,10 +40,15 @@ public:
         return pushed;
     }
 
+    // Consumer: pop an item into reusable storage.
+    bool try_pop(T& item) {
+        return fifo_.pop(item);
+    }
+
     // Consumer: pop an item. Returns nullopt if empty.
     std::optional<T> try_pop() {
         T item{};
-        if (fifo_.pop(item)) {
+        if (try_pop(item)) {
             return item;
         }
         return std::nullopt;

--- a/core/runtime/include/pulp/runtime/triple_buffer.hpp
+++ b/core/runtime/include/pulp/runtime/triple_buffer.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <array>
 #include <cstdint>
+#include <type_traits>
 
 namespace pulp::runtime {
 
@@ -35,6 +36,9 @@ namespace pulp::runtime {
 template <typename T>
 class TripleBuffer {
 public:
+    static_assert(std::atomic<std::uint8_t>::is_always_lock_free,
+                  "TripleBuffer publication flags must be lock-free");
+
     TripleBuffer() = default;
 
     /// Initialize all three internal buffers with the same value.
@@ -46,7 +50,7 @@ public:
 
     /// Publish a new value from the writer thread.
     /// Writes into the back buffer, then atomically swaps it to middle.
-    void write(const T& value) {
+    void write(const T& value) noexcept(std::is_nothrow_copy_assignable_v<T>) {
         auto idx = flags_.load(std::memory_order_acquire);
         int back = back_index(idx);
         buffers_[back] = value;
@@ -68,7 +72,7 @@ public:
     /// Read the latest published value from the reader thread.
     /// If new data is available, atomically swaps middle to front first.
     /// @return Const reference to the front buffer. Valid until the next read().
-    const T& read() {
+    const T& read() noexcept {
         uint8_t flags = flags_.load(std::memory_order_acquire);
         if (flags & kDirtyBit) {
             for (;;) {
@@ -91,12 +95,12 @@ private:
     // Flags layout: bits [1:0] = back, [3:2] = mid, [5:4] = front, [7] = dirty
     static constexpr uint8_t kDirtyBit = 0x80;
 
-    static uint8_t make_flags(int back, int mid, int front) {
+    static constexpr uint8_t make_flags(int back, int mid, int front) noexcept {
         return static_cast<uint8_t>((back & 3) | ((mid & 3) << 2) | ((front & 3) << 4));
     }
-    static int back_index(uint8_t f)  { return f & 3; }
-    static int mid_index(uint8_t f)   { return (f >> 2) & 3; }
-    static int front_index(uint8_t f) { return (f >> 4) & 3; }
+    static constexpr int back_index(uint8_t f) noexcept { return f & 3; }
+    static constexpr int mid_index(uint8_t f) noexcept { return (f >> 2) & 3; }
+    static constexpr int front_index(uint8_t f) noexcept { return (f >> 4) & 3; }
 
     std::array<T, 3> buffers_{};
     std::atomic<uint8_t> flags_{make_flags(0, 1, 2)};

--- a/core/runtime/include/pulp/runtime/websocket_channel.hpp
+++ b/core/runtime/include/pulp/runtime/websocket_channel.hpp
@@ -44,6 +44,8 @@ namespace pulp::runtime {
 struct WebSocketOptions {
     /// Executor used to dispatch `on_message`, `on_closed`, `on_error`.
     /// When empty, callbacks run on the reader thread.
+    /// Do not destroy the channel from an inline callback; call `close()` and
+    /// defer destruction, or provide an executor that owns callback lifetime.
     MessageExecutor executor;
 
     /// Maximum inbound payload size (bytes). Frames larger than this

--- a/core/runtime/src/network_stream.cpp
+++ b/core/runtime/src/network_stream.cpp
@@ -14,16 +14,16 @@ TcpStream::TcpStream(Socket&& connected)
 TcpStream::~TcpStream() { close(); }
 
 TcpStream::TcpStream(TcpStream&& other) noexcept
-    : socket_(std::move(other.socket_)), open_(other.open_) {
-    other.open_ = false;
+    : socket_(std::move(other.socket_)), open_(other.open_.load()) {
+    other.open_.store(false);
 }
 
 TcpStream& TcpStream::operator=(TcpStream&& other) noexcept {
     if (this != &other) {
         close();
         socket_ = std::move(other.socket_);
-        open_ = other.open_;
-        other.open_ = false;
+        open_.store(other.open_.load());
+        other.open_.store(false);
     }
     return *this;
 }
@@ -35,26 +35,26 @@ bool TcpStream::connect(std::string_view host, std::uint16_t port) {
         socket_.close();
         return false;
     }
-    open_ = true;
+    open_.store(true);
     return true;
 }
 
 StreamResult TcpStream::read(std::uint8_t* buffer, std::size_t size) {
-    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (!open_.load()) return StreamResult::fail(StreamError::Closed);
     if (size == 0) return StreamResult::make(0);
     if (buffer == nullptr) return StreamResult::fail(StreamError::Invalid);
 
     int n = socket_.receive(buffer, size);
     if (n < 0) return StreamResult::fail(StreamError::IoError);
     if (n == 0) {
-        open_ = false;
+        open_.store(false);
         return StreamResult::fail(StreamError::Closed);
     }
     return StreamResult::make(static_cast<std::size_t>(n));
 }
 
 StreamResult TcpStream::write(const std::uint8_t* buffer, std::size_t size) {
-    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (!open_.load()) return StreamResult::fail(StreamError::Closed);
     if (size == 0) return StreamResult::make(0);
     if (buffer == nullptr) return StreamResult::fail(StreamError::Invalid);
 
@@ -63,11 +63,13 @@ StreamResult TcpStream::write(const std::uint8_t* buffer, std::size_t size) {
     return StreamResult::make(static_cast<std::size_t>(n));
 }
 
+void TcpStream::shutdown() {
+    socket_.shutdown();
+}
+
 void TcpStream::close() {
-    if (open_) {
-        socket_.close();
-        open_ = false;
-    }
+    socket_.close();
+    open_.store(false);
 }
 
 // ─── HttpStream ───────────────────────────────────────────────────────────

--- a/core/runtime/src/websocket_channel.cpp
+++ b/core/runtime/src/websocket_channel.cpp
@@ -201,6 +201,7 @@ WebSocketChannel::WebSocketChannel(std::unique_ptr<TcpStream> tcp, Role role,
 WebSocketChannel::~WebSocketChannel() {
     close();
     if (reader_.joinable()) reader_.join();
+    if (tcp_) tcp_->close();
 }
 
 void WebSocketChannel::on_message(MessageCallback cb) {
@@ -225,10 +226,7 @@ void WebSocketChannel::close() {
         fire_closed();
         return;
     }
-    // Best-effort send a 1000 Normal Closure frame; ignore failures.
-    std::uint8_t close_payload[2] = {0x03, 0xE8};  // 1000 big-endian
-    send_frame(kOpClose, close_payload, 2);
-    if (tcp_) tcp_->close();
+    if (tcp_) tcp_->shutdown();
     fire_closed();
 }
 
@@ -320,7 +318,7 @@ void WebSocketChannel::reader_main() {
     while (open_.load()) {
         std::uint8_t hdr[2];
         if (!read_exactly(*tcp_, hdr, 2)) {
-            fire_error("read header failed");
+            if (open_.exchange(false)) fire_error("read header failed");
             break;
         }
         const bool fin = (hdr[0] & 0x80) != 0;
@@ -330,11 +328,17 @@ void WebSocketChannel::reader_main() {
 
         if (len == 126) {
             std::uint8_t ext[2];
-            if (!read_exactly(*tcp_, ext, 2)) { fire_error("read len16"); break; }
+            if (!read_exactly(*tcp_, ext, 2)) {
+                if (open_.exchange(false)) fire_error("read len16");
+                break;
+            }
             len = (std::uint64_t(ext[0]) << 8) | ext[1];
         } else if (len == 127) {
             std::uint8_t ext[8];
-            if (!read_exactly(*tcp_, ext, 8)) { fire_error("read len64"); break; }
+            if (!read_exactly(*tcp_, ext, 8)) {
+                if (open_.exchange(false)) fire_error("read len64");
+                break;
+            }
             len = 0;
             for (int i = 0; i < 8; ++i) len = (len << 8) | ext[i];
         }
@@ -347,14 +351,14 @@ void WebSocketChannel::reader_main() {
         std::array<std::uint8_t, 4> mask_key{};
         if (masked) {
             if (!read_exactly(*tcp_, mask_key.data(), 4)) {
-                fire_error("read mask");
+                if (open_.exchange(false)) fire_error("read mask");
                 break;
             }
         }
 
         std::vector<std::uint8_t> payload(len);
         if (len > 0 && !read_exactly(*tcp_, payload.data(), len)) {
-            fire_error("read payload");
+            if (open_.exchange(false)) fire_error("read payload");
             break;
         }
         if (masked) {

--- a/docs/reference/host-thread-rules.md
+++ b/docs/reference/host-thread-rules.md
@@ -49,8 +49,16 @@ live snapshot. **Never call them from the audio thread.**
   is re-called.
 - `inject_midi` / `extract_midi` — publish/read MIDI through
   snapshot-owned lock-free mailboxes; safe to call concurrently with
-  `process()`. In typical flow, the UI thread injects MIDI and reads
-  extracted events.
+  `process()`. Each `MidiInput` has exactly one injection writer: either a
+  control-side producer, or the audio thread immediately before `process()`,
+  never both concurrently. Injection is allocation-free after `prepare()`, is
+  latest-wins when several blocks are published before processing, and is
+  consumed exactly once. A `false` overflow result still publishes the bounded
+  prefix. Preserved `MidiInput` node IDs keep an unconsumed publication across
+  an ingress-only gap-free `prepare_swap()`. MIDI extraction remains a
+  control-side read. A topology containing `MidiOutput` uses the eager-prepare
+  fallback; that specific refusal keeps the old snapshot live so the control
+  thread can drain pending egress before calling ordinary `prepare()`.
 - `inject_parameter_events` — publishes one block of sample-offset parameter
   events through a snapshot-owned lock-free mailbox. It is safe to call
   concurrently with `process()` from one control-side writer. The latest
@@ -172,5 +180,7 @@ gap-free; `NeedsEagerPrepare` means the transaction failed closed and the caller
 must use ordinary `prepare()`. Eligibility requires unchanged node/plugin/custom
 instance contracts, sample rate, block size, total latency, and feed-forward PDC
 delay structure. Matching PDC history is shared by private connection identity;
-feedback, MIDI, smoothed sparse automation, anticipation, latency-changing edits,
-and disconnect/reconnect of a delayed edge use the eager path.
+feedback, MIDI output, smoothed sparse automation, anticipation,
+latency-changing edits, and disconnect/reconnect of a delayed edge use the eager
+path. Ingress-only MIDI edges are eligible because a stable `MidiInput` shares
+its mailbox and consumed-sequence state across snapshots.

--- a/docs/reference/host-thread-rules.md
+++ b/docs/reference/host-thread-rules.md
@@ -60,8 +60,11 @@ live snapshot. **Never call them from the audio thread.**
   extraction remains a
   control-side read. If either the current authoring topology or the live
   snapshot contains `MidiOutput`, the edit uses the eager-prepare fallback;
-  that specific refusal keeps the old snapshot live so the control
-  thread can drain pending egress before calling ordinary `prepare()`.
+  that specific refusal keeps the old snapshot live so the control thread can
+  drain its ordered four-block egress queue before calling ordinary
+  `prepare()`. Empty blocks do not overwrite pending output. If the bounded
+  queue fills, it retains the earliest blocks and `extract_midi()` reports
+  false while draining them.
 - `inject_parameter_events` — publishes one block of sample-offset parameter
   events through a snapshot-owned lock-free mailbox. It is safe to call
   concurrently with `process()` from one control-side writer. The latest

--- a/docs/reference/host-thread-rules.md
+++ b/docs/reference/host-thread-rules.md
@@ -53,11 +53,14 @@ live snapshot. **Never call them from the audio thread.**
   control-side producer, or the audio thread immediately before `process()`,
   never both concurrently. Injection is allocation-free after `prepare()`, is
   latest-wins when several blocks are published before processing, and is
-  consumed exactly once. A `false` overflow result still publishes the bounded
-  prefix. Preserved `MidiInput` node IDs keep an unconsumed publication across
-  an ingress-only gap-free `prepare_swap()`. MIDI extraction remains a
-  control-side read. A topology containing `MidiOutput` uses the eager-prepare
-  fallback; that specific refusal keeps the old snapshot live so the control
+  consumed exactly once. Publication sequence numbers never use zero (the
+  unpublished sentinel), including after 64-bit wrap. A `false` overflow result
+  still publishes the bounded prefix. Preserved `MidiInput` node IDs keep an
+  unconsumed publication across an ingress-only gap-free `prepare_swap()`. MIDI
+  extraction remains a
+  control-side read. If either the current authoring topology or the live
+  snapshot contains `MidiOutput`, the edit uses the eager-prepare fallback;
+  that specific refusal keeps the old snapshot live so the control
   thread can drain pending egress before calling ordinary `prepare()`.
 - `inject_parameter_events` — publishes one block of sample-offset parameter
   events through a snapshot-owned lock-free mailbox. It is safe to call

--- a/docs/reference/host-thread-rules.md
+++ b/docs/reference/host-thread-rules.md
@@ -64,7 +64,10 @@ live snapshot. **Never call them from the audio thread.**
   drain its ordered four-block egress queue before calling ordinary
   `prepare()`. Empty blocks do not overwrite pending output. If the bounded
   queue fills, it retains the earliest blocks and `extract_midi()` reports
-  false while draining them.
+  false while draining them. Extraction also returns false if the destination
+  lacks short-event, SysEx, or UMP-sidecar capacity. In that case the mailbox
+  retains the undelivered suffix; attach/provide sufficient storage and call
+  `extract_midi()` again to resume without replaying the delivered prefix.
 - `inject_parameter_events` — publishes one block of sample-offset parameter
   events through a snapshot-owned lock-free mailbox. It is safe to call
   concurrently with `process()` from one control-side writer. The latest

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -57,11 +57,14 @@ Four connection variants cover the non-audio-passthrough cases:
   before `process()`. The publication is consumed once and follows a preserved
   `MidiInput` node ID across a gap-free swap; its non-zero publication sequence
   skips the zero sentinel after 64-bit wrap. A `false` return still publishes
-  the fixed-capacity prefix. `extract_midi(node, &out)` reads the latest
-  `MidiOutput` input snapshot after a block. Ingress-only MIDI graphs may swap
-  gap-free; an edit whose candidate or currently-live graph contains
-  `MidiOutput` returns `NeedsEagerPrepare` while keeping the old snapshot
-  readable so pending egress can be drained before ordinary `prepare()`. MIDI
+  the fixed-capacity prefix. `extract_midi(node, &out)` drains nonempty
+  `MidiOutput` blocks in process order from a fixed four-block SPSC queue;
+  routine empty blocks cannot overwrite pending output, and bounded overflow
+  retains the earliest blocks while making extraction return false.
+  Ingress-only MIDI graphs may swap gap-free; an edit whose candidate or
+  currently-live graph contains `MidiOutput` returns `NeedsEagerPrepare` while
+  keeping the old snapshot readable so pending egress can be drained before
+  ordinary `prepare()`. MIDI
   edges
   preserve the full logical block: short MIDI events, SysEx sidecars, and an
   attached `UmpBuffer`. MPE is derived from those events rather than stored as a

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -341,10 +341,12 @@ takes a risk with the live stream to push a swap through:
   an eager re-prepare only when the measured cost would actually risk an overload
   on the audio thread, not merely because the plugin is different.
 
-When any gate refuses, the transaction is abandoned, the live snapshot is
-dropped, and `prepare_swap` returns `NeedsEagerPrepare` so the host
-re-prepares with a brief silence — the safe fallback, never a partial or
-racy swap.
+When a gate refuses, the transaction is abandoned and `prepare_swap` returns
+`NeedsEagerPrepare` so the host re-prepares with a brief silence — the safe
+fallback, never a partial or racy swap. Ordinary refusals drop the live snapshot.
+The one deliberate exception is a candidate or live graph containing
+`MidiOutput`: its pending-egress refusal keeps the old snapshot readable so the
+control thread can drain `extract_midi()` before ordinary `prepare()` replaces it.
 
 The staging, policy, catalog, and swap-transaction calls all run on the
 control/UI thread, never the audio thread.

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -60,7 +60,10 @@ Four connection variants cover the non-audio-passthrough cases:
   the fixed-capacity prefix. `extract_midi(node, &out)` drains nonempty
   `MidiOutput` blocks in process order from a fixed four-block SPSC queue;
   routine empty blocks cannot overwrite pending output, and bounded overflow
-  retains the earliest blocks while making extraction return false.
+  retains the earliest blocks while making extraction return false. A false
+  return can also mean the destination lacks short-event, SysEx, or attached
+  UMP-sidecar capacity. Provide sufficient storage and call again: extraction
+  resumes at the undelivered suffix without replaying the delivered prefix.
   Ingress-only MIDI graphs may swap gap-free; an edit whose candidate or
   currently-live graph contains `MidiOutput` returns `NeedsEagerPrepare` while
   keeping the old snapshot readable so pending egress can be drained before

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -55,12 +55,14 @@ Four connection variants cover the non-audio-passthrough cases:
   the latest block to a `MidiInput` before processing; one designated writer
   may call it from a control producer or from the audio callback immediately
   before `process()`. The publication is consumed once and follows a preserved
-  `MidiInput` node ID across a gap-free swap. A `false` return still publishes
+  `MidiInput` node ID across a gap-free swap; its non-zero publication sequence
+  skips the zero sentinel after 64-bit wrap. A `false` return still publishes
   the fixed-capacity prefix. `extract_midi(node, &out)` reads the latest
   `MidiOutput` input snapshot after a block. Ingress-only MIDI graphs may swap
-  gap-free; a graph containing `MidiOutput` returns `NeedsEagerPrepare` while
-  keeping the old snapshot readable so pending egress can be drained before
-  ordinary `prepare()`. MIDI edges
+  gap-free; an edit whose candidate or currently-live graph contains
+  `MidiOutput` returns `NeedsEagerPrepare` while keeping the old snapshot
+  readable so pending egress can be drained before ordinary `prepare()`. MIDI
+  edges
   preserve the full logical block: short MIDI events, SysEx sidecars, and an
   attached `UmpBuffer`. MPE is derived from those events rather than stored as a
   separate graph-owned sidecar, so route MIDI 1.0 MPE channel messages or MIDI

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -51,9 +51,16 @@ Four connection variants cover the non-audio-passthrough cases:
 
 - `connect_midi(from, to)` routes `MidiBuffer` events between node-scoped
   MIDI in/out buffers (ports are ignored). Participates in cycle
-  detection the same way audio edges do. `inject_midi(node, buf)` loads
-  a `MidiInput`'s output before a block; `extract_midi(node, &out)`
-  reads the latest `MidiOutput` input snapshot after a block. MIDI edges
+  detection the same way audio edges do. `inject_midi(node, buf)` publishes
+  the latest block to a `MidiInput` before processing; one designated writer
+  may call it from a control producer or from the audio callback immediately
+  before `process()`. The publication is consumed once and follows a preserved
+  `MidiInput` node ID across a gap-free swap. A `false` return still publishes
+  the fixed-capacity prefix. `extract_midi(node, &out)` reads the latest
+  `MidiOutput` input snapshot after a block. Ingress-only MIDI graphs may swap
+  gap-free; a graph containing `MidiOutput` returns `NeedsEagerPrepare` while
+  keeping the old snapshot readable so pending egress can be drained before
+  ordinary `prepare()`. MIDI edges
   preserve the full logical block: short MIDI events, SysEx sidecars, and an
   attached `UmpBuffer`. MPE is derived from those events rather than stored as a
   separate graph-owned sidecar, so route MIDI 1.0 MPE channel messages or MIDI

--- a/docs/reference/streams.md
+++ b/docs/reference/streams.md
@@ -64,6 +64,11 @@ AsyncStream io(std::move(tcp));
 io.start();
 ```
 
+`shutdown()` interrupts blocking socket I/O without invalidating the socket
+handle. It is intended for coordinated reader teardown: signal shutdown, join
+the reader, then call `close()` to release the handle. `is_open()` may be read
+concurrently with normal reads and writes, including peer-EOF transitions.
+
 ### `HttpStream`
 
 ```cpp
@@ -162,6 +167,8 @@ ws->send_text("hello");
 - TLS is not currently handled at the channel layer — for `wss://`, supply a TLS-wrapped TCP stream (future `SecureTcpStream`).
 - Control frames (ping/pong/close) are handled internally; ping triggers an automatic pong.
 - Payloads up to `options.max_payload` (default 16 MiB) are accepted; larger frames fire `on_error` and close the channel.
+- `close()` interrupts the channel's blocking reader; destruction joins that reader before releasing the TCP socket handle.
+- Without an executor, callbacks run inline on the reader thread. They may call `close()`, but must defer channel destruction until after the callback returns.
 
 ### OSC
 

--- a/test/test_core_runtime_rt_safety_contract.cpp
+++ b/test/test_core_runtime_rt_safety_contract.cpp
@@ -111,6 +111,19 @@ TEST_CASE("Core runtime RT safety contracts pin expected classifications",
     CHECK(graph->safety_class == RtSafetyClass::AudioCallbackSafeAfterPrepare);
     CHECK(graph->requires_prepare);
 
+    const auto* inject_midi =
+        find_core_runtime_rt_safety_contract("SignalGraph", "inject_midi");
+    REQUIRE(inject_midi != nullptr);
+    CHECK(inject_midi->safety_class ==
+          RtSafetyClass::AudioCallbackSafeAfterPrepare);
+    CHECK(inject_midi->audio_callback_allowed);
+    CHECK_FALSE(inject_midi->may_allocate);
+    CHECK_FALSE(inject_midi->may_lock);
+    CHECK_FALSE(inject_midi->may_block);
+    CHECK(inject_midi->requires_prepare);
+    CHECK(inject_midi->owner_boundary ==
+          "exactly one writer per MidiInput node; audio-thread snapshot consumer");
+
     const auto* proc = find_core_runtime_rt_safety_contract("Processor", "process");
     REQUIRE(proc != nullptr);
     CHECK(proc->audio_callback_allowed);

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -2201,13 +2201,8 @@ TEST_CASE("SignalGraph connect_midi routes events through the graph",
     pulp::midi::UmpBuffer arrived_ump;
     arrived.attach_ump(&arrived_ump);
     REQUIRE(graph.extract_midi(mo, arrived));
-    REQUIRE(arrived.size() == 2);
-    REQUIRE(arrived[0].sample_offset == 0);
-    REQUIRE(arrived[1].sample_offset == 16);
-    REQUIRE(arrived.sysex_size() == 1);
-    REQUIRE(arrived.sysex()[0].data
-            == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
-    REQUIRE(arrived.sysex()[0].sample_offset == 8);
+    REQUIRE(arrived.empty());
+    REQUIRE(arrived.sysex_size() == 0);
     REQUIRE(arrived_ump.size() == 1);
     REQUIRE(arrived_ump[0].sample_offset == 24);
     REQUIRE(arrived_ump[0].packet.channel() == 2);
@@ -2437,15 +2432,23 @@ TEST_CASE("SignalGraph MIDI sidecar drops are caller-visible",
     REQUIRE(chain_arrived.size() == event_capacity);
     plugin_chain_overflow_graph.release();
 
-    pulp::midi::MidiBuffer one_event;
-    one_event.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
-    REQUIRE(graph.inject_midi(mi, one_event));
+    pulp::midi::MidiBuffer two_events;
+    two_events.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    two_events.add(pulp::midi::MidiEvent::note_on(0, 61, 100));
+    REQUIRE(graph.inject_midi(mi, two_events));
     graph.process(ov, iv, 32);
     pulp::midi::MidiBuffer limited_extract;
-    limited_extract.reserve(0);
+    limited_extract.reserve(1);
     limited_extract.set_realtime_capacity_limit(true);
     REQUIRE_FALSE(graph.extract_midi(mo, limited_extract));
+    REQUIRE(limited_extract.size() == 1);
+    CHECK(limited_extract[0].note() == 60);
     REQUIRE(limited_extract.dropped_event_count() == 1);
+
+    pulp::midi::MidiBuffer resumed_extract;
+    REQUIRE(graph.extract_midi(mo, resumed_extract));
+    REQUIRE(resumed_extract.size() == 1);
+    CHECK(resumed_extract[0].note() == 61);
 
     graph.release();
 }
@@ -2701,17 +2704,25 @@ TEST_CASE("SignalGraph MIDI egress queue retains earliest blocks on overflow",
             graph.process(out, in, 32);
         }
 
-        pulp::midi::MidiBuffer arrived;
-        REQUIRE_FALSE(graph.extract_midi(midi_out, arrived));
-        REQUIRE(arrived.size() == 4);
-        for (int index = 0; index < 4; ++index) {
-            CHECK(arrived[static_cast<std::size_t>(index)].is_note_off());
-            CHECK(arrived[static_cast<std::size_t>(index)].note() == 60 + index);
+        pulp::midi::MidiBuffer limited;
+        limited.reserve(1);
+        limited.set_realtime_capacity_limit(true);
+        REQUIRE_FALSE(graph.extract_midi(midi_out, limited));
+        REQUIRE(limited.size() == 1);
+        CHECK(limited[0].is_note_off());
+        CHECK(limited[0].note() == 60);
+
+        pulp::midi::MidiBuffer resumed;
+        REQUIRE_FALSE(graph.extract_midi(midi_out, resumed));
+        REQUIRE(resumed.size() == 3);
+        for (int index = 0; index < 3; ++index) {
+            CHECK(resumed[static_cast<std::size_t>(index)].is_note_off());
+            CHECK(resumed[static_cast<std::size_t>(index)].note() == 61 + index);
         }
 
-        arrived.clear();
-        REQUIRE(graph.extract_midi(midi_out, arrived));
-        CHECK(arrived.empty());
+        resumed.clear();
+        REQUIRE(graph.extract_midi(midi_out, resumed));
+        CHECK(resumed.empty());
     }
 }
 

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <limits>
 #include <string>
 #include <thread>
 #include <utility>
@@ -2535,49 +2536,74 @@ TEST_CASE("SignalGraph MIDI ingress is latest wins and consumed once",
 
 TEST_CASE("SignalGraph MIDI ingress survives a gap free swap",
           "[host][graph][midi][mailbox][live-swap]") {
-    SignalGraph graph;
-    const auto input = graph.add_input_node(1, "input");
-    auto slot = std::make_unique<MidiForwarder>();
-    auto* probe = slot.get();
-    const auto plugin = graph.add_plugin_node(std::move(slot), 1, 1, "forwarder");
-    const auto gain = graph.add_gain_node("inserted");
-    const auto output = graph.add_output_node(1, "output");
-    const auto midi_in = graph.add_midi_input_node("keys");
-    REQUIRE(graph.connect(input, 0, plugin, 0));
-    REQUIRE(graph.connect(plugin, 0, output, 0));
-    REQUIRE(graph.connect_midi(midi_in, plugin));
-    REQUIRE(graph.prepare(48000.0, 32));
+    for (const int mode : {0, 1, 2}) {
+        INFO("routing mode " << mode);
+        SignalGraph graph;
+        const auto input = graph.add_input_node(1, "input");
+        auto slot = std::make_unique<MidiForwarder>();
+        auto* probe = slot.get();
+        const auto plugin = graph.add_plugin_node(
+            std::move(slot), 1, 1, "forwarder");
+        const auto gain = graph.add_gain_node("inserted");
+        const auto output = graph.add_output_node(1, "output");
+        const auto midi_in = graph.add_midi_input_node("keys");
+        REQUIRE(graph.connect(input, 0, plugin, 0));
+        REQUIRE(graph.connect(plugin, 0, output, 0));
+        REQUIRE(graph.connect_midi(midi_in, plugin));
+        graph.set_canonical_executor_routing_enabled(mode != 0);
+        graph.set_parallel_routing_enabled(mode == 2);
+        graph.set_parallel_min_work_units(0);
+        REQUIRE(graph.prepare(48000.0, 32));
 
-    constexpr std::size_t event_capacity = ParameterEventQueue::kCapacity;
-    pulp::midi::MidiBuffer overflow;
-    for (std::size_t index = 0; index <= event_capacity; ++index) {
-        auto event = pulp::midi::MidiEvent::note_on(
-            0, static_cast<int>(index % 127), 100);
-        event.sample_offset = static_cast<int32_t>(index % 32);
-        overflow.add(event);
+        pulp::midi::MidiBuffer stale;
+        stale.add(pulp::midi::MidiEvent::note_on(0, 126, 100));
+        REQUIRE(graph.inject_midi(midi_in, stale));
+
+        constexpr std::size_t event_capacity = ParameterEventQueue::kCapacity;
+        pulp::midi::MidiBuffer overflow;
+        for (std::size_t index = 0; index <= event_capacity; ++index) {
+            auto event = pulp::midi::MidiEvent::note_on(
+                0, static_cast<int>(index % 127), 100);
+            event.sample_offset = static_cast<int32_t>(index % 32);
+            overflow.add(event);
+        }
+        REQUIRE_FALSE(graph.inject_midi(midi_in, overflow));
+
+        // Publish the replacement snapshot between injection and process(). The
+        // stable MidiInput must carry the latest retained prefix exactly once.
+        graph.begin_swap_edit();
+        REQUIRE(graph.disconnect(plugin, 0, output, 0));
+        REQUIRE(graph.connect(plugin, 0, gain, 0));
+        REQUIRE(graph.connect(gain, 0, output, 0));
+        REQUIRE(graph.prepare_swap(48000.0, 32)
+                == SignalGraph::SwapResult::Swapped);
+
+        std::array<float, 32> source{};
+        const float* input_ptrs[] = {source.data()};
+        std::array<float, 32> rendered{};
+        float* output_ptrs[] = {rendered.data()};
+        pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
+        pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
+        const auto stats_before = graph.routing_executor_stats();
+        graph.process(out, in, 32);
+
+        REQUIRE(probe->last_seen().size() == event_capacity);
+        CHECK(probe->last_seen()[0].note() == 0);
+        const auto stats_after = graph.routing_executor_stats();
+        if (mode == 0) {
+            CHECK(stats_after.blocks_processed == stats_before.blocks_processed);
+        } else {
+            CHECK(stats_after.blocks_processed > stats_before.blocks_processed);
+        }
+        if (mode == 2) {
+            CHECK(stats_after.parallel_levels_dispatched
+                  > stats_before.parallel_levels_dispatched);
+        }
+        CHECK(graph.routed_walk_fallbacks() == 0);
+
+        graph.process(out, in, 32);
+        CHECK(probe->last_seen().empty());
     }
-    REQUIRE_FALSE(graph.inject_midi(midi_in, overflow));
-
-    // Publish the replacement snapshot between injection and process(). The
-    // stable MidiInput must carry the retained bounded prefix exactly once.
-    graph.begin_swap_edit();
-    REQUIRE(graph.disconnect(plugin, 0, output, 0));
-    REQUIRE(graph.connect(plugin, 0, gain, 0));
-    REQUIRE(graph.connect(gain, 0, output, 0));
-    REQUIRE(graph.prepare_swap(48000.0, 32) == SignalGraph::SwapResult::Swapped);
-
-    std::array<float, 32> source{};
-    const float* input_ptrs[] = {source.data()};
-    std::array<float, 32> rendered{};
-    float* output_ptrs[] = {rendered.data()};
-    pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
-    pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
-    graph.process(out, in, 32);
-
-    REQUIRE(probe->last_seen().size() == event_capacity);
-
-    graph.process(out, in, 32);
-    CHECK(probe->last_seen().empty());
 }
 
 TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
@@ -2586,7 +2612,6 @@ TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
     const auto input = graph.add_input_node(1, "input");
     const auto plugin = graph.add_plugin_node(
         std::make_unique<MidiForwarder>(), 1, 1, "forwarder");
-    const auto gain = graph.add_gain_node("inserted");
     const auto output = graph.add_output_node(1, "output");
     const auto midi_in = graph.add_midi_input_node("keys");
     const auto midi_out = graph.add_midi_output_node("thru");
@@ -2608,9 +2633,7 @@ TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
     graph.process(out, in, 32);
 
     graph.begin_swap_edit();
-    REQUIRE(graph.disconnect(plugin, 0, output, 0));
-    REQUIRE(graph.connect(plugin, 0, gain, 0));
-    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.remove_node(midi_out));
     REQUIRE(graph.prepare_swap(48000.0, 32)
             == SignalGraph::SwapResult::NeedsEagerPrepare);
 
@@ -2620,14 +2643,52 @@ TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
     CHECK(arrived[0].is_note_off());
     CHECK(arrived[0].note() == 60);
 
-    // The requested eager replacement adopts the authoring edits only after
-    // the pending old-snapshot egress was drained. Its fresh mailbox must not
-    // replay the note-off or retain a pointer into the retired snapshot.
+    // The requested eager replacement adopts the output-node removal only after
+    // the pending old-snapshot egress was drained. The retired NodeId must not
+    // replay the note-off or retain a pointer into the old snapshot.
     REQUIRE(graph.prepare(48000.0, 32));
-    graph.process(out, in, 32);
     arrived.clear();
-    REQUIRE(graph.extract_midi(midi_out, arrived));
+    REQUIRE_FALSE(graph.extract_midi(midi_out, arrived));
     CHECK(arrived.empty());
+}
+
+TEST_CASE("SignalGraph MIDI ingress sequence skips zero after wrap",
+          "[host][graph][midi][mailbox][sequence-wrap]") {
+    SignalGraph graph;
+    const auto midi_in = graph.add_midi_input_node("keys");
+    const auto midi_out = graph.add_midi_output_node("thru");
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE(graph.prepare(48000.0, 32));
+    REQUIRE(graph.seed_midi_input_sequence_for_test(
+        midi_in, std::numeric_limits<std::uint64_t>::max() - 1));
+
+    float sample = 0.f;
+    const float* input_ptrs[] = {&sample};
+    float* output_ptrs[] = {&sample};
+    pulp::audio::BufferView<const float> in(input_ptrs, 0, 32);
+    pulp::audio::BufferView<float> out(output_ptrs, 0, 32);
+    pulp::midi::MidiBuffer arrived;
+
+    const std::array expected_sequences{
+        std::numeric_limits<std::uint64_t>::max(), std::uint64_t{1}};
+    for (std::size_t index = 0; index < expected_sequences.size(); ++index) {
+        const int note = 61 + static_cast<int>(index);
+        pulp::midi::MidiBuffer publication;
+        publication.add(pulp::midi::MidiEvent::note_on(0, note, 100));
+        REQUIRE(graph.inject_midi(midi_in, publication));
+        CHECK(graph.midi_input_sequence_for_test(midi_in)
+              == expected_sequences[index]);
+        graph.process(out, in, 32);
+        arrived.clear();
+        REQUIRE(graph.extract_midi(midi_out, arrived));
+        REQUIRE(arrived.size() == 1);
+        CHECK(arrived[0].note() == note);
+
+        graph.process(out, in, 32);
+        arrived.clear();
+        REQUIRE(graph.extract_midi(midi_out, arrived));
+        CHECK(arrived.empty());
+    }
 }
 
 TEST_CASE("SignalGraph audio-thread MIDI ingress is race free during swaps",

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -2453,6 +2453,71 @@ TEST_CASE("SignalGraph MIDI sidecar drops are caller-visible",
     graph.release();
 }
 
+TEST_CASE("SignalGraph MIDI egress resumes partial sidecar copies",
+          "[host][graph][midi][mailbox][egress]") {
+    SignalGraph graph;
+    const auto midi_in = graph.add_midi_input_node("keys");
+    const auto midi_out = graph.add_midi_output_node("thru");
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    float sample = 0.0f;
+    const float* input_ptrs[] = {&sample};
+    float* output_ptrs[] = {&sample};
+    pulp::audio::BufferView<const float> in(input_ptrs, 0, 32);
+    pulp::audio::BufferView<float> out(output_ptrs, 0, 32);
+
+    pulp::midi::MidiBuffer sysex_source;
+    sysex_source.add_sysex({0xF0, 0x7D, 0x01, 0xF7});
+    sysex_source.add_sysex({0xF0, 0x7D, 0x02, 0xF7});
+    REQUIRE(graph.inject_midi(midi_in, sysex_source));
+    graph.process(out, in, 32);
+
+    pulp::midi::MidiBuffer limited_sysex;
+    limited_sysex.reserve(0, 1, 4);
+    limited_sysex.set_realtime_capacity_limit(true);
+    REQUIRE_FALSE(graph.extract_midi(midi_out, limited_sysex));
+    REQUIRE(limited_sysex.sysex_size() == 1);
+    CHECK(limited_sysex.sysex()[0].data
+          == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+
+    pulp::midi::MidiBuffer resumed_sysex;
+    REQUIRE(graph.extract_midi(midi_out, resumed_sysex));
+    REQUIRE(resumed_sysex.sysex_size() == 1);
+    CHECK(resumed_sysex.sysex()[0].data
+          == std::vector<uint8_t>{0xF0, 0x7D, 0x02, 0xF7});
+
+    pulp::midi::MidiBuffer ump_source;
+    pulp::midi::UmpBuffer source_ump;
+    source_ump.add(pulp::midi::UmpPacket::note_on_2(0, 2, 67, 0x8000));
+    source_ump.add(pulp::midi::UmpPacket::note_on_2(0, 2, 68, 0x8000));
+    ump_source.attach_ump(&source_ump);
+    REQUIRE(graph.inject_midi(midi_in, ump_source));
+    graph.process(out, in, 32);
+
+    pulp::midi::MidiBuffer limited_ump_extract;
+    pulp::midi::UmpBuffer limited_ump;
+    const auto ump_capacity = limited_ump.capacity();
+    for (std::size_t i = 0; i + 1 < ump_capacity; ++i) {
+        REQUIRE(limited_ump.add(
+            pulp::midi::UmpPacket::note_on_2(0, 1, 1, 0x4000)));
+    }
+    limited_ump.set_realtime_capacity_limit(true);
+    limited_ump_extract.attach_ump(&limited_ump);
+    REQUIRE_FALSE(graph.extract_midi(midi_out, limited_ump_extract));
+    REQUIRE(limited_ump.size() == ump_capacity);
+    CHECK(limited_ump[ump_capacity - 1].packet.note_number() == 67);
+
+    pulp::midi::MidiBuffer resumed_ump_extract;
+    pulp::midi::UmpBuffer resumed_ump;
+    resumed_ump_extract.attach_ump(&resumed_ump);
+    REQUIRE(graph.extract_midi(midi_out, resumed_ump_extract));
+    REQUIRE(resumed_ump.size() == 1);
+    CHECK(resumed_ump[0].packet.note_number() == 68);
+
+    graph.release();
+}
+
 TEST_CASE("SignalGraph MIDI injection and extraction require a live node runtime",
           "[host][graph][midi]") {
     SignalGraph graph;

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -2500,6 +2500,201 @@ TEST_CASE("SignalGraph MIDI ingress and egress mailboxes allocate only at prepar
     REQUIRE(out.size() == 1);
 }
 
+TEST_CASE("SignalGraph MIDI ingress is latest wins and consumed once",
+          "[host][graph][midi][mailbox]") {
+    SignalGraph graph;
+    const auto midi_in = graph.add_midi_input_node("keys");
+    const auto midi_out = graph.add_midi_output_node("thru");
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    pulp::midi::MidiBuffer first;
+    first.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    pulp::midi::MidiBuffer latest;
+    latest.add(pulp::midi::MidiEvent::note_on(0, 67, 100));
+    REQUIRE(graph.inject_midi(midi_in, first));
+    REQUIRE(graph.inject_midi(midi_in, latest));
+
+    float in_sample = 0.f, out_sample = 0.f;
+    const float* in_ptrs[1] = {&in_sample};
+    float* out_ptrs[1] = {&out_sample};
+    pulp::audio::BufferView<const float> in(in_ptrs, 0, 32);
+    pulp::audio::BufferView<float> out(out_ptrs, 0, 32);
+    graph.process(out, in, 32);
+
+    pulp::midi::MidiBuffer arrived;
+    REQUIRE(graph.extract_midi(midi_out, arrived));
+    REQUIRE(arrived.size() == 1);
+    CHECK(arrived[0].note() == 67);
+
+    graph.process(out, in, 32);
+    arrived.clear();
+    REQUIRE(graph.extract_midi(midi_out, arrived));
+    CHECK(arrived.empty());
+}
+
+TEST_CASE("SignalGraph MIDI ingress survives a gap free swap",
+          "[host][graph][midi][mailbox][live-swap]") {
+    SignalGraph graph;
+    const auto input = graph.add_input_node(1, "input");
+    auto slot = std::make_unique<MidiForwarder>();
+    auto* probe = slot.get();
+    const auto plugin = graph.add_plugin_node(std::move(slot), 1, 1, "forwarder");
+    const auto gain = graph.add_gain_node("inserted");
+    const auto output = graph.add_output_node(1, "output");
+    const auto midi_in = graph.add_midi_input_node("keys");
+    REQUIRE(graph.connect(input, 0, plugin, 0));
+    REQUIRE(graph.connect(plugin, 0, output, 0));
+    REQUIRE(graph.connect_midi(midi_in, plugin));
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    constexpr std::size_t event_capacity = ParameterEventQueue::kCapacity;
+    pulp::midi::MidiBuffer overflow;
+    for (std::size_t index = 0; index <= event_capacity; ++index) {
+        auto event = pulp::midi::MidiEvent::note_on(
+            0, static_cast<int>(index % 127), 100);
+        event.sample_offset = static_cast<int32_t>(index % 32);
+        overflow.add(event);
+    }
+    REQUIRE_FALSE(graph.inject_midi(midi_in, overflow));
+
+    // Publish the replacement snapshot between injection and process(). The
+    // stable MidiInput must carry the retained bounded prefix exactly once.
+    graph.begin_swap_edit();
+    REQUIRE(graph.disconnect(plugin, 0, output, 0));
+    REQUIRE(graph.connect(plugin, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.prepare_swap(48000.0, 32) == SignalGraph::SwapResult::Swapped);
+
+    std::array<float, 32> source{};
+    const float* input_ptrs[] = {source.data()};
+    std::array<float, 32> rendered{};
+    float* output_ptrs[] = {rendered.data()};
+    pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
+    pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
+    graph.process(out, in, 32);
+
+    REQUIRE(probe->last_seen().size() == event_capacity);
+
+    graph.process(out, in, 32);
+    CHECK(probe->last_seen().empty());
+}
+
+TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
+          "[host][graph][midi][mailbox][live-swap][egress]") {
+    SignalGraph graph;
+    const auto input = graph.add_input_node(1, "input");
+    const auto plugin = graph.add_plugin_node(
+        std::make_unique<MidiForwarder>(), 1, 1, "forwarder");
+    const auto gain = graph.add_gain_node("inserted");
+    const auto output = graph.add_output_node(1, "output");
+    const auto midi_in = graph.add_midi_input_node("keys");
+    const auto midi_out = graph.add_midi_output_node("thru");
+    REQUIRE(graph.connect(input, 0, plugin, 0));
+    REQUIRE(graph.connect(plugin, 0, output, 0));
+    REQUIRE(graph.connect_midi(midi_in, plugin));
+    REQUIRE(graph.connect_midi(plugin, midi_out));
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    pulp::midi::MidiBuffer events;
+    events.add(pulp::midi::MidiEvent::note_off(0, 60, 0));
+    REQUIRE(graph.inject_midi(midi_in, events));
+    std::array<float, 32> source{};
+    const float* input_ptrs[] = {source.data()};
+    std::array<float, 32> rendered{};
+    float* output_ptrs[] = {rendered.data()};
+    pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
+    pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
+    graph.process(out, in, 32);
+
+    graph.begin_swap_edit();
+    REQUIRE(graph.disconnect(plugin, 0, output, 0));
+    REQUIRE(graph.connect(plugin, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.prepare_swap(48000.0, 32)
+            == SignalGraph::SwapResult::NeedsEagerPrepare);
+
+    pulp::midi::MidiBuffer arrived;
+    REQUIRE(graph.extract_midi(midi_out, arrived));
+    REQUIRE(arrived.size() == 1);
+    CHECK(arrived[0].is_note_off());
+    CHECK(arrived[0].note() == 60);
+
+    // The requested eager replacement adopts the authoring edits only after
+    // the pending old-snapshot egress was drained. Its fresh mailbox must not
+    // replay the note-off or retain a pointer into the retired snapshot.
+    REQUIRE(graph.prepare(48000.0, 32));
+    graph.process(out, in, 32);
+    arrived.clear();
+    REQUIRE(graph.extract_midi(midi_out, arrived));
+    CHECK(arrived.empty());
+}
+
+TEST_CASE("SignalGraph audio-thread MIDI ingress is race free during swaps",
+          "[host][graph][midi][mailbox][live-swap][race][tsan]") {
+    SignalGraph graph;
+    const auto input = graph.add_input_node(1, "input");
+    const auto plugin = graph.add_plugin_node(
+        std::make_unique<MidiForwarder>(), 1, 1, "forwarder");
+    const auto gain = graph.add_gain_node("inserted");
+    const auto output = graph.add_output_node(1, "output");
+    const auto midi_in = graph.add_midi_input_node("keys");
+    REQUIRE(graph.connect(input, 0, plugin, 0));
+    REQUIRE(graph.connect(plugin, 0, output, 0));
+    REQUIRE(graph.connect_midi(midi_in, plugin));
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> inject_failed{false};
+    std::atomic<std::uint64_t> processed_blocks{0};
+    std::thread audio_thread([&] {
+        std::array<float, 32> source{};
+        const float* input_ptrs[] = {source.data()};
+        std::array<float, 32> rendered{};
+        float* output_ptrs[] = {rendered.data()};
+        pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
+        pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
+        pulp::midi::MidiBuffer events;
+        events.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+
+        while (!stop.load(std::memory_order_acquire)) {
+            if (!graph.inject_midi(midi_in, events)) {
+                inject_failed.store(true, std::memory_order_relaxed);
+            }
+            graph.process(out, in, 32);
+            processed_blocks.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    while (processed_blocks.load(std::memory_order_relaxed) < 8) {
+        std::this_thread::yield();
+    }
+
+    bool all_swaps_succeeded = true;
+    for (int iteration = 0; iteration < 32; ++iteration) {
+        graph.begin_swap_edit();
+        if ((iteration % 2) == 0) {
+            all_swaps_succeeded = graph.disconnect(plugin, 0, output, 0) &&
+                graph.connect(plugin, 0, gain, 0) &&
+                graph.connect(gain, 0, output, 0) && all_swaps_succeeded;
+        } else {
+            all_swaps_succeeded = graph.disconnect(plugin, 0, gain, 0) &&
+                graph.disconnect(gain, 0, output, 0) &&
+                graph.connect(plugin, 0, output, 0) && all_swaps_succeeded;
+        }
+        all_swaps_succeeded =
+            graph.prepare_swap(48000.0, 32) == SignalGraph::SwapResult::Swapped &&
+            all_swaps_succeeded;
+    }
+
+    stop.store(true, std::memory_order_release);
+    audio_thread.join();
+
+    REQUIRE(all_swaps_succeeded);
+    REQUIRE_FALSE(inject_failed.load(std::memory_order_relaxed));
+    REQUIRE(processed_blocks.load(std::memory_order_relaxed) > 8);
+}
+
 TEST_CASE("SignalGraph MIDI ingress and egress mailboxes are Race-free",
           "[host][graph][midi][race][tsan]") {
     SignalGraph graph;

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -2691,7 +2691,7 @@ TEST_CASE("SignalGraph MIDI ingress sequence skips zero after wrap",
     }
 }
 
-TEST_CASE("SignalGraph audio-thread MIDI ingress is race free during swaps",
+TEST_CASE("SignalGraph audio-thread MIDI ingress is Race-free during swaps",
           "[host][graph][midi][mailbox][live-swap][race][tsan]") {
     SignalGraph graph;
     const auto input = graph.add_input_node(1, "input");

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -2377,8 +2377,15 @@ TEST_CASE("SignalGraph MIDI sidecar drops are caller-visible",
     REQUIRE_FALSE(graph.extract_midi(mo, arrived));
     REQUIRE(arrived_ump.size() == event_capacity);
 
+    REQUIRE_FALSE(graph.inject_midi(mi, ump_overflow));
+    graph.process(ov, iv, 32);
     pulp::midi::MidiBuffer missing_ump_extract;
     REQUIRE_FALSE(graph.extract_midi(mo, missing_ump_extract));
+    pulp::midi::MidiBuffer recovered_ump_extract;
+    pulp::midi::UmpBuffer recovered_ump;
+    recovered_ump_extract.attach_ump(&recovered_ump);
+    REQUIRE_FALSE(graph.extract_midi(mo, recovered_ump_extract));
+    REQUIRE(recovered_ump.size() == event_capacity);
 
     SignalGraph fan_in_graph;
     auto mi_a = fan_in_graph.add_midi_input_node("a");
@@ -2608,48 +2615,104 @@ TEST_CASE("SignalGraph MIDI ingress survives a gap free swap",
 
 TEST_CASE("SignalGraph preserves pending MIDI egress by rejecting a live swap",
           "[host][graph][midi][mailbox][live-swap][egress]") {
-    SignalGraph graph;
-    const auto input = graph.add_input_node(1, "input");
-    const auto plugin = graph.add_plugin_node(
-        std::make_unique<MidiForwarder>(), 1, 1, "forwarder");
-    const auto output = graph.add_output_node(1, "output");
-    const auto midi_in = graph.add_midi_input_node("keys");
-    const auto midi_out = graph.add_midi_output_node("thru");
-    REQUIRE(graph.connect(input, 0, plugin, 0));
-    REQUIRE(graph.connect(plugin, 0, output, 0));
-    REQUIRE(graph.connect_midi(midi_in, plugin));
-    REQUIRE(graph.connect_midi(plugin, midi_out));
-    REQUIRE(graph.prepare(48000.0, 32));
+    for (const int mode : {0, 1, 2}) {
+        INFO("routing mode " << mode);
+        SignalGraph graph;
+        const auto input = graph.add_input_node(1, "input");
+        const auto plugin = graph.add_plugin_node(
+            std::make_unique<MidiForwarder>(), 1, 1, "forwarder");
+        const auto output = graph.add_output_node(1, "output");
+        const auto midi_in = graph.add_midi_input_node("keys");
+        const auto midi_out = graph.add_midi_output_node("thru");
+        REQUIRE(graph.connect(input, 0, plugin, 0));
+        REQUIRE(graph.connect(plugin, 0, output, 0));
+        REQUIRE(graph.connect_midi(midi_in, plugin));
+        REQUIRE(graph.connect_midi(plugin, midi_out));
+        graph.set_canonical_executor_routing_enabled(mode != 0);
+        graph.set_parallel_routing_enabled(mode == 2);
+        graph.set_parallel_min_work_units(0);
+        REQUIRE(graph.prepare(48000.0, 32));
 
-    pulp::midi::MidiBuffer events;
-    events.add(pulp::midi::MidiEvent::note_off(0, 60, 0));
-    REQUIRE(graph.inject_midi(midi_in, events));
-    std::array<float, 32> source{};
-    const float* input_ptrs[] = {source.data()};
-    std::array<float, 32> rendered{};
-    float* output_ptrs[] = {rendered.data()};
-    pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
-    pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
-    graph.process(out, in, 32);
+        pulp::midi::MidiBuffer events;
+        events.add(pulp::midi::MidiEvent::note_off(0, 60, 0));
+        REQUIRE(graph.inject_midi(midi_in, events));
+        std::array<float, 32> source{};
+        const float* input_ptrs[] = {source.data()};
+        std::array<float, 32> rendered{};
+        float* output_ptrs[] = {rendered.data()};
+        pulp::audio::BufferView<const float> in(input_ptrs, 1, source.size());
+        pulp::audio::BufferView<float> out(output_ptrs, 1, rendered.size());
+        graph.process(out, in, 32);
 
-    graph.begin_swap_edit();
-    REQUIRE(graph.remove_node(midi_out));
-    REQUIRE(graph.prepare_swap(48000.0, 32)
-            == SignalGraph::SwapResult::NeedsEagerPrepare);
+        graph.begin_swap_edit();
+        REQUIRE(graph.remove_node(midi_out));
+        REQUIRE(graph.prepare_swap(48000.0, 32)
+                == SignalGraph::SwapResult::NeedsEagerPrepare);
 
-    pulp::midi::MidiBuffer arrived;
-    REQUIRE(graph.extract_midi(midi_out, arrived));
-    REQUIRE(arrived.size() == 1);
-    CHECK(arrived[0].is_note_off());
-    CHECK(arrived[0].note() == 60);
+        // The old output-bearing snapshot remains live until eager prepare.
+        // An empty block must not overwrite the pending note-off, and a later
+        // nonempty block must queue behind it rather than replacing it.
+        graph.process(out, in, 32);
+        events.clear();
+        events.add(pulp::midi::MidiEvent::note_on(0, 67, 100));
+        REQUIRE(graph.inject_midi(midi_in, events));
+        graph.process(out, in, 32);
 
-    // The requested eager replacement adopts the output-node removal only after
-    // the pending old-snapshot egress was drained. The retired NodeId must not
-    // replay the note-off or retain a pointer into the old snapshot.
-    REQUIRE(graph.prepare(48000.0, 32));
-    arrived.clear();
-    REQUIRE_FALSE(graph.extract_midi(midi_out, arrived));
-    CHECK(arrived.empty());
+        pulp::midi::MidiBuffer arrived;
+        REQUIRE(graph.extract_midi(midi_out, arrived));
+        REQUIRE(arrived.size() == 2);
+        CHECK(arrived[0].is_note_off());
+        CHECK(arrived[0].note() == 60);
+        CHECK(arrived[1].is_note_on());
+        CHECK(arrived[1].note() == 67);
+
+        // The requested eager replacement adopts the output-node removal only
+        // after old-snapshot egress was drained. The retired NodeId must not
+        // retain a pointer into that snapshot.
+        REQUIRE(graph.prepare(48000.0, 32));
+        arrived.clear();
+        REQUIRE_FALSE(graph.extract_midi(midi_out, arrived));
+        CHECK(arrived.empty());
+    }
+}
+
+TEST_CASE("SignalGraph MIDI egress queue retains earliest blocks on overflow",
+          "[host][graph][midi][mailbox][egress][overflow]") {
+    for (const int mode : {0, 1, 2}) {
+        INFO("routing mode " << mode);
+        SignalGraph graph;
+        const auto midi_in = graph.add_midi_input_node("keys");
+        const auto midi_out = graph.add_midi_output_node("thru");
+        REQUIRE(graph.connect_midi(midi_in, midi_out));
+        graph.set_canonical_executor_routing_enabled(mode != 0);
+        graph.set_parallel_routing_enabled(mode == 2);
+        graph.set_parallel_min_work_units(0);
+        REQUIRE(graph.prepare(48000.0, 32));
+
+        float sample = 0.0f;
+        const float* input_ptrs[] = {&sample};
+        float* output_ptrs[] = {&sample};
+        pulp::audio::BufferView<const float> in(input_ptrs, 0, 32);
+        pulp::audio::BufferView<float> out(output_ptrs, 0, 32);
+        for (int block = 0; block < 5; ++block) {
+            pulp::midi::MidiBuffer events;
+            events.add(pulp::midi::MidiEvent::note_off(0, 60 + block, 0));
+            REQUIRE(graph.inject_midi(midi_in, events));
+            graph.process(out, in, 32);
+        }
+
+        pulp::midi::MidiBuffer arrived;
+        REQUIRE_FALSE(graph.extract_midi(midi_out, arrived));
+        REQUIRE(arrived.size() == 4);
+        for (int index = 0; index < 4; ++index) {
+            CHECK(arrived[static_cast<std::size_t>(index)].is_note_off());
+            CHECK(arrived[static_cast<std::size_t>(index)].note() == 60 + index);
+        }
+
+        arrived.clear();
+        REQUIRE(graph.extract_midi(midi_out, arrived));
+        CHECK(arrived.empty());
+    }
 }
 
 TEST_CASE("SignalGraph MIDI ingress sequence skips zero after wrap",
@@ -2785,7 +2848,6 @@ TEST_CASE("SignalGraph MIDI ingress and egress mailboxes are Race-free",
     });
 
     bool all_injects_succeeded = true;
-    bool all_extracts_succeeded = true;
     bool saw_invalid_output = false;
     constexpr int kMinMidiUpdates = 10000;
     constexpr int kMinBlocksDuringUpdates = 4;
@@ -2807,10 +2869,16 @@ TEST_CASE("SignalGraph MIDI ingress and egress mailboxes are Race-free",
             graph.inject_midi(midi_in, events) && all_injects_succeeded;
 
         pulp::midi::MidiBuffer out;
-        all_extracts_succeeded =
-            graph.extract_midi(midi_out, out) && all_extracts_succeeded;
-        if (out.size() > 1 || out.sysex_size() != 0) {
+        static_cast<void>(graph.extract_midi(midi_out, out));
+        if (out.size() > 4 || out.sysex_size() != 0) {
             saw_invalid_output = true;
+        }
+        for (const auto& output_event : out) {
+            if (output_event.note() < 60 || output_event.note() > 71
+                || output_event.sample_offset < 0
+                || output_event.sample_offset >= 32) {
+                saw_invalid_output = true;
+            }
         }
         if ((update_count % 64) == 0) std::this_thread::yield();
         ++update_count;
@@ -2821,7 +2889,6 @@ TEST_CASE("SignalGraph MIDI ingress and egress mailboxes are Race-free",
     audio_thread.join();
 
     REQUIRE(all_injects_succeeded);
-    REQUIRE(all_extracts_succeeded);
     REQUIRE(processed_blocks.load(std::memory_order_relaxed) > 0);
     REQUIRE(blocks_during_updates.load(std::memory_order_relaxed)
             >= kMinBlocksDuringUpdates);
@@ -2888,7 +2955,6 @@ TEST_CASE("SignalGraph live controls and MIDI handoff are TSan-clean together",
 
     bool all_gain_updates_succeeded = true;
     bool all_injects_succeeded = true;
-    bool all_extracts_succeeded = true;
     bool saw_invalid_midi = false;
     constexpr int kMinControlUpdates = 10000;
     constexpr int kMinBlocksDuringUpdates = 4;
@@ -2915,10 +2981,16 @@ TEST_CASE("SignalGraph live controls and MIDI handoff are TSan-clean together",
             graph.inject_midi(midi_in, events) && all_injects_succeeded;
 
         pulp::midi::MidiBuffer extracted;
-        all_extracts_succeeded =
-            graph.extract_midi(midi_out, extracted) && all_extracts_succeeded;
-        if (extracted.size() > 1 || extracted.sysex_size() != 0) {
+        static_cast<void>(graph.extract_midi(midi_out, extracted));
+        if (extracted.size() > 4 || extracted.sysex_size() != 0) {
             saw_invalid_midi = true;
+        }
+        for (const auto& output_event : extracted) {
+            if (output_event.note() < 60 || output_event.note() > 71
+                || output_event.sample_offset < 0
+                || output_event.sample_offset >= 32) {
+                saw_invalid_midi = true;
+            }
         }
 
         if ((update_count % 64) == 0) std::this_thread::yield();
@@ -2931,7 +3003,6 @@ TEST_CASE("SignalGraph live controls and MIDI handoff are TSan-clean together",
 
     REQUIRE(all_gain_updates_succeeded);
     REQUIRE(all_injects_succeeded);
-    REQUIRE(all_extracts_succeeded);
     REQUIRE(processed_blocks.load(std::memory_order_relaxed) > 0);
     REQUIRE(blocks_during_updates.load(std::memory_order_relaxed)
             >= kMinBlocksDuringUpdates);

--- a/test/test_osc_dco.cpp
+++ b/test/test_osc_dco.cpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <numbers>
 #include <span>
+#include <utility>
 #include <vector>
 
 using Catch::Matchers::WithinAbs;

--- a/test/test_signal_graph_prepared_swap_live.cpp
+++ b/test/test_signal_graph_prepared_swap_live.cpp
@@ -6,7 +6,9 @@
 // allow-set edits do NOT silence the live snapshot; prepare_swap() recompiles and
 // atomically publishes the new snapshot (publish-new-before-retire, seq_cst) so no
 // output block is ever silent. A non-reinit-free edit instead returns
-// NeedsEagerPrepare (and invalidates), so the caller falls back to prepare().
+// NeedsEagerPrepare, so the caller falls back to prepare(). Ordinary rejection
+// classes invalidate the live snapshot; the MidiOutput pending-egress class keeps
+// it live long enough to drain before eager prepare.
 //
 // This suite asserts (a) a reinit-free gain-graph swap under a live render drops NO
 // block to silence, and (b) each non-reinit-free class is rejected.

--- a/test/test_signal_graph_prepared_swap_live.cpp
+++ b/test/test_signal_graph_prepared_swap_live.cpp
@@ -213,7 +213,7 @@ TEST_CASE("prepare_swap rejects non-reinit-free edits -> NeedsEagerPrepare (2.2b
         CHECK(g.prepare_swap(kSr, kFrames)
               == SignalGraph::SwapResult::NeedsEagerPrepare);
     }
-    SECTION("MIDI edge in the graph -> NeedsEagerPrepare (M4 stuck-note gate)") {
+    SECTION("MIDI output keeps pending egress on eager-prepare path") {
         SignalGraph g;
         NodeId gain{};
         build_gain_graph(g, gain);

--- a/test/test_signal_graph_rt_safety.cpp
+++ b/test/test_signal_graph_rt_safety.cpp
@@ -18,6 +18,7 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/host/signal_graph.hpp>
 #include <pulp/midi/buffer.hpp>
+#include <pulp/midi/ump_buffer.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -175,6 +176,10 @@ TEST_CASE("SignalGraph process() with injected MIDI stays RT-safe",
     note.sample_offset = 8;
     injected.add(note);
     injected.add(pulp::midi::MidiEvent::cc(0, 1, 64));
+    injected.add_sysex({0xF0, 0x7D, 0x01, 0xF7}, 12);
+    pulp::midi::UmpBuffer injected_ump;
+    injected_ump.add(pulp::midi::UmpPacket::note_on_2(0, 0, 64, 0x8000), 16);
+    injected.attach_ump(&injected_ump);
 
     StereoBlock in(kFrames, 0.0f);
     StereoBlock out(kFrames, 0.0f);
@@ -184,17 +189,13 @@ TEST_CASE("SignalGraph process() with injected MIDI stays RT-safe",
     // Warm up with an empty mailbox, OUTSIDE the probe.
     graph.process(out_view, in_view, static_cast<int>(kFrames));
 
-    // inject_midi() runs on the control/UI thread and publishes into the
-    // graph's TripleBuffer mailbox. Inject immediately before the probed block
-    // (with no intervening process()) so the measured block actually carries
-    // and drains the events — process() clears the MIDI input scratch each
-    // block, so a warm-up process() between inject and measure would consume
-    // them and make this assertion vacuous.
-    REQUIRE(graph.inject_midi(midi_in, injected));
-
     std::size_t allocation_count = 0;
     {
         pulp::test::ScopedRtProcessProbe probe;
+        // A single producer may inject on the audio thread immediately before
+        // process(). The fixed event, SysEx, and UMP mailbox storage must keep
+        // both operations allocation- and lock-free.
+        REQUIRE(graph.inject_midi(midi_in, injected));
         graph.process(out_view, in_view, static_cast<int>(kFrames));
         allocation_count = probe.allocation_count();
     }

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -303,13 +303,14 @@ TEST_CASE("SpscQueue reports capacity, empty state, and FIFO order",
     REQUIRE_FALSE(queue.empty());
     REQUIRE(queue.size_approx() == 2);
 
-    auto first = queue.try_pop();
+    int first = 0;
+    REQUIRE(queue.try_pop(first));
     auto second = queue.try_pop();
-    REQUIRE(first.has_value());
     REQUIRE(second.has_value());
-    REQUIRE(*first == 10);
+    REQUIRE(first == 10);
     REQUIRE(*second == 20);
     REQUIRE(queue.empty());
+    REQUIRE_FALSE(queue.try_pop(first));
 }
 
 TEST_CASE("SpscQueue rejects pushes when full and accepts after pop",

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -173,7 +173,6 @@ TEST_CASE("WebSocketChannel echo round-trip on loopback", "[websocket]") {
     auto client = WebSocketChannel::connect(std::move(client_tcp), "127.0.0.1", "/");
     REQUIRE(client != nullptr);
     REQUIRE(client->is_open());
-
     std::mutex client_mu;
     std::vector<std::string> client_seen;
     client->on_message([&](const Message& m) {
@@ -201,8 +200,8 @@ TEST_CASE("WebSocketChannel echo round-trip on loopback", "[websocket]") {
     }
 
     client->close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel rejects handshake without upgrade header", "[websocket]") {
@@ -364,6 +363,8 @@ TEST_CASE("WebSocketChannel close flips is_open to false",
     auto client = WebSocketChannel::connect(std::move(client_tcp), "127.0.0.1", "/");
     REQUIRE(client != nullptr);
     REQUIRE(client->is_open());
+    std::atomic<bool> client_error{false};
+    client->on_error([&](std::string_view) { client_error.store(true); });
 
     client->close();
     REQUIRE_FALSE(client->is_open());
@@ -371,9 +372,11 @@ TEST_CASE("WebSocketChannel close flips is_open to false",
     // Double-close is safe.
     client->close();
     REQUIRE_FALSE(client->is_open());
+    client.reset();
+    REQUIRE_FALSE(client_error.load());
 
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel echoes a >126-byte message (16-bit payload length)",
@@ -428,8 +431,8 @@ TEST_CASE("WebSocketChannel echoes a >126-byte message (16-bit payload length)",
     }
 
     client->close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel delivers binary send as binary message",
@@ -481,8 +484,8 @@ TEST_CASE("WebSocketChannel delivers binary send as binary message",
     }
 
     client->close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel assembles fragmented text frames",
@@ -544,8 +547,8 @@ TEST_CASE("WebSocketChannel assembles fragmented text frames",
     }
 
     client.close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel reports unknown frame opcodes",
@@ -601,8 +604,8 @@ TEST_CASE("WebSocketChannel reports unknown frame opcodes",
     }));
 
     client.close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 // max_payload bounds a single frame, but a message reassembled across
@@ -677,8 +680,8 @@ TEST_CASE("WebSocketChannel bounds total reassembled message size",
     REQUIRE(messages.load() == 0);  // never delivered a partial/oversized message
 
     client.close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel replies to ping frames with pong",
@@ -726,8 +729,8 @@ TEST_CASE("WebSocketChannel replies to ping frames with pong",
     REQUIRE(*payload == std::vector<std::uint8_t>{'o', 'k'});
 
     client.close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel echoes close frames and closes",
@@ -781,8 +784,8 @@ TEST_CASE("WebSocketChannel echoes close frames and closes",
     REQUIRE_FALSE(server_ws->is_open());
 
     client.close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
@@ -842,8 +845,8 @@ TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
     }
 
     client->close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }
 
 TEST_CASE("WebSocketChannel rejects frames above max_payload",
@@ -897,6 +900,6 @@ TEST_CASE("WebSocketChannel rejects frames above max_payload",
     }
 
     client->close();
-    if (server_ws) server_ws->close();
     server_thread.join();
+    if (server_ws) server_ws->close();
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes MIDI I/O in `SignalGraph` real‑time safe and swap‑safe. Ingress is single‑writer and preserved across gap‑free swaps; egress uses a bounded, ordered queue with resumable drains to prevent stuck notes.

- New Features
  - `inject_midi()` is audio‑callback‑safe after `prepare()`: fixed‑capacity, `noexcept`, lock/alloc‑free, latest‑wins, consumed once, and shared across gap‑free `prepare_swap()` for a stable `MidiInput`.
  - Ingress publication sequence never uses zero and wraps skipping zero; added test seams to seed/read the sequence.
  - `extract_midi()` drains `MidiOutput` via a fixed four‑block `runtime::SpscQueue` in process order; partial copies (events, SysEx, UMP) resume without replay; returns false on overflow or insufficient destination/sidecar capacity.
  - Live swap allows ingress‑only MIDI; if the candidate or live graph has `MidiOutput`, `prepare_swap()` returns `NeedsEagerPrepare` and keeps the old snapshot live so pending egress can be drained.
  - Registered RT‑safety for `SignalGraph::inject_midi`; tightened `runtime::TripleBuffer`/`runtime::SpscQueue` APIs and `noexcept` paths; added `TcpStream::shutdown()` and made `WebSocketChannel::close()` interrupt reads and join the reader before closing; updated docs/tests.

- Migration
  - Treat a false `extract_midi()` as “incomplete”: provide more event/SysEx/UMP capacity and call again to resume.
  - If `prepare_swap()` returns `NeedsEagerPrepare` due to `MidiOutput`, drain pending output with `extract_midi()` first, then call `prepare()`.

<sup>Written for commit 40313dc7a181620838bd4c711dbc9344f3d65fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- whence {"labels": ["1·codex", "2·m3", "4·Timeline v2"], "prov": {"agent": "codex", "tab": "Timeline v2"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Tab** | Timeline v2 |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019f76f4-ca64-7c11-bfab-f5e4760ad402` |

**Resume**
```
codex resume 019f76f4-ca64-7c11-bfab-f5e4760ad402
```
**Jump to this tab**
```
cmux surface focus 5B6BF9F2-E9CA-4378-88AC-996A403ECAA6
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 5B6BF9F2-E9CA-4378-88AC-996A403ECAA6
```

<sub>stamped 2026-07-19 01:43 UTC</sub>
<!-- /whence -->