### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.786.0
+    VERSION 0.786.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 82825b554227..103994a1c9a1.
sdk 0.786.0->0.786.1 (patch)

Version-Bump-Applied: 103994a1c9a165510329562dbaa50a048421d73d

<!-- whence {"labels": ["1·codex", "2·m3", "3·Tahoe4", "4·pulp queue monitor v3"], "prov": {"agent": "codex", "tab": "pulp queue monitor v3", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `Tahoe4` |
| **Tab** | pulp queue monitor v3 |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019fe7c5-a461-7230-8121-6f5022a35c35` |

**Resume**
```
codex resume 019fe7c5-a461-7230-8121-6f5022a35c35
```
**Jump to this tab**
```
cmux surface focus 9A8E9D92-5632-4995-885C-8005575DE073
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 9A8E9D92-5632-4995-885C-8005575DE073
```

<sub>stamped 2026-08-10 05:10 UTC</sub>
<!-- /whence -->