### PR TITLE
fix(ci): skip irrelevant WebCLAP proof work

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -866,6 +866,13 @@ uses, or the golden warms a cache the real jobs never touch.
   `_ext/` and pass `-DPULP_EXAMPLE_PLUGINS_DIR` / `-DPULP_CLASSIC_EFFECTS_DIR`.
   The lane now asserts a couple of gallery wasms exist right after the build, so
   the cause is reported where it happens rather than downstream.
+  Because this is a required context, the workflow still starts on every PR;
+  `webclap_relevance.py` only skips the expensive setup/build/proof steps for an
+  unrelated diff. Relevance is evaluated with the classifier fetched from the
+  PR's base SHA, includes both names of renamed files, and fails closed at the
+  GitHub API's 3,000-file cap. Keep the workflow and classifier self-changes on
+  the unconditional full-proof path, and never expose `GH_TOKEN` to the
+  PR-controlled checkout while resolving relevance.
 - **`screenshot-sync` is a three-layer gate that mirrors skill-sync.** A repo opts
   in by committing a `.pulp/screenshots.toml` manifest (presence == opt-in);
   `tools/scripts/screenshot_sync_check.py` then diffs the manifest's `[trigger].paths`

--- a/.github/workflows/wclap-cloudflare.yml
+++ b/.github/workflows/wclap-cloudflare.yml
@@ -22,10 +22,11 @@ on:
       - "tools/cmake/PulpWclap.cmake"
       - "tools/cmake/wasi-toolchain.cmake"
       - ".github/workflows/wclap-cloudflare.yml"
-  # No paths filter on pull_request ON PURPOSE: this lane is a REQUIRED status check
-  # (branch protection), and a required check that is path-filtered leaves any PR that
-  # does not touch those paths stuck forever on "Expected — Waiting for status". It must
-  # run on EVERY PR. It ALSO catches the real silent-breakage risk this lane exists for:
+  # No event-level paths filter on pull_request: this lane is a REQUIRED status check,
+  # and a required check that is path-filtered leaves unrelated PRs stuck forever on
+  # "Expected — Waiting for status". The job therefore always reports, but its first
+  # step classifies the PR diff and skips the expensive proof for unrelated changes.
+  # Relevant core/web changes still catch the real silent-breakage risk this lane exists for:
   # the wasm UI build hand-lists its sources (PulpWebUi.cmake), so a CORE refactor
   # (core/view/**, core/canvas/**) that splits a TU breaks the link with nothing under
   # examples/web-demos/** touched — invisible to a path-filtered lane. Deploy stays
@@ -58,6 +59,65 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve WebCLAP relevance
+        id: relevance
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CHANGED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # GitHub caps the pull files API at 3,000 entries. At the boundary
+          # the response may be truncated, so fail closed and run the proof.
+          if [ "${CHANGED_FILE_COUNT:-0}" -ge 3000 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(mktemp)"
+          trusted_classifier="$(mktemp)"
+          trap 'rm -f "$changed_files" "$trusted_classifier"' EXIT
+          GH_TOKEN="${{ github.token }}" gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | .filename, (.previous_filename // empty)' > "$changed_files"
+
+          # A PR must never use its own classifier to decide whether that
+          # classifier or this workflow receives the full proof. This also
+          # bootstraps the first landing, before the base branch has the script.
+          if grep -Fxq '.github/workflows/wclap-cloudflare.yml' "$changed_files" \
+              || grep -Fxq 'tools/scripts/webclap_relevance.py' "$changed_files"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Execute the classifier from the trusted base SHA, not the PR
+          # checkout. Scope the token to gh only; PR-controlled Python never
+          # inherits a repository credential.
+          GH_TOKEN="${{ github.token }}" gh api \
+            "repos/${{ github.repository }}/contents/tools/scripts/webclap_relevance.py?ref=${BASE_SHA}" \
+            --jq '.content' | base64 --decode > "$trusted_classifier"
+          set +e
+          python3 "$trusted_classifier" < "$changed_files"
+          relevance_status=$?
+          set -e
+          case "$relevance_status" in
+            0) echo "run=true" >> "$GITHUB_OUTPUT" ;;
+            1)
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "WebCLAP proof skipped: the PR does not touch a WebCLAP build surface."
+              ;;
+            *) exit "$relevance_status" ;;
+          esac
+
+      - name: Test WebCLAP relevance policy
+        if: steps.relevance.outputs.run == 'true'
+        run: python3 tools/scripts/test_webclap_relevance.py
+
       # The gallery's 23 plugins do NOT live in pulp — they live in two separate
       # public repos (the examples-out-of-core split), and wclap-build/CMakeLists.txt
       # declares each gallery target ONLY IF its plugin header is present. A job that
@@ -67,19 +127,23 @@ jobs:
       # skip is quiet; the assemble is not. Without these two checkouts this workflow
       # cannot deploy the gallery at all, which is exactly how it broke.
       - uses: actions/checkout@v4
