### PR TITLE
fix(tooling): preserve nested lambda defaults

### DIFF
--- a/tools/dsp_vocabulary.py
+++ b/tools/dsp_vocabulary.py
@@ -359,15 +359,34 @@ def matching_brace(text: str, opening: int) -> int:
 def opens_lambda_body(text: str, opening: int) -> bool:
     """Whether a parameter-list brace starts a lambda rather than an initializer."""
     prefix = text[max(0, opening - 512):opening]
-    return re.search(
-        r"\[[^\[\]]*\]"
+    suffix = re.compile(
         r"(?:\s*<[^{};]*>)?"
         r"\s*(?:\([^{};]*\))?"
         r"\s*(?:(?:mutable|constexpr|consteval)\s+)*"
         r"(?:noexcept(?:\s*\([^{};]*\))?\s*)?"
-        r"(?:->\s*[^{};]+)?\s*$",
-        prefix,
-    ) is not None
+        r"(?:\s*\[\[[^{};]*\]\])*"
+        r"(?:\s*->\s*[^{};]+?)?"
+        r"(?:\s*requires\b[\s\S]+)?"
+        r"(?:\s*\[\[[^{};]*\]\])*\s*$",
+    )
+    for closing in range(len(prefix) - 1, -1, -1):
+        if prefix[closing] != "]" or suffix.fullmatch(prefix[closing + 1:]) is None:
+            continue
+        depth = 0
+        for pos in range(closing, -1, -1):
+            if prefix[pos] == "]":
+                depth += 1
+            elif prefix[pos] == "[":
+                depth -= 1
+                if depth == 0:
+                    return True
+    return False
+
+
+def opens_requires_expression_body(text: str, opening: int) -> bool:
+    """Whether a parameter-list brace starts a requires-expression body."""
+    prefix = text[max(0, opening - 512):opening]
+    return re.search(r"\brequires\s*(?:\([^{};]*\))?\s*$", prefix) is not None
 
 
 def public_declarations(text: str, cls: str, *, source_is_code: bool = False) -> str:
@@ -409,7 +428,7 @@ def public_declarations(text: str, cls: str, *, source_is_code: bool = False) ->
         elif depth == 0 and char == ")":
             parameter_depth = max(0, parameter_depth - 1)
         elif depth == 0 and char == "{" and parameter_depth > 0:
-            if opens_lambda_body(body, i):
+            if opens_requires_expression_body(body, i) or opens_lambda_body(body, i):
                 parameter_lambda_depth = 1
             else:
                 parameter_brace_depth += 1

--- a/tools/test_dsp_vocabulary.py
+++ b/tools/test_dsp_vocabulary.py
@@ -116,8 +116,9 @@ class Probe {
   public:
     void prepare() { helper(private_state_); }
     void configure(const Params& params = {}) { helper(params.value); }
+    void configure_if(bool valid = requires(T value) { value.configure(); });
     void note_on(float velocity = float{1}) { helper(static_cast<int>(velocity)); }
-    void set_callback(Callback cb = [](int x) { return helper(x); });
+    void set_callback(Callback cb = [value = values[0]]<typename T>(T x)requires requires(T y) { y.foo(); } { return helper(value + x); });
     void reset() noexcept { private_state_ = 0; }
     int retained_bytes() const noexcept { return private_state_; }
   private:
@@ -130,8 +131,9 @@ class Probe {
         "prepare()",
         "reset()",
         "configure(const Params& params = {})",
+        "configure_if(bool valid = requires(T value) { })",
         "note_on(float velocity = float{1})",
-        "set_callback(Callback cb = [](int x) { })",
+        "set_callback(Callback cb = [value = values[0]]<typename T>(T x)requires requires(T y) { } { })",
         "retained_bytes()",
     ]
     if methods != expected:


### PR DESCRIPTION
## Summary

- parse defaults containing nested lambda init-captures without truncating public signatures
- handle constrained generic lambdas and requires-expressions, including no-whitespace )requires tokenization
- add focused regressions while keeping the generated capability manifest byte-stable

## Validation

- DSP vocabulary: 336 classes across 217 headers, zero problems
- capability generator fresh: 72 keys / 423 headers
- 86 capability evolution, surface, and compatibility checks
- full Python 3.12 + PyYAML gates
- GPT-5.6-Sol medium review clean after one accepted tokenization fix

Shipyard completed skill/version validation and pushed exact head c66b63586f67d12802e2609a165c136c9f03672a; its PR-create handoff alone failed on local x509 trust after the host OS update, so this PR was created with the authenticated gh client from that exact pushed head.

Skill-Update: skip skill=agent-capabilities reason="parser correctness fix does not change capability authoring workflow"

<!-- whence {"labels": ["1·codex", "2·m1"], "prov": {"agent": "codex", "tab": "", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m1` |
| **Directory** | `~/Code/pulp-parser-nested-lambda-followup-20260810` |
| **Session** | `019fe803-c55c-7201-ae51-2d0779b123e7` |

**Resume**
```
codex resume 019fe803-c55c-7201-ae51-2d0779b123e7
```
**Jump to this tab**
```
cmux surface focus F1D355D8-C055-446F-A6DC-6B3E9E9D8FFC
```
**Relaunch (any agent)**
```
cmux surface resume get --surface F1D355D8-C055-446F-A6DC-6B3E9E9D8FFC
```

<sub>stamped 2026-08-10 16:05 UTC</sub>
<!-- /whence -->