### PR TITLE
fix(release): raise the post-tag Shipyard pin above the [skip ci] bug and enforce it

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1074,12 +1074,33 @@ ubuntu-latest, and runs `shipyard release-bot hook run`, which reads
 So there are TWO Shipyard versions that matter, and they drift independently: the
 one on each fleet Mac (`tools/shipyard.toml` + `install-shipyard.sh`), and the one
 THIS workflow installs. If the workflow's pin is older than a config key it must
-honour, it silently ignores the key. Concretely: `push_mode = "pr"` needs
-v0.78.0; a stale `post-tag-sync.yml` pin at 0.70.0 reverted to a direct push to
-`main` that the merge-queue ruleset refuses — defeating the config change and the
-fleet upgrade both. Keep `SHIPYARD_VERSION` here `>=` the `tools/shipyard.toml`
-pin whenever a post-tag-hook feature depends on it. (Durable fix is for
-`hook install` to pin from `tools/shipyard.toml` — a Shipyard-side change.)
+honour, it silently ignores the key. A stale pin at 0.70.0 reverted to a direct
+push to `main` that the merge-queue ruleset refuses — defeating the config change
+and the fleet upgrade both.
+
+**The `push_mode = "pr"` floor is v0.79.0, NOT v0.78.0.** This distinction is
+subtle and it cost nine unmergeable PRs. 0.78.0 honours `push_mode` far enough to
+*open* the PR, so the pin looks correct and the branch appears — but the commit is
+still stamped `docs: regenerate changelog for <tag> [skip ci]`. That marker is
+right for the direct-push path it was written for and **fatal on the PR path**:
+Actions skips every workflow, so the PR never obtains the required checks branch
+protection demands, so it can never merge, and the next release opens another one.
+They stacked from v0.751.0 to v0.759.0 and blocked the release pipeline, surfacing
+as a run of `release: stuck — fix/feat merged without bump` issues rather than as
+anything pointing at the changelog PRs. Shipyard split the two subjects in 0.79.0
+(`release_bot_commit_subject`: `pr` omits the marker, direct keeps it).
+
+Diagnosing this class: a PR whose required checks read **`MISSING`** (not
+pending, not failing — absent) is almost always a workflow that never dispatched.
+Check the tip commit for `[skip ci]` first, then whether the PR was opened by an
+App token — GitHub does not dispatch `pull_request` workflows for App-token
+actions, and neither `workflow_dispatch` (its runs do not attach to the PR as
+checks) nor close/reopen from an App token will fix that. A commit pushed from a
+**user** identity does.
+
+Keep `SHIPYARD_VERSION` here `>=` the `tools/shipyard.toml` pin whenever a
+post-tag-hook feature depends on it. (Durable fix is for `hook install` to pin
+from `tools/shipyard.toml` — a Shipyard-side change.)
 
 ### NEVER set `run-name:` on release-cli.yml (it stops all releases)
 

--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -27,7 +27,14 @@ env:
   # it, and reverts to a direct push to main that the main-merge-queue
   # ruleset refuses — so the changelog sync fails even though the local
   # fleet CLI is current. Keep this in lockstep with tools/shipyard.toml.
-  SHIPYARD_VERSION: "0.78.0"
+  # Floor is 0.79.0, NOT 0.78.0. `push_mode = "pr"` was honoured from 0.78.0
+  # onward, but until 0.79.0 the changelog commit was still stamped
+  # `[skip ci]` — correct for the direct-push path, fatal on the PR path,
+  # because Actions then skips every workflow and the PR can never obtain
+  # the required checks it needs to merge. Nine changelog PRs accumulated
+  # unmergeable that way (v0.751.0 → v0.759.0) and blocked the release
+  # pipeline behind them. Keep in lockstep with tools/shipyard.toml.
+  SHIPYARD_VERSION: "0.80.2"
 
 jobs:
   sync:

--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -373,7 +373,7 @@ and asset metadata should move together.
 
 See [CLAUDE.md § Dependency Update Workflow](https://github.com/Generous-Corp/pulp/blob/main/CLAUDE.md#dependency-update-workflow) for the full procedure. The `ci` skill's path map catches the file change and demands a SKILL.md review.
 
-### Why the pin sits at v0.78.0 — the merge queue made it load-bearing
+### Why the pin sits at v0.80.2 — the merge queue made it load-bearing
 
 The pin moved v0.70.0 → v0.78.0 for one reason that is specific to this repo:
 **Shipyard's post-tag hook could no longer push.**
@@ -389,8 +389,29 @@ plus a silently stale CHANGELOG.
 
 Shipyard v0.78.0 adds `push_mode` to that hook. With `push_mode = "pr"` the hook
 opens a pull request instead of pushing, so the changelog lands *through* the
-queue like everything else. That is the setting Pulp uses, and it is why the pin
-cannot stay below v0.78.0 while the merge queue is enabled.
+queue like everything else. That is the setting Pulp uses.
+
+**But v0.78.0 is not sufficient — the floor is v0.79.0**, and the gap between
+those two versions cost nine unmergeable PRs on 2026-07-28. v0.78.0 honours
+`push_mode` far enough to *open* the PR, so the pin looks correct and the branch
+appears — but the commit is still subject
+`docs: regenerate changelog for <tag> [skip ci]`. That marker is right for the
+direct-push path it was written for and **fatal on the PR path**: GitHub Actions
+skips every workflow, so the PR never obtains the required checks branch
+protection demands, so it can never merge. The next release opens another one.
+They accumulated from v0.751.0 to v0.759.0 and stalled the release pipeline,
+visible only as a run of `release: stuck — fix/feat merged without bump` issues
+that pointed nowhere near the changelog PRs. Shipyard split the two subjects in
+v0.79.0 (`release_bot_commit_subject`: the `pr` path omits the marker).
+
+This class of mistake — pins that agree with each other but sit below what a
+config key needs — is now mechanically caught. `tools/scripts/check_shipyard_pin.py`
+validates equality across `tools/shipyard.toml` and every workflow's
+`SHIPYARD_VERSION`, **and** a `FEATURE_FLOORS` table asserting that an enabled
+config key's minimum version is met. It runs from `tools/scripts/gates.sh`, so
+both drifts fail before push rather than at the next release. Record a new floor
+there when you start depending on a version-gated behaviour, instead of writing
+it in a comment that goes stale — which is exactly what happened here.
 
 Keep the three in step — the pin, the installed binary on every fleet Mac, and
 `push_mode` — because a host still on an older Shipyard silently ignores

--- a/tools/scripts/check_shipyard_pin.py
+++ b/tools/scripts/check_shipyard_pin.py
@@ -48,6 +48,48 @@ REQUIRED_PIN_WORKFLOWS: tuple[str, ...] = (
     "post-tag-sync.yml",
 )
 
+SHIPYARD_CONFIG = REPO_ROOT / ".shipyard" / "config.toml"
+
+# Minimum Shipyard version required by a config key we actually USE.
+# Equality between shipyard.toml and the workflows is not sufficient: both
+# can agree on a version that is too old for a feature the config enables,
+# and the failure is silent. `push_mode = "pr"` is honoured from 0.78.0, but
+# until 0.79.0 the changelog commit was still stamped `[skip ci]` — which
+# makes Actions skip the required checks, which makes the changelog PR
+# permanently unmergeable. Nine stacked up and stalled the release pipeline.
+#
+# Each entry: (regex matching the enabling config, floor, why it matters).
+FEATURE_FLOORS: tuple[tuple[str, str, str], ...] = (
+    (
+        r'^\s*push_mode\s*=\s*"pr"\s*$',
+        "0.79.0",
+        'post_tag_hook push_mode = "pr" — below 0.79.0 the changelog commit '
+        "is stamped [skip ci], so its required checks never run and the PR "
+        "can never merge",
+    ),
+)
+
+
+def _as_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split(".") if part.isdigit())
+
+
+def check_feature_floors(pinned: str) -> list[str]:
+    """Violations where the pin is below a floor the config demands."""
+    if not SHIPYARD_CONFIG.exists():
+        return []
+    text = SHIPYARD_CONFIG.read_text(errors="replace")
+    problems: list[str] = []
+    for pattern, floor, why in FEATURE_FLOORS:
+        if not re.search(pattern, text, re.MULTILINE):
+            continue
+        if _as_tuple(pinned) < _as_tuple(floor):
+            problems.append(
+                f"pin {pinned} is below the {floor} floor required by "
+                f".shipyard/config.toml: {why}"
+            )
+    return problems
+
 # `version = "v0.56.2"` in shipyard.toml. The leading `v` is part of the
 # release tag; workflows historically store the unprefixed semver.
 PIN_VERSION_RE = re.compile(r'^\s*version\s*=\s*"v?([\d.]+)"\s*$', re.MULTILINE)
