### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.402.1",
+      "version": "0.402.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.402.1"
+  "version": "0.402.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.402.1",
+  "version": "0.402.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.766.0
+    VERSION 0.766.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4620,7 +4620,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.402.1",
+        "version": "0.402.2",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4635,13 +4635,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.402.1",
+        "catalog_version": "0.402.2",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.402.1",
+        "version": "0.402.2",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 4befdef96690..afa0798457c5.
sdk 0.766.0->0.766.1 (patch); plugin 0.402.1->0.402.2 (patch)

Version-Bump-Applied: afa0798457c5c35b0a3395f43d4a7eee79ad9e62

<!-- whence {"labels": ["1·codex", "2·m1", "4·pickup work on mini…"], "prov": {"agent": "codex", "tab": "pickup work on mini and pro v2"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m1` |
| **Tab** | pickup work on mini and pro v2 |
| **Directory** | `~/Code/pulp` |
| **Session** | `019fc099-bf5b-74f0-983a-a020fa874c79` |

**Resume**
```
codex resume 019fc099-bf5b-74f0-983a-a020fa874c79
```
**Jump to this tab**
```
cmux surface focus 0B8B957E-FC9C-403E-B94F-B510DC96993D
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 0B8B957E-FC9C-403E-B94F-B510DC96993D
```

<sub>stamped 2026-08-02 10:27 UTC</sub>
<!-- /whence -->