+        if: steps.relevance.outputs.run == 'true'
         with:
           repository: danielraffel/pulp-example-plugins
           path: _ext/pulp-example-plugins
       - uses: actions/checkout@v4
+        if: steps.relevance.outputs.run == 'true'
         with:
           repository: danielraffel/pulp-classic-effects
           path: _ext/pulp-classic-effects
 
       - uses: actions/setup-node@v4
+        if: steps.relevance.outputs.run == 'true'
         with:
           node-version: "22"
 
       - name: Set up wasi-sdk (pinned)
+        if: steps.relevance.outputs.run == 'true'
         run: |
           set -euo pipefail
           ver=25
@@ -90,15 +154,18 @@ jobs:
           echo "WASI_SDK_PREFIX=$HOME/wasi-sdk" >> "$GITHUB_ENV"
 
       - name: Set up Chrome
+        if: steps.relevance.outputs.run == 'true'
         id: chrome
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable
 
       - name: Install playwright-core
+        if: steps.relevance.outputs.run == 'true'
         run: npm install --no-save playwright-core
 
       - name: Build WebCLAP module
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build
         run: |
           set -euo pipefail
@@ -134,11 +201,13 @@ jobs:
       # site, "skipped" means DELETED from the live URL, not "left as it was". That is a
       # far worse failure than the loud one it replaced, so they are built here.
       - name: Set up Emscripten
+        if: steps.relevance.outputs.run == 'true'
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: 6.0.2
 
       - name: Vendor choc for the WAM build
+        if: steps.relevance.outputs.run == 'true'
         run: |
           set -euo pipefail
           git clone --depth 1 --branch pulp-webview-dnd-poc1 \
@@ -146,6 +215,7 @@ jobs:
           echo "PULP_WAM_CHOC_INCLUDE=$HOME/choc-src" >> "$GITHUB_ENV"
 
       - name: Cache the Skia wasm slice
+        if: steps.relevance.outputs.run == 'true'
         id: skia-cache
         uses: actions/cache@v4
         with:
@@ -153,6 +223,7 @@ jobs:
           key: skia-wasm-${{ hashFiles('tools/deps/manifest.json') }}
 
       - name: Build the WAM, Pulp-UI and WebGPU-DSP modules
+        if: steps.relevance.outputs.run == 'true'
         run: |
           set -euo pipefail
 
@@ -199,6 +270,7 @@ jobs:
           fi
 
       - name: Assemble self-contained deploy dir
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build/cloudflare
         run: |
           set -euo pipefail
@@ -238,6 +310,7 @@ jobs:
       # assemble-gallery pass is required — it bakes the og:image/twitter tags in
       # only for pages whose og.png now exists.
       - name: Render OG preview images (per page, from the started plugin)
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build/cloudflare
         run: |
           set -euo pipefail
@@ -256,14 +329,17 @@ jobs:
             $gpu_args
 
       - name: Guard — every demo page has a fresh OG image
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build/cloudflare
         run: node check-og-images.mjs
 
       - name: Prove @danielraffel/web-player adapter unit tests
+        if: steps.relevance.outputs.run == 'true'
         working-directory: packages/pulp-web-player
         run: npm test
 
       - name: "Prove locally (single-plugin: crossOriginIsolated + WebCLAP audio + subresources)"
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build/cloudflare
         env:
           CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
@@ -273,13 +349,14 @@ jobs:
           node validate-deploy.mjs --screenshot /tmp/wclap-cloudflare.png
 
       - name: "Prove locally (shared player: real-time WebCLAP + param + clap.state, same UI as WAM)"
+        if: steps.relevance.outputs.run == 'true'
         working-directory: examples/web-demos/wclap-build/cloudflare
         env:
           CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: node validate-player.mjs --screenshot /tmp/wclap-shared-player.png
 
       - name: Upload proof screenshots
-        if: always()
+        if: always() && steps.relevance.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: wclap-cloudflare-proof
@@ -303,7 +380,7 @@ jobs:
         # invisible because merge-group runs were starving before reaching this
         # step. Naming the events that MAY deploy fails closed when the next
         # trigger is added.
-        if: ${{ contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) && env.HAS_CF_TOKEN == 'true' }}
+        if: ${{ steps.relevance.outputs.run == 'true' && contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) && env.HAS_CF_TOKEN == 'true' }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -328,6 +405,6 @@ jobs:
         # invisible because merge-group runs were starving before reaching this
         # step. Naming the events that MAY deploy fails closed when the next
         # trigger is added.
-        if: ${{ contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) && env.HAS_CF_TOKEN == 'true' }}
+        if: ${{ steps.relevance.outputs.run == 'true' && contains(fromJSON('["push","schedule","workflow_dispatch"]'), github.event_name) && env.HAS_CF_TOKEN == 'true' }}
         working-directory: examples/web-demos/wclap-build/cloudflare
         run: node check-unfurl.mjs --base https://pulp-wclap-demos.pages.dev

