### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.780.0
+    VERSION 0.781.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on ffad5bf8672a..f5d00c4b9ab1.
sdk 0.780.0->0.781.0 (minor)

Version-Bump-Applied: f5d00c4b9ab1f6a5865e820c0cbdea3353eb6c7d
