### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.390.0",
+      "version": "0.391.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.390.0"
+  "version": "0.391.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.390.0",
+  "version": "0.391.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.750.0
+    VERSION 0.751.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4470,7 +4470,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.390.0",
+        "version": "0.391.0",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4485,13 +4485,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.390.0",
+        "catalog_version": "0.391.0",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.390.0",
+        "version": "0.391.0",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 3e93ec0bca9b..2bff0650e276.
sdk 0.750.0->0.751.0 (minor); plugin 0.390.0->0.390.1 (patch)

Version-Bump-Applied: 2bff0650e276d0ee185885f3b96b96c07ff25149

<!-- whence {"labels": ["1·claude", "2·m3", "3·Mon Claude recover Codex", "4·Forge v10"], "prov": {"agent": "claude", "tab": "Forge v10"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m3` |
| **Workspace** | `Mon Claude recover Codex` |
| **Tab** | Forge v10 |
| **Directory** | `/Volumes/Workshop/Code/pulp-integration-review-20260727` |
| **Session** | `69f62eab-7b7b-48a3-8dfe-49aca09432c2` |

**Resume**
```
claude --resume 69f62eab-7b7b-48a3-8dfe-49aca09432c2
```
**Jump to this tab**
```
cmux surface focus B0563D7E-5F4A-4463-AB65-97DEC3747488
```
**Relaunch (any agent)**
```
cmux surface resume get --surface B0563D7E-5F4A-4463-AB65-97DEC3747488
```

<sub>stamped 2026-07-27 15:07 UTC</sub>
<!-- /whence -->