--- a/tools/scripts/test_webclap_relevance.py
+++ b/tools/scripts/test_webclap_relevance.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+import webclap_relevance
+
+
+class WebclapRelevanceTests(unittest.TestCase):
+    def test_web_build_surfaces_are_relevant(self) -> None:
+        for path in (
+            "core/view/src/view.cpp",
+            "examples/web-demos/wclap-build/CMakeLists.txt",
+            "examples/pulp-gain/PulpGain.h",
+            "examples/pulp-pluck/PulpPluck.h",
+            "examples/super-convolver/processor.cpp",
+            "packages/pulp-web-player/src/index.ts",
+            "tools/cmake/PulpWclap.cmake",
+            "tools/deps/manifest.json",
+            "tools/scripts/webclap_relevance.py",
+            "tools/scripts/test_webclap_relevance.py",
+            ".github/workflows/wclap-cloudflare.yml",
+            "CMakeLists.txt",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(webclap_relevance.is_relevant(path))
+
+    def test_unrelated_surfaces_take_the_fast_path(self) -> None:
+        for path in (
+            "experimental/pulp-rs/src/fallthrough.rs",
+            "docs/runner-operations.md",
+            "tools/scripts/native-intel-runner.sh",
+            ".github/workflows/build.yml",
+            "README.md",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(webclap_relevance.is_relevant(path))
+
+    def test_expensive_workflow_steps_are_guarded(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "wclap-cloudflare.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("id: relevance", workflow)
+        self.assertIn("pulls/${PR_NUMBER}/files", workflow)
+        self.assertIn(".previous_filename // empty", workflow)
+        self.assertIn("contents/tools/scripts/webclap_relevance.py?ref=${BASE_SHA}", workflow)
+        self.assertIn('CHANGED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}', workflow)
+        self.assertIn('"${CHANGED_FILE_COUNT:-0}" -ge 3000', workflow)
+        self.assertIn("PR-controlled Python never", workflow)
+        self.assertNotIn("          GH_TOKEN: ${{ github.token }}", workflow)
+        self.assertIn('*) exit "$relevance_status"', workflow)
+        self.assertEqual(
+            workflow.count("steps.relevance.outputs.run == 'true'"),
+            21,
+            "every expensive step after relevance classification must be guarded",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/webclap_relevance.py
+++ b/tools/scripts/webclap_relevance.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Return success when a changed path can affect the WebCLAP proof lane."""
+
+from __future__ import annotations
+
+import sys
+
+
+RELEVANT_PREFIXES = (
+    ".github/actions/",
+    "cmake/",
+    "core/",
+    "examples/pulp-gain/",
+    "examples/pulp-pluck/",
+    "examples/super-convolver/",
+    "examples/web-demos/",
+    "external/",
+    "packages/pulp-web-player/",
+    "tools/cmake/",
+    "tools/deps/",
+)
+
+RELEVANT_FILES = {
+    ".github/workflows/wclap-cloudflare.yml",
+    "CMakeLists.txt",
+    "package.json",
+    "package-lock.json",
+    "tools/scripts/webclap_relevance.py",
+    "tools/scripts/test_webclap_relevance.py",
+}
+
+
+def is_relevant(path: str) -> bool:
+    normalized = path.strip()
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized in RELEVANT_FILES or normalized.startswith(RELEVANT_PREFIXES)
+
+
+def main() -> int:
+    return 0 if any(is_relevant(line) for line in sys.stdin) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Keep the required WebCLAP context available to the merge queue without spending a full browser/module build on changes that cannot affect WebCLAP.

A lightweight classifier runs first, then the existing proof/deploy work runs only for relevant paths. Irrelevant merge groups report the same required aggregate context successfully after classification.

Validation:
- focused relevance tests pass
- four prior review rounds were clean
- decisions contract validation passes
- pre-push static gates pass

The owner-gated deploy behavior and relevant-path proof remain unchanged.

<!-- whence {"labels": ["1·codex", "2·m1", "4·pickup work on mini…"], "prov": {"agent": "codex", "tab": "pickup work on mini and pro"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m1` |
| **Tab** | pickup work on mini and pro |
| **Directory** | `~/Code/pulp-webclap-relevance-fast-path` |
| **Session** | `019fbb5b-28c7-71f1-88e5-d4dd9aaecf72` |

**Resume**
```
codex resume 019fbb5b-28c7-71f1-88e5-d4dd9aaecf72
```
**Jump to this tab**
```
cmux surface focus A2644125-8348-45F6-AC9E-358628190431
```
**Relaunch (any agent)**
```
cmux surface resume get --surface A2644125-8348-45F6-AC9E-358628190431
```

<sub>stamped 2026-08-01 21:57 UTC</sub>
<!-- /whence -->