### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.412.2",
+      "version": "0.412.3",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.412.2"
+  "version": "0.412.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.412.2",
+  "version": "0.412.3",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4690,7 +4690,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.412.2",
+        "version": "0.412.3",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4705,13 +4705,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.412.2",
+        "catalog_version": "0.412.3",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.412.2",
+        "version": "0.412.3",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 541ddac442b6..f49d227c992a.
plugin 0.412.2->0.412.3 (patch)

Version-Bump-Applied: f49d227c992ac4d2047dd9fac29097c798da1130
