### PR TITLE
fix(runtime): mark TcpStream closed on shutdown

### DIFF
--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -140,9 +140,10 @@ Patterns that are easy to get wrong:
    structured access.
 5. **Interrupt a WebSocket reader before releasing its socket.**
    `WebSocketChannel::close()` uses `TcpStream::shutdown()` to wake blocking
-   reads. Destruction then joins the reader before closing the socket handle.
-   Preserve that order; closing the handle while the reader is inside
-   `receive()` races with descriptor invalidation.
+   reads and mark the stream closed. Destruction then joins the reader before
+   releasing the socket handle with `close()`. Preserve that order; closing the
+   handle while the reader is inside `receive()` races with descriptor
+   invalidation.
 6. **Do not destroy a WebSocket channel from an inline callback.** With no
    executor, callbacks run on the reader thread. They may call `close()`, but
    must defer destruction until after the callback returns; otherwise the

--- a/core/runtime/include/pulp/runtime/network_stream.hpp
+++ b/core/runtime/include/pulp/runtime/network_stream.hpp
@@ -40,7 +40,7 @@ public:
 
     StreamResult read(std::uint8_t* buffer, std::size_t size) override;
     StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
-    /// Interrupt blocking I/O without closing or invalidating the socket handle.
+    /// Mark the stream closed and interrupt blocking I/O without releasing the socket handle.
     void shutdown();
     void close() override;
     bool is_open() const override { return open_.load(); }

--- a/core/runtime/src/network_stream.cpp
+++ b/core/runtime/src/network_stream.cpp
@@ -64,6 +64,7 @@ StreamResult TcpStream::write(const std::uint8_t* buffer, std::size_t size) {
 }
 
 void TcpStream::shutdown() {
+    open_.store(false);
     socket_.shutdown();
 }
 

--- a/docs/reference/streams.md
+++ b/docs/reference/streams.md
@@ -64,10 +64,12 @@ AsyncStream io(std::move(tcp));
 io.start();
 ```
 
-`shutdown()` interrupts blocking socket I/O without invalidating the socket
-handle. It is intended for coordinated reader teardown: signal shutdown, join
-the reader, then call `close()` to release the handle. `is_open()` may be read
-concurrently with normal reads and writes, including peer-EOF transitions.
+`shutdown()` marks the stream closed and interrupts blocking socket I/O without
+releasing the socket handle. It is intended for coordinated reader teardown:
+signal shutdown, join the reader, then call `close()` to release the handle.
+After shutdown, `is_open()` is false and new reads or writes return `Closed`.
+`is_open()` may be read concurrently with normal reads and writes, including
+peer-EOF transitions.
 
 ### `HttpStream`
 

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -30,6 +30,8 @@ using pulp::runtime::HttpStream;
 using pulp::runtime::MemoryStream;
 using pulp::runtime::NamedPipe;
 using pulp::runtime::PipeStream;
+using pulp::runtime::Socket;
+using pulp::runtime::SocketType;
 using pulp::runtime::Stream;
 using pulp::runtime::StreamError;
 using pulp::runtime::StreamResult;
@@ -801,6 +803,33 @@ TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
     REQUIRE_FALSE(second.is_open());
     REQUIRE(second.read(&byte, 1).closed());
     REQUIRE(second.write(&byte, 1).closed());
+}
+
+TEST_CASE("TcpStream shutdown closes the stream but retains its socket handle",
+          "[stream][tcp]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    REQUIRE(listener.bind("127.0.0.1", 0));
+    REQUIRE(listener.listen(1));
+    const auto port = listener.local_port();
+    REQUIRE(port != 0);
+
+    TcpStream stream;
+    REQUIRE(stream.connect("127.0.0.1", port));
+    auto accepted = listener.accept();
+    REQUIRE(accepted.has_value());
+
+    stream.shutdown();
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.socket().is_open());
+
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+
+    stream.close();
+    REQUIRE_FALSE(stream.socket().is_open());
+    accepted->close();
 }
 
 TEST_CASE("HttpStream invalid URLs fail without external transport",


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Mark `TcpStream` as closed on `shutdown()` to make teardown predictable while keeping the socket handle open. After shutdown, `is_open()` is false and reads/writes return `Closed`; `close()` still releases the handle.

- **Bug Fixes**
  - Set `open_ = false` in `shutdown()` to reject new I/O.
  - Preserve the socket handle until `close()`; added tests to verify handle state and I/O results.
  - Updated docs and skills guide to clarify shutdown semantics and WebSocket teardown order.

<sup>Written for commit 0b7aff55af0e17618e553cdffb154ac1b92edc0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/6319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- whence {"labels": ["1·codex", "2·m3", "4·Timeline v2"], "prov": {"agent": "codex", "tab": "Timeline v2"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Tab** | Timeline v2 |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019f76f4-ca64-7c11-bfab-f5e4760ad402` |

**Resume**
```
codex resume 019f76f4-ca64-7c11-bfab-f5e4760ad402
```
**Jump to this tab**
```
cmux surface focus 5B6BF9F2-E9CA-4378-88AC-996A403ECAA6
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 5B6BF9F2-E9CA-4378-88AC-996A403ECAA6
```

<sub>stamped 2026-07-19 04:21 UTC</sub>
<!-- /whence -->