### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.387.1",
+      "version": "0.388.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.387.1"
+  "version": "0.388.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.387.1",
+  "version": "0.388.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.747.0
+    VERSION 0.748.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on fc8ebc952fc3..096b9148556f.
sdk 0.747.0->0.748.0 (minor); plugin 0.387.1->0.388.0 (minor)

Version-Bump-Applied: 096b9148556fe78638e8835e38f3635e914f6633

<!-- whence {"labels": ["1·codex", "2·m3", "4·Set up fleet v4…"], "prov": {"agent": "codex", "tab": "Set up fleet v4 project with Orchestrate in new workspace"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Tab** | Set up fleet v4 project with Orchestrate in new workspace |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019f8d81-7a2e-7720-827b-cedaddde5597` |

**Resume**
```
codex resume 019f8d81-7a2e-7720-827b-cedaddde5597
```
**Jump to this tab**
```
cmux surface focus 25FC2E65-DF16-4779-8D63-F21E598716A8
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 25FC2E65-DF16-4779-8D63-F21E598716A8
```

<sub>stamped 2026-07-23 12:10 UTC</sub>
<!-- /whence -->