@@ -142,6 +184,22 @@ def main() -> int:
             file=sys.stderr,
         )
         return 0
+
+    floor_problems = check_feature_floors(pinned)
+    if floor_problems:
+        print(
+            "Shipyard pin is version-consistent but TOO OLD for the config:",
+            file=sys.stderr,
+        )
+        for problem in floor_problems:
+            print(f"  ✗ {problem}", file=sys.stderr)
+        print(
+            "\nFix: raise the pin in tools/shipyard.toml (and every workflow's\n"
+            "SHIPYARD_VERSION, which this check also enforces), or stop using the\n"
+            "config key that demands the floor.",
+            file=sys.stderr,
+        )
+        return 1
 
     print(
         f"Shipyard pin OK: {len(workflow_versions)} workflow(s) match "

--- a/tools/scripts/compose_release_notes.py
+++ b/tools/scripts/compose_release_notes.py
@@ -20,7 +20,15 @@ SKIP_SUBJECT_PATTERNS = (
     re.compile(r"^chore: bump .*version", re.IGNORECASE),
     re.compile(r"^chore\(release\): ", re.IGNORECASE),
     re.compile(r"^bump .*to v?\d+\.\d+\.\d+$", re.IGNORECASE),
-    re.compile(r"^docs: regenerate changelog for v\d+\.\d+\.\d+ \[skip ci\]$", re.IGNORECASE),
+    # The `[skip ci]` suffix is OPTIONAL: Shipyard stamps it only on the
+    # direct-push path. From 0.79.0 the PR path omits it (the marker made the
+    # changelog PR unmergeable, since Actions then skipped the required
+    # checks), so a suffix-mandatory pattern would stop matching and leak
+    # changelog-regeneration commits into release notes as real changes.
+    re.compile(
+        r"^docs: regenerate changelog for v\d+\.\d+\.\d+( \[skip ci\])?$",
+        re.IGNORECASE,
+    ),
 )
 
 SECTION_ORDER = (

--- a/tools/scripts/gates.sh
+++ b/tools/scripts/gates.sh
@@ -167,6 +167,23 @@ if ! "$PYTHON" "$VBC" --base "$BASE" --config "$CFG" --mode=report \
     fail=1
 fi
 
+# ── 2b. shipyard-pin lockstep ──────────────────────────────────────────────
+# `tools/shipyard.toml` and every workflow's inline `SHIPYARD_VERSION` must
+# agree. The checker for this already existed but was wired into nothing, so
+# the two drifted to 0.78.0 vs 0.70.0 unnoticed — and a post-tag-sync pin
+# below 0.79.0 stamps the changelog commit `[skip ci]`, which makes Actions
+# skip the required checks, which makes the changelog PR unmergeable. Nine
+# stacked up that way and stalled the release pipeline. Cheap and offline,
+# so it runs unconditionally.
+PIN_CHECK="$ROOT/tools/scripts/check_shipyard_pin.py"
+if [ -f "$PIN_CHECK" ]; then
+    echo "" >&2
+    echo "▸ shipyard-pin lockstep check" >&2
+    if ! "$PYTHON" "$PIN_CHECK"; then
+        fail=1
+    fi
+fi
+
 # ── 3. compat-sync (optional — only if both files exist) ───────────────────
 COMPAT_MAP="$ROOT/tools/scripts/compat_path_map.json"
 if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -67,7 +67,7 @@
 #   rather than double-running the PR). This is why Pulp moves to this pin —
 #   it removes a whole class of "wedged same-PR ship" stalls. Bundles #349
 #   (self-hosted empty-log diagnostics point at the ctest artifact).
-version = "v0.78.0"
+version = "v0.80.2"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Supersedes #6778, which was authored by `app/shipyard-local`. GitHub does not dispatch `pull_request` workflows for App-authored PRs, so its required checks read MISSING and it could never merge — the same class of trap this PR fixes.

## The bug

`post-tag-sync.yml` pinned Shipyard 0.78.0. That version honours `push_mode = "pr"` far enough to *open* the changelog PR — so the pin looks correct — but still stamps the commit `docs: regenerate changelog for <tag> [skip ci]`.

`[skip ci]` makes Actions skip every workflow, so the PR never obtains the required checks branch protection demands, so it can never merge. The next release opens another one. **Nine accumulated**, v0.751.0 → v0.759.0, dating to 2026-07-26, and stalled the release pipeline — visible only as a run of `release: stuck — fix/feat merged without bump` issues that pointed nowhere near the changelog PRs.

Shipyard split the two subjects in **v0.79.0**; the direct-push path keeps the marker, the PR path drops it.

## Changes

- **`post-tag-sync.yml` pin 0.78.0 → 0.80.2**, with the floor explained inline
- **`tools/shipyard.toml` 0.78.0 → 0.80.2** via `shipyard pin bump`, restoring the lockstep the workflow comment demands
- **Wired `check_shipyard_pin.py` into `gates.sh`.** It already existed, and its docstring already described this exact failure — it was connected to nothing. That is the shape of the whole incident.
- **Added `FEATURE_FLOORS` to that checker.** Equality is insufficient: both locations can agree on a version below what an enabled config key needs, and the failure is silent. Now `push_mode = "pr"` asserts >= 0.79.0.
- **Made the `[skip ci]` suffix optional in `compose_release_notes.py`** — a regression the pin bump itself would have caused, since the skip pattern required the suffix and would have started leaking changelog commits into release notes.
- Corrected `docs/guides/versioning.md` (titled "Why the pin sits at v0.78.0", documenting the wrong floor) and the `ci` skill.

## Verification

Adversarial, both directions:

- reintroduce 0.78.0 in **one** location → equality check fails
- set **both** to 0.78.0 (equality passes) → floor check fails
- restored → passes

The floor table is the intended home for "this version is the minimum for a behaviour we depend on", so it is enforced rather than living in a comment that goes stale — which is exactly how this drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpNjpSMPxbfZHMmvXeYVgV

<!-- whence {"labels": ["1·claude", "2·m1", "4·three-fixes"], "prov": {"agent": "claude", "tab": "three-fixes"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m1` |
| **Tab** | three-fixes |
| **Directory** | `~/Code/pulp-skipci` |
| **Session** | `0198c61b-b46a-455d-bfd8-97879f519492` |

**Resume**
```
claude --resume 0198c61b-b46a-455d-bfd8-97879f519492
```
**Jump to this tab**
```
cmux surface focus E773562C-5146-4C25-BD3C-32E0A46CF137
```
**Relaunch (any agent)**
```
cmux surface resume get --surface E773562C-5146-4C25-BD3C-32E0A46CF137
```
**Restore URL** — https://claude.ai/code/session_01KpNjpSMPxbfZHMmvXeYVgV

<sub>stamped 2026-07-28 17:16 UTC</sub>
<!-- /whence -->