### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.389.0",
+      "version": "0.390.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.389.0"
+  "version": "0.390.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.389.0",
+  "version": "0.390.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.749.0
+    VERSION 0.750.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on dc0e0f837d8e..b22bea4ee484.
sdk 0.749.0->0.750.0 (minor); plugin 0.389.0->0.390.0 (minor)

Version-Bump-Applied: b22bea4ee48416e26458faad023edb05063cafbc

<!-- whence {"labels": ["1·claude", "2·m3", "3·Mon Claude recover Codex", "4·Forge v10"], "prov": {"agent": "claude", "tab": "Forge v10"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m3` |
| **Workspace** | `Mon Claude recover Codex` |
| **Tab** | Forge v10 |
| **Directory** | `/Volumes/Workshop/Code/pulp-integration-review-20260727` |
| **Session** | `69f62eab-7b7b-48a3-8dfe-49aca09432c2` |

**Resume**
```
claude --resume 69f62eab-7b7b-48a3-8dfe-49aca09432c2
```
**Jump to this tab**
```
cmux surface focus B0563D7E-5F4A-4463-AB65-97DEC3747488
```
**Relaunch (any agent)**
```
cmux surface resume get --surface B0563D7E-5F4A-4463-AB65-97DEC3747488
```

<sub>stamped 2026-07-27 15:07 UTC</sub>
<!-- /whence -->