### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.419.2",
+      "version": "0.420.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.419.2"
+  "version": "0.420.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.419.2",
+  "version": "0.420.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.788.0
+    VERSION 0.789.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4798,7 +4798,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.419.2",
+        "version": "0.420.0",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4813,13 +4813,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.419.2",
+        "catalog_version": "0.420.0",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.419.2",
+        "version": "0.420.0",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 0b43dc9e3162..2c83c9014f12.
sdk 0.788.0->0.789.0 (minor); plugin 0.419.2->0.420.0 (minor)

Version-Bump-Applied: 2c83c9014f12cc8ee6438fb83350c3d1be925a2f

<!-- whence {"labels": ["1·codex", "2·m3", "3·Tahoe4", "4·pulp queue monitor v3"], "prov": {"agent": "codex", "tab": "pulp queue monitor v3", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `Tahoe4` |
| **Tab** | pulp queue monitor v3 |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `019fe7c5-a461-7230-8121-6f5022a35c35` |

**Resume**
```
codex resume 019fe7c5-a461-7230-8121-6f5022a35c35
```
**Jump to this tab**
```
cmux surface focus 9A8E9D92-5632-4995-885C-8005575DE073
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 9A8E9D92-5632-4995-885C-8005575DE073
```

<sub>stamped 2026-08-10 05:10 UTC</sub>
<!-- /whence -->