### PR TITLE
ci: detect stalled merge queue heads

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -4299,8 +4299,8 @@ three properties when editing that workflow — running anything out of
 
 ### `merge_group` belongs ONLY on workflows that produce a required context
 
-A queue entry re-runs every workflow that declares `merge_group:`, and with
-`max_entries_to_build: 1` the queue validates one batch at a time — so any
+A queue entry re-runs every workflow that declares `merge_group:`. The live
+build window is configurable, so any
 workflow on `merge_group` whose contexts are **not** required sets the drain
 rate while being unable to affect the merge decision. Nine workflows once fired
 per entry when only five could gate; two of the extras (`Validate examples
@@ -4331,6 +4331,21 @@ queue slow, so re-verify rather than believing the comment.
 Dropping `merge_group` costs no PR-time signal: those workflows keep
 `pull_request` and still run on every PR. They just stop re-running against a
 merged result they cannot gate.
+
+### Diagnose a stalled queue from its active build window
+
+`tools/scripts/merge_stall_watchdog.py` treats the merge queue as its own
+failure surface. It reads `maximumEntriesToBuild`, tracks activity only across
+the entries GitHub can currently build, and reports the head's exact synthetic
+merge SHA and unresolved required contexts. Activity from entries outside that
+window must not suppress an alarm; activity from a cumulative follower inside
+it is real progress. If live collection is degraded, preserve prior state and
+fail closed instead of clearing an existing incident from an incomplete sweep.
+
+Use the head-specific blocker list before cancelling anything. A queued
+required context is evidence of capacity pressure, not a disposable run; only
+cancel exact-current advisory work after proving it cannot contribute to a
+required context or another agent's live PR.
 
 ### Install consumer smoke (`install-consumer-smoke.yml`)
 

--- a/.github/workflows/merge-stall-check.yml
+++ b/.github/workflows/merge-stall-check.yml
@@ -50,6 +50,10 @@ on:
         description: 'Merge-ready age (min) that, sustained two sweeps, opens an issue'
         required: false
         default: '45'
+      queue_threshold_minutes:
+        description: 'Merge-queue head age (min) without a new batch that opens an issue'
+        required: false
+        default: '30'
       dry_run:
         description: 'Log findings but do not touch the tracking issue'
         required: false
@@ -73,6 +77,7 @@ jobs:
 
     env:
       THRESHOLD_MINUTES: ${{ github.event.inputs.threshold_minutes || '45' }}
+      QUEUE_THRESHOLD_MINUTES: ${{ github.event.inputs.queue_threshold_minutes || '30' }}
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
       TRACKING_TITLE: 'Merge stall: green PRs are not merging'
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,6 +129,7 @@ jobs:
               --repo '${{ github.repository }}' \
               --base main \
               --threshold-minutes "${THRESHOLD_MINUTES}" \
+              --queue-threshold-minutes "${QUEUE_THRESHOLD_MINUTES}" \
               --prev-state prev/state.json \
               --findings-out findings.json \
               --snapshot-out snapshot.json \
@@ -132,8 +138,10 @@ jobs:
               --summary-out "${GITHUB_STEP_SUMMARY}" \
               | tee scan.log
 
-          count=$(python3 -c "import json; print(sum(1 for f in json.load(open('findings.json')) if f['level'] == 'alarm'))")
+          count=$(python3 -c "import json; print(sum(1 for f in json.load(open('findings.json')) if f['level'] in ('alarm', 'queue_alarm')))")
           echo "count=${count}" >> "$GITHUB_OUTPUT"
+          degraded=$(python3 -c "import json; print('true' if json.load(open('snapshot.json')).get('errors') else 'false')")
+          echo "degraded=${degraded}" >> "$GITHUB_OUTPUT"
           echo "Alarm count: ${count}"
 
       - name: Persist this-sweep state
@@ -150,6 +158,7 @@ jobs:
         shell: bash
         env:
           COUNT: ${{ steps.scan.outputs.count }}
+          DEGRADED: ${{ steps.scan.outputs.degraded }}
         run: |
           set -euo pipefail
 
@@ -169,6 +178,10 @@ jobs:
           existing_state=$(echo "$existing_json" | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('state','') or '')")
 
           if [ "$COUNT" -eq 0 ]; then
+              if [ "$DEGRADED" = "true" ]; then
+                  echo "Collection was degraded — preserving any existing tracker until a complete sweep proves recovery."
+                  exit 0
+              fi
               if [ -n "${existing:-}" ] && [ "$existing_state" = "OPEN" ]; then
                   echo "Merges are flowing again — closing tracker #${existing}."
                   gh api -X POST "/repos/${repo}/issues/${existing}/comments" \

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -1168,7 +1168,8 @@ automated process dereferences it on a schedule and alarms on failure.
 ### Off-fleet merge-stall watchdog (`merge-stall-check.yml`)
 
 `.github/workflows/merge-stall-check.yml` sweeps every 30 minutes and opens a
-tracking issue when PRs are **merge-ready but not merging**. It runs on
+tracking issue when PRs are **merge-ready but not merging** or the GitHub merge
+queue has stopped advancing. It runs on
 `ubuntu-latest` for the same reason as the queue-age watchdog: the wedge it
 catches lives in whatever presses the merge button (Shipyard's per-host
 queue-tick), so an on-fleet guard would die with the thing it watches.
@@ -1186,8 +1187,9 @@ hours with 34 PRs open and nothing merging while every check was green.)
 
 1. **Required checks green** — every check in the repo's REQUIRED set. That set
    is read from branch protection at runtime, not hardcoded; if the token cannot
-   read protection rules it falls back to the documented `main` set (`macos`,
-   `Enforce version & skill sync`).
+   read protection rules it falls back to the complete documented `main` set:
+   `macos`, `Enforce version & skill sync`, `Build + prove + (owner-gated)
+   deploy`, `Vellum trusted freeze`, and `Vellum freeze`.
 2. **`mergeStateStatus` in `{CLEAN, BEHIND}`** — GitHub's own merge verdict.
    `DIRTY` (conflicts), `BLOCKED` (a required check red/missing/review pending),
    and `UNSTABLE` (a non-required check still moving) are excluded — those wait
@@ -1210,23 +1212,33 @@ reaches the second observation, so it never trips. The cross-sweep memory is the
 set of stuck PR numbers, persisted as a workflow artifact — crash-safe, held by
 GitHub independently of this repo or any host.
 
+**Merge-queue predicate.** Once the queue is non-empty, the watchdog also reads
+its GraphQL `MergeQueue.entries` head and the latest `merge_group` Actions run.
+It alarms when the head has waited at least 30 minutes and no new merge-group
+batch has started in that window. The age window is already the anti-flap
+period, so this condition alarms on its first observed sweep. The report names
+the head PR, queue depth/state, last batch start, and any required check that is
+missing, queued, in progress, or red. This catches the incident where a required
+hosted alias waited behind advisory work while matching self-hosted build
+capacity was idle.
+
 The issue is edited in place each sweep and closes automatically once no PR is
 stuck merge-ready — the same open/update/auto-close contract as the release
-watchdogs (see [release-watchdog.md](release-watchdog.md)).
+watchdogs (see [release-watchdog.md](release-watchdog.md)). A degraded API sweep
+never closes an existing tracker; only a complete snapshot can prove recovery.
 
 Analysis and the predicate live in `tools/scripts/merge_stall_watchdog.py`,
 tested by `tools/scripts/test_merge_stall_watchdog.py` — which pins the
 must-stay-quiet cases (young PR, DIRTY, BLOCKED, no auto-merge, single-sweep
 blip) as regressions so a future edit that would make the guard cry wolf fails
-at PR time. The script also carries an inert, clearly-marked stub for a **second
-condition to add once a GitHub merge queue is enabled** ("queue depth > 0 AND no
-`merge_group` check started in 30 min" — a wedged *queue*, distinct from a wedged
-auto-merger); it stays off until the queue is live.
+at PR time. Queue-specific tests pin empty/young/recent-batch cases quiet and an
+old head plus old batch as an immediate alarm.
 
 ```bash
 # Dry-run a sweep by hand (log findings, do not touch the issue)
 gh workflow run merge-stall-check.yml -f dry_run=true
 gh workflow run merge-stall-check.yml -f threshold_minutes=60
+gh workflow run merge-stall-check.yml -f queue_threshold_minutes=30
 
 # Replay a recorded snapshot offline (no API calls, verdict pinned to capture time)
 python3 tools/scripts/merge_stall_watchdog.py --snapshot snapshot.json --prev-state state.json

--- a/tools/scripts/merge_stall_watchdog.py
+++ b/tools/scripts/merge_stall_watchdog.py
@@ -64,12 +64,19 @@ import sys
 from typing import Any
 
 THRESHOLD_MINUTES = 45
+MERGE_QUEUE_THRESHOLD_MINUTES = 30
 
 # Fallback only. The workflow reads the live required-check set from branch
 # protection; this list is what we assume when that read is unavailable (the
 # default GITHUB_TOKEN cannot always see protection rules). Kept in sync with
 # the documented required set for the `main` branch.
-DEFAULT_REQUIRED_CHECKS = ["macos", "Enforce version & skill sync"]
+DEFAULT_REQUIRED_CHECKS = [
+    "macos",
+    "Enforce version & skill sync",
+    "Build + prove + (owner-gated) deploy",
+    "Vellum trusted freeze",
+    "Vellum freeze",
+]
 
 # A CheckRun conclusion that satisfies a required-status-check gate. SKIPPED and
 # NEUTRAL count as green to branch protection, so they count here too.
@@ -192,31 +199,54 @@ def analyze(
     return findings, stuck_now
 
 
-# --------------------------------------------------------------------------
-# FUTURE / TODO — merge-queue stall predicate (DO NOT IMPLEMENT YET)
-# --------------------------------------------------------------------------
-def merge_queue_stall_todo(snapshot: dict[str, Any], now: dt.datetime) -> list[dict[str, Any]]:
-    """STUB — enable ONLY after the GitHub merge queue is turned on for `main`.
+def analyze_merge_queue(
+    snapshot: dict[str, Any],
+    now: dt.datetime,
+    threshold_minutes: float = MERGE_QUEUE_THRESHOLD_MINUTES,
+) -> list[dict[str, Any]]:
+    """Detect an enqueued head whose merge group has stopped making progress.
 
-    The predicate above catches a wedged AUTO-MERGER (Shipyard's queue-tick held
-    in reap-only mode): green PRs that stay green and unmerged. Once merges route
-    through a GitHub *merge queue* instead, a different wedge becomes possible —
-    the queue itself stalls: entries are enqueued but the queue stops forming the
-    `merge_group` batches that actually test-and-merge them. That shape is
-    invisible to the predicate above, because an enqueued PR's own
-    mergeStateStatus is no longer CLEAN/BEHIND while it waits in the queue.
-
-    Second condition to add THEN (not now — the queue is not live):
-
-        merge queue depth > 0  AND  no `merge_group` check run has STARTED in the
-        last 30 minutes
-
-    i.e. work is enqueued but the queue has formed no batch in a full sweep-plus
-    window. Data source: the merge-queue GraphQL fields (`MergeQueue.entries`,
-    their `enqueuedAt`) plus `merge_group`-triggered check runs on the base
-    branch. Until the queue is enabled this returns nothing and is never called.
+    A non-empty queue is healthy while its current merge group is young. It is
+    stalled when the head has waited past the threshold and no merge-group run
+    has started within that same window. This is deliberately a one-sweep
+    alarm: the age window already supplies the anti-flap observation period.
     """
-    return []  # intentionally inert until the merge queue is enabled
+    queue = snapshot.get("merge_queue") or {}
+    if int(queue.get("depth") or 0) <= 0:
+        return []
+    head = queue.get("head") or {}
+    enqueued_at = head.get("enqueued_at")
+    if not enqueued_at:
+        return []
+    age = _minutes_between(now, parse_ts(enqueued_at))
+    if age < threshold_minutes:
+        return []
+
+    last_started_text = queue.get("last_merge_group_started_at")
+    minutes_since_batch: float | None = None
+    if last_started_text:
+        minutes_since_batch = _minutes_between(now, parse_ts(last_started_text))
+        if minutes_since_batch < threshold_minutes:
+            return []
+
+    return [
+        {
+            "level": "queue_alarm",
+            "number": head.get("number"),
+            "title": head.get("title", ""),
+            "url": head.get("url", ""),
+            "queue_state": head.get("state", "UNKNOWN"),
+            "queue_depth": int(queue.get("depth") or 0),
+            "queue_minutes": round(age, 1),
+            "last_merge_group_started_at": last_started_text,
+            "minutes_since_batch": (
+                round(minutes_since_batch, 1)
+                if minutes_since_batch is not None
+                else None
+            ),
+            "blocking_checks": head.get("blocking_checks") or [],
+        }
+    ]
 
 
 # --------------------------------------------------------------------------
@@ -267,6 +297,80 @@ query($owner:String!, $name:String!, $cursor:String) {
                     }
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_MERGE_QUEUE_QUERY = """
+query($owner:String!, $name:String!, $branch:String!) {
+  repository(owner:$owner, name:$name) {
+    mergeQueue(branch:$branch) {
+      configuration { maximumEntriesToBuild }
+      entries(first:20) {
+        totalCount
+        nodes {
+          position
+          enqueuedAt
+          state
+          pullRequest { number title url }
+          headCommit {
+            oid
+            statusCheckRollup {
+              contexts(first:100) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                    completedAt
+                    detailsUrl
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    createdAt
+                    targetUrl
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_COMMIT_ROLLUP_QUERY = """
+query($owner:String!, $name:String!, $oid:GitObjectID!) {
+  repository(owner:$owner, name:$name) {
+    object(oid:$oid) {
+      ... on Commit {
+        oid
+        statusCheckRollup {
+          contexts(first:100) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                name
+                status
+                conclusion
+                completedAt
+                detailsUrl
+              }
+              ... on StatusContext {
+                context
+                state
+                createdAt
+                targetUrl
               }
             }
           }
@@ -343,6 +447,173 @@ def resolve_required_checks(repo: str, base: str) -> tuple[list[str], str]:
     return list(DEFAULT_REQUIRED_CHECKS), "default"
 
 
+def _blocking_contexts(commit: dict[str, Any], required: set[str]) -> list[dict[str, Any]]:
+    """Return non-green required contexts from a merge-group head commit."""
+    rollup = (commit or {}).get("statusCheckRollup") or {}
+    contexts = (rollup.get("contexts") or {}).get("nodes", []) or []
+    by_name: dict[str, dict[str, Any]] = {}
+    for context in contexts:
+        if context.get("__typename") == "CheckRun":
+            name = context.get("name")
+            green = (
+                context.get("status") == "COMPLETED"
+                and context.get("conclusion") in GREEN_CONCLUSIONS
+            )
+            state = (
+                context.get("conclusion")
+                if context.get("status") == "COMPLETED"
+                else context.get("status")
+            ) or "UNKNOWN"
+            url = context.get("detailsUrl") or ""
+        elif context.get("__typename") == "StatusContext":
+            name = context.get("context")
+            green = context.get("state") == "SUCCESS"
+            state = context.get("state") or "UNKNOWN"
+            url = context.get("targetUrl") or ""
+        else:
+            continue
+        if name in required and not green:
+            by_name[name] = {"name": name, "state": state, "url": url}
+        elif name in required and green:
+            by_name.pop(name, None)
+    for name in required:
+        if name not in by_name and not any(
+            (c.get("name") == name or c.get("context") == name)
+            for c in contexts
+        ):
+            by_name[name] = {"name": name, "state": "MISSING", "url": ""}
+    return [by_name[name] for name in sorted(by_name)]
+
+
+def _commit_rollup(repo: str, sha: str) -> dict[str, Any]:
+    """Read checks from the synthetic merge-group commit identified by a run."""
+    owner, _, name = repo.partition("/")
+    raw = _gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={_COMMIT_ROLLUP_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-f",
+            f"oid={sha}",
+        ]
+    )
+    payload = json.loads(raw)
+    if payload.get("errors"):
+        raise KeyError(f"GraphQL commit rollup failed: {payload['errors']!r}")
+    return (
+        payload
+        .get("data", {})
+        .get("repository", {})
+        .get("object", {})
+        or {}
+    )
+
+
+def collect_merge_queue(repo: str, base: str, required: list[str]) -> dict[str, Any]:
+    """Collect queue depth/head plus the last merge-group run start time."""
+    owner, _, name = repo.partition("/")
+    result: dict[str, Any] = {"depth": 0, "head": None}
+    raw = _gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={_MERGE_QUEUE_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-f",
+            f"branch={base}",
+        ]
+    )
+    payload = json.loads(raw)
+    if payload.get("errors"):
+        raise KeyError(f"GraphQL merge queue query failed: {payload['errors']!r}")
+    queue = payload.get("data", {}).get("repository", {}).get("mergeQueue")
+    if not queue:
+        return result
+    entries = queue.get("entries") or {}
+    result["depth"] = int(entries.get("totalCount") or 0)
+    nodes = entries.get("nodes") or []
+    maximum_entries_to_build = max(
+        1,
+        int((queue.get("configuration") or {}).get("maximumEntriesToBuild") or 1),
+    )
+    result["maximum_entries_to_build"] = maximum_entries_to_build
+    if nodes:
+        node = nodes[0]
+        pull = node.get("pullRequest") or {}
+        result["head"] = {
+            "number": pull.get("number"),
+            "title": pull.get("title", ""),
+            "url": pull.get("url", ""),
+            "position": node.get("position"),
+            "state": node.get("state"),
+            "enqueued_at": node.get("enqueuedAt"),
+            "queue_head_sha": (node.get("headCommit") or {}).get("oid"),
+            "merge_group_sha": None,
+            "blocking_checks": [],
+        }
+
+    runs = json.loads(
+        _gh(
+            [
+                "api",
+                f"/repos/{repo}/actions/runs?event=merge_group&per_page=100",
+            ]
+        )
+    ).get("workflow_runs", [])
+    queue_ref_prefix = f"gh-readonly-queue/{base}/"
+    if result.get("head"):
+        number = result["head"].get("number")
+        build_window_numbers = {
+            (node.get("pullRequest") or {}).get("number")
+            for node in nodes[:maximum_entries_to_build]
+        }
+        build_window_runs = [
+            run
+            for run in runs
+            if any(
+                str(run.get("head_branch") or "").startswith(
+                    f"{queue_ref_prefix}pr-{candidate}-"
+                )
+                for candidate in build_window_numbers
+                if candidate is not None
+            )
+            and run.get("created_at")
+        ]
+        if build_window_runs:
+            result["last_merge_group_started_at"] = max(
+                run["created_at"] for run in build_window_runs
+            )
+        head_runs = [
+            run
+            for run in runs
+            if str(run.get("head_branch") or "").startswith(
+                f"{queue_ref_prefix}pr-{number}-"
+            )
+            and run.get("head_sha")
+        ]
+        if head_runs:
+            latest = max(
+                head_runs,
+                key=lambda run: run.get("created_at") or "",
+            )
+            merge_group_sha = latest["head_sha"]
+            commit = _commit_rollup(repo, merge_group_sha)
+            result["head"]["merge_group_sha"] = merge_group_sha
+            result["head"]["blocking_checks"] = _blocking_contexts(
+                commit, set(required)
+            )
+    return result
+
+
 def collect_snapshot(repo: str, base: str, now: dt.datetime) -> dict[str, Any]:
     """Collect all open PRs' merge state via one paginated GraphQL query.
 
@@ -362,6 +633,13 @@ def collect_snapshot(repo: str, base: str, now: dt.datetime) -> dict[str, Any]:
         "open_prs": [],
         "errors": [],
     }
+
+    try:
+        snapshot["merge_queue"] = collect_merge_queue(repo, base, required)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as exc:
+        snapshot["errors"].append(
+            {"stage": "merge-queue", "error": str(exc)[:200]}
+        )
 
     cursor: str | None = None
     for _ in range(50):  # hard page cap; 50 * 50 = 2500 open PRs
@@ -383,6 +661,14 @@ def collect_snapshot(repo: str, base: str, now: dt.datetime) -> dict[str, Any]:
             data = json.loads(_gh(args))
         except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
             snapshot["errors"].append({"stage": "graphql", "error": str(exc)[:200]})
+            break
+        if data.get("errors"):
+            snapshot["errors"].append(
+                {
+                    "stage": "graphql",
+                    "error": f"GraphQL PR query failed: {data['errors']!r}"[:200],
+                }
+            )
             break
 
         prs = (
@@ -425,39 +711,61 @@ def render_body(
     now: dt.datetime,
 ) -> str:
     alarms = [f for f in findings if f["level"] == "alarm"]
+    queue_alarms = [f for f in findings if f["level"] == "queue_alarm"]
     lines: list[str] = []
     lines.append(
         "_Auto-generated by `.github/workflows/merge-stall-check.yml` on "
         f"{now.strftime('%Y-%m-%d %H:%M UTC')}._"
     )
     lines.append("")
-    lines.append(
-        f"**{len(alarms)} PR(s) have been merge-ready for more than "
-        f"{threshold_minutes:g} minutes across two consecutive sweeps, and are "
-        "still unmerged.** Every required check is green, GitHub's merge verdict "
-        "is CLEAN or BEHIND, and auto-merge is enabled — the only thing left to "
-        "act is whatever presses the merge button. Nothing is queued waiting on a "
-        "runner (that is a different watchdog). This is the signature of a wedged "
-        "auto-merger: green in, nothing out."
-    )
-    lines.append("")
-    lines.append("### Merge-ready but not merging")
-    lines.append("")
-    for f in alarms:
+    if queue_alarms:
+        lines.append("**The GitHub merge queue is not advancing.**")
+        lines.append("")
+        for f in queue_alarms:
+            lines.append(
+                f"- **[#{f['number']}]({f['url']})** is queue head in "
+                f"`{f['queue_state']}` for {f['queue_minutes']:g} min; "
+                f"queue depth is **{f['queue_depth']}**."
+            )
+            if f.get("last_merge_group_started_at"):
+                lines.append(
+                    "  - Last merge-group batch started "
+                    f"{f['minutes_since_batch']:g} min ago "
+                    f"({f['last_merge_group_started_at']})."
+                )
+            else:
+                lines.append("  - No merge-group run was found.")
+            blockers = f.get("blocking_checks") or []
+            if blockers:
+                rendered = ", ".join(
+                    f"[{b['name']}]({b['url']}) `{b['state']}`"
+                    if b.get("url")
+                    else f"{b['name']} `{b['state']}`"
+                    for b in blockers
+                )
+                lines.append(f"  - Required blockers: {rendered}")
+        lines.append("")
+    if alarms:
         lines.append(
-            f"- **[#{f['number']}]({f['url']})** — {f['merge_state_status']}, "
-            f"merge-ready {f['ready_minutes']:g} min (green since {f['green_since']})"
+            f"**{len(alarms)} PR(s) have been merge-ready for more than "
+            f"{threshold_minutes:g} minutes across two consecutive sweeps, and "
+            "are still unmerged.**"
         )
-        title = f.get("title")
-        if title:
-            lines.append(f"  - {title}")
+        lines.append("")
+        lines.append("### Merge-ready but not merging")
+        lines.append("")
+        for f in alarms:
+            lines.append(
+                f"- **[#{f['number']}]({f['url']})** — {f['merge_state_status']}, "
+                f"merge-ready {f['ready_minutes']:g} min (green since {f['green_since']})"
+            )
+            title = f.get("title")
+            if title:
+                lines.append(f"  - {title}")
     lines.append("")
     lines.append("### Where to look")
     lines.append("")
-    lines.append(
-        "Required checks green + nothing queued + nothing merging points at the "
-        "MERGER, not the runners. Cheapest first:"
-    )
+    lines.append("Start with the queue head's required blockers, then runner routing and capacity.")
     lines.append("")
     lines.append(
         "- Shipyard's per-host queue-tick stuck in reap-only mode "
@@ -486,6 +794,7 @@ def render_summary(
 ) -> str:
     alarms = [f for f in findings if f["level"] == "alarm"]
     pendings = [f for f in findings if f["level"] == "pending"]
+    queue_alarms = [f for f in findings if f["level"] == "queue_alarm"]
     lines = ["## Merge-stall watchdog", ""]
     if errors:
         lines.append(
@@ -506,14 +815,21 @@ def render_summary(
         f"- **{len(pendings)}** pending (qualified this sweep only — promoted next "
         "sweep if it persists)"
     )
+    lines.append(f"- **{len(queue_alarms)}** stalled merge queue")
     lines.append("")
     lines.append("| level | PR | merge state | ready (min) |")
     lines.append("| --- | --- | --- | --- |")
     for f in findings:
-        lines.append(
-            f"| {f['level']} | #{f['number']} | {f['merge_state_status']} | "
-            f"{f['ready_minutes']:g} |"
-        )
+        if f["level"] == "queue_alarm":
+            lines.append(
+                f"| queue alarm | #{f['number']} | {f['queue_state']} | "
+                f"{f['queue_minutes']:g} |"
+            )
+        else:
+            lines.append(
+                f"| {f['level']} | #{f['number']} | {f['merge_state_status']} | "
+                f"{f['ready_minutes']:g} |"
+            )
     return "\n".join(lines)
 
 
@@ -524,6 +840,11 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--snapshot", default="", help="read a recorded snapshot instead of the API")
     ap.add_argument("--prev-state", default="", help="previous-tick stuck-PR state file")
     ap.add_argument("--threshold-minutes", type=float, default=THRESHOLD_MINUTES)
+    ap.add_argument(
+        "--queue-threshold-minutes",
+        type=float,
+        default=MERGE_QUEUE_THRESHOLD_MINUTES,
+    )
     ap.add_argument("--findings-out", default="findings.json")
     ap.add_argument("--snapshot-out", default="")
     ap.add_argument("--state-out", default="state.json")
@@ -552,18 +873,32 @@ def main(argv: list[str] | None = None) -> int:
             prev_stuck = []
 
     findings, stuck_now = analyze(snapshot, prev_stuck, now, args.threshold_minutes)
+    findings.extend(
+        analyze_merge_queue(snapshot, now, args.queue_threshold_minutes)
+    )
     alarms = [f for f in findings if f["level"] == "alarm"]
+    queue_alarms = [f for f in findings if f["level"] == "queue_alarm"]
+    # An incomplete observation must never erase the prior sweep's memory.
+    # Keep any newly observed stuck PRs too, but only a complete sweep may
+    # remove a PR from the persisted two-sweep set.
+    persisted_stuck = (
+        sorted(set(prev_stuck) | set(stuck_now))
+        if snapshot.get("errors")
+        else stuck_now
+    )
 
     with open(args.findings_out, "w", encoding="utf-8") as fh:
         json.dump(findings, fh, indent=2)
     with open(args.state_out, "w", encoding="utf-8") as fh:
         json.dump(
-            {"generated_at": now.isoformat(), "stuck_prs": stuck_now}, fh, indent=2
+            {"generated_at": now.isoformat(), "stuck_prs": persisted_stuck},
+            fh,
+            indent=2,
         )
     if args.snapshot_out:
         with open(args.snapshot_out, "w", encoding="utf-8") as fh:
             json.dump(snapshot, fh, indent=2)
-    if alarms:
+    if alarms or queue_alarms:
         with open(args.body_out, "w", encoding="utf-8") as fh:
             fh.write(render_body(findings, args.threshold_minutes, now))
 
@@ -581,7 +916,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Exit 0 regardless of findings: the workflow decides what to do with them.
     # A watchdog that reddens its own run gets ignored.
-    print(f"alarm_count={len(alarms)}")
+    print(f"alarm_count={len(alarms) + len(queue_alarms)}")
     return 0
 
 

--- a/tools/scripts/test_merge_stall_watchdog.py
+++ b/tools/scripts/test_merge_stall_watchdog.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -209,7 +210,15 @@ class TestRequiredCheckResolution(unittest.TestCase):
         self.assertEqual(f2, [])  # "linux" is required but not present/green
 
     def test_default_required_set_used_when_snapshot_omits_it(self):
-        s = {"open_prs": [pr(402, merge_state="CLEAN", green_age_min=90)]}
+        s = {
+            "open_prs": [
+                pr(
+                    402,
+                    merge_state="CLEAN",
+                    checks=green_checks(90, msw.DEFAULT_REQUIRED_CHECKS),
+                )
+            ]
+        }
         _, stuck1 = msw.analyze(s, prev_stuck=[], now=NOW)
         f2, _ = msw.analyze(s, prev_stuck=stuck1, now=NOW)
         self.assertEqual(levels(f2), ["alarm"])
@@ -231,9 +240,213 @@ class TestMultiPrPopulation(unittest.TestCase):
         self.assertEqual(stuck_now, [501, 502])
 
 
-class TestFutureStub(unittest.TestCase):
-    def test_merge_queue_stub_is_inert(self):
-        self.assertEqual(msw.merge_queue_stall_todo({}, NOW), [])
+class TestMergeQueueStall(unittest.TestCase):
+    def queue_snapshot(self, *, age=60, depth=16, last_batch_age=60):
+        return {
+            "merge_queue": {
+                "depth": depth,
+                "last_merge_group_started_at": ago(last_batch_age),
+                "head": {
+                    "number": 6997,
+                    "title": "queue head",
+                    "url": "https://example.invalid/pr/6997",
+                    "state": "AWAITING_CHECKS",
+                    "enqueued_at": ago(age),
+                    "blocking_checks": [
+                        {"name": "macos", "state": "QUEUED", "url": ""}
+                    ],
+                },
+            }
+        }
+
+    def test_old_queue_and_old_batch_alarm_in_one_sweep(self):
+        findings = msw.analyze_merge_queue(self.queue_snapshot(), NOW)
+        self.assertEqual([f["level"] for f in findings], ["queue_alarm"])
+        self.assertEqual(findings[0]["queue_depth"], 16)
+        self.assertEqual(findings[0]["blocking_checks"][0]["name"], "macos")
+
+    def test_recent_batch_keeps_old_queue_quiet(self):
+        findings = msw.analyze_merge_queue(
+            self.queue_snapshot(age=120, last_batch_age=10), NOW
+        )
+        self.assertEqual(findings, [])
+
+    def test_young_head_is_not_stalled(self):
+        self.assertEqual(
+            msw.analyze_merge_queue(self.queue_snapshot(age=10), NOW), []
+        )
+
+    def test_empty_or_unavailable_queue_is_quiet(self):
+        self.assertEqual(msw.analyze_merge_queue({}, NOW), [])
+        self.assertEqual(
+            msw.analyze_merge_queue(self.queue_snapshot(depth=0), NOW), []
+        )
+
+
+class TestMergeQueueCollection(unittest.TestCase):
+    def test_collection_rejects_graphql_errors_in_http_200_response(self):
+        payload = {
+            "data": {"repository": {"mergeQueue": None}},
+            "errors": [{"message": "temporary schema failure"}],
+        }
+        with mock.patch.object(msw, "_gh", return_value=json.dumps(payload)):
+            with self.assertRaisesRegex(KeyError, "merge queue query failed"):
+                msw.collect_merge_queue("Generous-Corp/pulp", "main", REQUIRED)
+
+    def test_collection_scopes_queue_and_runs_to_requested_base(self):
+        queue_payload = {
+            "data": {
+                "repository": {
+                    "mergeQueue": {
+                        "entries": {"totalCount": 0, "nodes": []}
+                    }
+                }
+            }
+        }
+        runs_payload = {
+            "workflow_runs": [
+                {
+                    "head_branch": "gh-readonly-queue/release/pr-9-old",
+                    "run_started_at": "2026-07-16T11:59:00Z",
+                },
+                {
+                    "head_branch": "gh-readonly-queue/main/pr-8-base",
+                    "run_started_at": "2026-07-16T11:30:00Z",
+                },
+            ]
+        }
+        calls: list[list[str]] = []
+
+        def fake_gh(args):
+            calls.append(args)
+            return json.dumps(queue_payload if "graphql" in args else runs_payload)
+
+        with mock.patch.object(msw, "_gh", side_effect=fake_gh):
+            result = msw.collect_merge_queue("Generous-Corp/pulp", "main", REQUIRED)
+
+        self.assertNotIn("last_merge_group_started_at", result)
+        self.assertIn("branch=main", calls[0])
+        self.assertIn("mergeQueue(branch:$branch)", msw._MERGE_QUEUE_QUERY)
+
+    def test_collection_reads_blockers_from_current_merge_group_sha(self):
+        queue_payload = {
+            "data": {
+                "repository": {
+                    "mergeQueue": {
+                        "configuration": {"maximumEntriesToBuild": 2},
+                        "entries": {
+                            "totalCount": 2,
+                            "nodes": [
+                                {
+                                    "position": 1,
+                                    "enqueuedAt": "2026-07-16T11:00:00Z",
+                                    "state": "AWAITING_CHECKS",
+                                    "pullRequest": {
+                                        "number": 42,
+                                        "title": "queued",
+                                        "url": "https://example.invalid/pr/42",
+                                    },
+                                    "headCommit": {"oid": "queue-head-red"},
+                                },
+                                {
+                                    "position": 2,
+                                    "enqueuedAt": "2026-07-16T11:05:00Z",
+                                    "state": "QUEUED",
+                                    "pullRequest": {
+                                        "number": 99,
+                                        "title": "cumulative follower",
+                                        "url": "https://example.invalid/pr/99",
+                                    },
+                                    "headCommit": {"oid": "unrelated-newer"},
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+        runs_payload = {
+            "workflow_runs": [
+                {
+                    "head_branch": "gh-readonly-queue/main/pr-99-unrelated",
+                    "head_sha": "unrelated-newer",
+                    "created_at": "2026-07-16T11:55:00Z",
+                    "run_started_at": "2026-07-16T11:56:00Z",
+                },
+                {
+                    "head_branch": "gh-readonly-queue/main/pr-42-current",
+                    "head_sha": "merge-group-red",
+                    "created_at": "2026-07-16T11:30:00Z",
+                    # A rerun/start delay must not refresh batch formation.
+                    "run_started_at": "2026-07-16T11:59:00Z",
+                }
+            ]
+        }
+        rollup_payload = {
+            "data": {
+                "repository": {
+                    "object": {
+                        "oid": "merge-group-red",
+                        "statusCheckRollup": {
+                            "contexts": {
+                                "nodes": [
+                                    {
+                                        "__typename": "CheckRun",
+                                        "name": "macos",
+                                        "status": "QUEUED",
+                                        "conclusion": None,
+                                        "detailsUrl": "https://example.invalid/check",
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        def fake_gh(args):
+            if "graphql" not in args:
+                return json.dumps(runs_payload)
+            query = next(arg for arg in args if arg.startswith("query="))
+            return json.dumps(
+                rollup_payload if "object(oid:$oid)" in query else queue_payload
+            )
+
+        with mock.patch.object(msw, "_gh", side_effect=fake_gh):
+            result = msw.collect_merge_queue(
+                "Generous-Corp/pulp", "main", REQUIRED
+            )
+
+        self.assertEqual(result["head"]["queue_head_sha"], "queue-head-red")
+        self.assertEqual(result["head"]["merge_group_sha"], "merge-group-red")
+        self.assertEqual(
+            result["last_merge_group_started_at"], "2026-07-16T11:55:00Z"
+        )
+        self.assertEqual(result["maximum_entries_to_build"], 2)
+        blockers = {
+            check["name"]: check for check in result["head"]["blocking_checks"]
+        }
+        self.assertEqual(blockers["macos"]["state"], "QUEUED")
+
+    def test_completed_failure_reports_its_conclusion(self):
+        commit = {
+            "statusCheckRollup": {
+                "contexts": {
+                    "nodes": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "macos",
+                            "status": "COMPLETED",
+                            "conclusion": "FAILURE",
+                            "detailsUrl": "https://example.invalid/check",
+                        }
+                    ]
+                }
+            }
+        }
+        blockers = msw._blocking_contexts(commit, {"macos"})
+        self.assertEqual(blockers[0]["state"], "FAILURE")
 
 
 class TestMainCli(unittest.TestCase):
@@ -282,6 +495,91 @@ class TestMainCli(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertFalse((d / "body.md").exists())
             self.assertEqual(json.loads((d / "state.json").read_text())["stuck_prs"], [])
+
+    def test_degraded_snapshot_preserves_previous_two_sweep_state(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            degraded = snap()
+            degraded["errors"] = [{"stage": "graphql", "error": "timeout"}]
+            (d / "snap.json").write_text(json.dumps(degraded))
+            (d / "prev.json").write_text(json.dumps({"stuck_prs": [601]}))
+
+            rc = msw.main(
+                [
+                    "--snapshot", str(d / "snap.json"),
+                    "--prev-state", str(d / "prev.json"),
+                    "--findings-out", str(d / "findings.json"),
+                    "--state-out", str(d / "state.json"),
+                    "--body-out", str(d / "body.md"),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            state = json.loads((d / "state.json").read_text())
+            self.assertEqual(state["stuck_prs"], [601])
+
+    def test_open_pr_graphql_errors_mark_live_snapshot_degraded(self):
+        queue_payload = {
+            "data": {
+                "repository": {
+                    "mergeQueue": {
+                        "entries": {"totalCount": 0, "nodes": []}
+                    }
+                }
+            }
+        }
+        runs_payload = {"workflow_runs": []}
+        pr_error_payload = {
+            "data": {"repository": None},
+            "errors": [{"message": "temporary authorization failure"}],
+        }
+
+        def fake_gh(args):
+            if "graphql" not in args:
+                return json.dumps(runs_payload)
+            query = next(arg for arg in args if arg.startswith("query="))
+            if "mergeQueue(branch:$branch)" in query:
+                return json.dumps(queue_payload)
+            return json.dumps(pr_error_payload)
+
+        with (
+            mock.patch.object(msw, "_gh", side_effect=fake_gh),
+            mock.patch.object(
+                msw,
+                "resolve_required_checks",
+                return_value=(REQUIRED, "branch-protection"),
+            ),
+        ):
+            snapshot = msw.collect_snapshot(
+                "Generous-Corp/pulp", "main", NOW
+            )
+
+        self.assertEqual(snapshot["open_prs"], [])
+        self.assertEqual(snapshot["errors"][0]["stage"], "graphql")
+        self.assertIn("authorization failure", snapshot["errors"][0]["error"])
+
+    def test_workflow_counts_queue_alarms_for_issue_maintenance(self):
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "merge-stall-check.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("f['level'] in ('alarm', 'queue_alarm')", workflow)
+        self.assertIn('degraded=${degraded}', workflow)
+        self.assertIn('if [ "$DEGRADED" = "true" ]', workflow)
+
+    def test_documented_fallback_contains_every_main_required_context(self):
+        self.assertEqual(
+            set(msw.DEFAULT_REQUIRED_CHECKS),
+            {
+                "macos",
+                "Enforce version & skill sync",
+                "Build + prove + (owner-gated) deploy",
+                "Vellum trusted freeze",
+                "Vellum freeze",
+            },
+        )
 
 
 class TestChecksFromRollup(unittest.TestCase):


### PR DESCRIPTION
Detect the queue-specific failure mode where PRs look healthy but the active merge window stops making progress.

The watchdog now:
- reads the live maximumEntriesToBuild configuration
- scopes progress to the active build window
- records the synthetic merge-group SHA and exact required blockers for the head
- preserves prior incident state when collection is degraded
- fails closed on GraphQL errors and incomplete required-context reads

Validation:
- 33 focused watchdog tests pass
- live proof against the current 20-entry queue identified the exact head and required WebCLAP blocker
- decisions contract validation passes
- pre-push static gates pass

This workflow observes and opens/updates incidents only; it never merges, rebases, adopts a head, or cancels work.

<!-- whence {"labels": ["1·codex", "2·m1", "4·pickup work on mini…"], "prov": {"agent": "codex", "tab": "pickup work on mini and pro"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m1` |
| **Tab** | pickup work on mini and pro |
| **Directory** | `~/Code/pulp-merge-queue-stall` |
| **Session** | `019fbb5b-28c7-71f1-88e5-d4dd9aaecf72` |

**Resume**
```
codex resume 019fbb5b-28c7-71f1-88e5-d4dd9aaecf72
```
**Jump to this tab**
```
cmux surface focus A2644125-8348-45F6-AC9E-358628190431
```
**Relaunch (any agent)**
```
cmux surface resume get --surface A2644125-8348-45F6-AC9E-358628190431
```

<sub>stamped 2026-08-02 00:24 UTC</sub>
<!-- /whence -->