### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.387.0",
+      "version": "0.387.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.387.0"
+  "version": "0.387.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.387.0",
+  "version": "0.387.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on f949eacfc0ca..cd461245eabc.
plugin 0.387.0->0.387.1 (patch)

Version-Bump-Applied: cd461245eabc464ce35d7f03ed6bf70111184dd5

<!-- whence {"labels": ["1·codex", "2·m3", "4·Set up fleet v4…"], "prov": {"agent": "codex", "tab": "Set up fleet v4 project with Orchestrate in new workspace"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Tab** | Set up fleet v4 project with Orchestrate in new workspace |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019f8d81-7a2e-7720-827b-cedaddde5597` |

**Resume**
```
codex resume 019f8d81-7a2e-7720-827b-cedaddde5597
```
**Jump to this tab**
```
cmux surface focus 25FC2E65-DF16-4779-8D63-F21E598716A8
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 25FC2E65-DF16-4779-8D63-F21E598716A8
```

<sub>stamped 2026-07-23 12:10 UTC</sub>
<!-- /whence -->