### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.799.0
+    VERSION 0.799.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on a88c99b9ccb1..cb17258c8d36.
sdk 0.799.0->0.799.1 (patch)

Version-Bump-Applied: cb17258c8d362b4c10d603aef8aa006f502867c0

<!-- whence {"labels": ["1·codex", "2·m3", "3·pre-colo", "4·DSP", "5·unresolved"], "prov": {"agent": "codex", "tab": "DSP", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `pre-colo` |
| **Tab** | DSP |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a01d48-922d-7a92-8e49-40876ef346f6` |

**Resume**
```
codex resume 01a01d48-922d-7a92-8e49-40876ef346f6
```
**Jump to this tab**
```
cmux surface focus 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```

<sub>stamped 2026-08-20 13:18 UTC</sub>
<!-- /whence -->