### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.417.1",
+      "version": "0.418.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.417.1"
+  "version": "0.418.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.417.1",
+  "version": "0.418.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.781.0
+    VERSION 0.782.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4798,7 +4798,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.417.1",
+        "version": "0.418.0",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4813,13 +4813,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.417.1",
+        "catalog_version": "0.418.0",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.417.1",
+        "version": "0.418.0",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 763443173f08..8d5de8dd4bb6.
sdk 0.781.0->0.782.0 (minor); plugin 0.417.1->0.418.0 (minor)

Version-Bump-Applied: 8d5de8dd4bb60e2ec921b78960dbbeed4af38da9
