### PR TITLE
ci: route trusted Linux checks through Mac Pro pool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,11 @@ jobs:
           # Mac Pro Proxmox pool:
           #      ["self-hosted","Linux","X64","pulp-build-linux-x64",
           #       "pulp-host-macpro"].
-          # A workflow_dispatch input overrides it. Other events deliberately
-          # authorize neither selector and fall through to GitHub-hosted Linux.
+          # A workflow_dispatch input overrides it. Same-repository pull_request
+          # and protected merge_group events may use it after the trusted
+          # workflow-ref boundary is applied below; fork pull requests remain
+          # hosted. If no local selector is configured, the resolver falls back
+          # to GitHub-hosted Linux.
           # Windows is deliberately different: the required PR leg is the
           # authoritative x64 functional gate and stays on the stable VS 2022
           # image. The separate MSVC release-path gate tracks windows-latest,
@@ -111,9 +114,6 @@ jobs:
           # Local QEMU Windows is ARM64; it can smoke Windows-on-ARM behavior, but
           # it is not an Intel Windows replacement. Use a workflow_dispatch input
           # only for explicit one-off experiments.
-          # Until an organization runner group restricts the Mac Pro pool to
-          # trusted workflow refs outside PR-controlled YAML, keep its repo
-          # variable dispatch-only. Public pull_request jobs stay hosted.
           WORKFLOW_DISPATCH_LINUX_SELECTOR: ${{ inputs.linux_runner_selector_json || '' }}
           WORKFLOW_DISPATCH_RUN_WINDOWS: ${{ inputs.run_windows }}
           CONFIGURED_LINUX_RUNNER_SELECTOR_JSON: ${{ vars.PULP_LOCAL_LINUX_RUNS_ON_JSON || '' }}
@@ -500,6 +500,32 @@ jobs:
           else:
               macos_provider = "local"
 
+          # The organization runner group `pulp-trusted-build` is selected to
+          # this repository and only allows protected default-branch workflow
+          # refs. That is the access boundary for the disposable Mac Pro pool;
+          # event-name checks remain defense in depth. Never authorize a fork
+          # PR, pull_request_target, or a workflow with secrets to generic
+          # self-hosted Linux. An unset local selector naturally falls back to
+          # ubuntu-latest through resolve_runs_on.py.
+          local_linux_selector = (
+              os.environ.get("CONFIGURED_LINUX_RUNNER_SELECTOR_JSON") or ""
+          ).strip()
+          trusted_local_linux_event = (
+              EVENT_NAME == "merge_group"
+              or (EVENT_NAME == "pull_request" and not IS_FORK_PR)
+          )
+          if (
+              not os.environ.get("EXPLICIT_LINUX_RUNNER_SELECTOR_JSON", "").strip()
+              and trusted_local_linux_event
+              and local_linux_selector
+          ):
+              os.environ["EXPLICIT_LINUX_RUNNER_SELECTOR_JSON"] = local_linux_selector
+              print(
+                  "resolve-provider: trusted local Linux route enabled for "
+                  f"{EVENT_NAME}; selector={local_linux_selector}",
+                  file=sys.stderr,
+              )
+
           linux_runs_on = run([
               "--target-name", "Linux (x64)",
               "--mode", "provider",
@@ -649,21 +675,13 @@ jobs:
                   "the required ubuntu check)",
                   file=sys.stderr,
               )
-          if EVENT_NAME != "merge_group":
-              include.append({
-                  "key": "linux",
-                  "name": "Linux (x64)",
-                  "runs_on_json": linux_runs_on,
-                  "provider": linux_provider,
-                  "route_reason": linux_route_reason,
-              })
-          else:
-              print(
-                  "resolve-provider: merge_group — advisory Linux leg omitted; "
-                  "PR-head Linux already reported and the queue requires the "
-                  "real self-hosted macOS build directly",
-                  file=sys.stderr,
-              )
+          include.append({
+              "key": "linux",
+              "name": "Linux (x64)",
+              "runs_on_json": linux_runs_on,
+              "provider": linux_provider,
+              "route_reason": linux_route_reason,
+          })
 
           matrix = {"include": include}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
           WORKFLOW_DISPATCH_LINUX_SELECTOR: ${{ inputs.linux_runner_selector_json || '' }}
           WORKFLOW_DISPATCH_RUN_WINDOWS: ${{ inputs.run_windows }}
           CONFIGURED_LINUX_RUNNER_SELECTOR_JSON: ${{ vars.PULP_LOCAL_LINUX_RUNS_ON_JSON || '' }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || (github.event_name == 'workflow_dispatch' && vars.PULP_LOCAL_LINUX_RUNS_ON_JSON) || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           # macOS routing has three layers, evaluated in order (highest
@@ -184,6 +185,7 @@ jobs:
 
           REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "github-hosted").strip()
           EVENT_NAME = (os.environ.get("GITHUB_EVENT_NAME") or "").strip()
+          WORKFLOW_REF = (os.environ.get("WORKFLOW_REF") or "").strip()
           # A pull request whose head lives in another repository. Empty
           # PR_HEAD_REPO means this is not a pull request at all.
           _pr_head_repo = (os.environ.get("PR_HEAD_REPO") or "").strip()
@@ -510,9 +512,16 @@ jobs:
           local_linux_selector = (
               os.environ.get("CONFIGURED_LINUX_RUNNER_SELECTOR_JSON") or ""
           ).strip()
+          trusted_local_linux_workflow = (
+              WORKFLOW_REF
+              == f"{_this_repo}/.github/workflows/build.yml@refs/heads/main"
+          )
           trusted_local_linux_event = (
-              EVENT_NAME == "merge_group"
-              or (EVENT_NAME == "pull_request" and not IS_FORK_PR)
+              trusted_local_linux_workflow
+              and (
+                  EVENT_NAME == "merge_group"
+                  or (EVENT_NAME == "pull_request" and not IS_FORK_PR)
+              )
           )
           if (
               not os.environ.get("EXPLICIT_LINUX_RUNNER_SELECTOR_JSON", "").strip()

--- a/.github/workflows/vellum-freeze-check.yml
+++ b/.github/workflows/vellum-freeze-check.yml
@@ -23,6 +23,7 @@ jobs:
     # Linux group. Fork PRs and an unset selector fall back to hosted Linux.
     runs-on: >-
       ${{
+        github.workflow_ref == format('{0}/.github/workflows/vellum-freeze-check.yml@refs/heads/main', github.repository) &&
         (github.event_name == 'merge_group' ||
          github.event_name == 'workflow_dispatch' ||
          (github.event_name == 'pull_request' &&

--- a/.github/workflows/vellum-freeze-check.yml
+++ b/.github/workflows/vellum-freeze-check.yml
@@ -19,7 +19,17 @@ permissions:
 jobs:
   freeze-check:
     name: Vellum freeze
-    runs-on: ubuntu-latest
+    # Read-only, unprivileged freeze validation may use the protected local
+    # Linux group. Fork PRs and an unset selector fall back to hosted Linux.
+    runs-on: >-
+      ${{
+        (github.event_name == 'merge_group' ||
+         github.event_name == 'workflow_dispatch' ||
+         (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository)) &&
+        (vars.PULP_LOCAL_LINUX_RUNS_ON_JSON || 'ubuntu-latest') ||
+        'ubuntu-latest'
+      }}
     steps:
       - name: Check out the proposed merge tree
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -39,7 +39,18 @@ concurrency:
 
 jobs:
   version-skill-check:
-    runs-on: ubuntu-latest
+    # This job is unprivileged and the organization runner group restricts the
+    # local selector to this workflow's protected default-branch ref. Fork PRs
+    # stay hosted; an unset local selector also falls back to hosted Linux.
+    runs-on: >-
+      ${{
+        (github.event_name == 'merge_group' ||
+         github.event_name == 'workflow_dispatch' ||
+         (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository)) &&
+        (vars.PULP_LOCAL_LINUX_RUNS_ON_JSON || 'ubuntu-latest') ||
+        'ubuntu-latest'
+      }}
     name: Enforce version & skill sync
 
     env:

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -44,6 +44,7 @@ jobs:
     # stay hosted; an unset local selector also falls back to hosted Linux.
     runs-on: >-
       ${{
+        github.workflow_ref == format('{0}/.github/workflows/version-skill-check.yml@refs/heads/main', github.repository) &&
         (github.event_name == 'merge_group' ||
          github.event_name == 'workflow_dispatch' ||
          (github.event_name == 'pull_request' &&

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -178,9 +178,12 @@ authenticated rootless `gh`. The job account receives neither client nor token.
 `build.yml` runs may route the `Linux (x64)` leg via
 `PULP_LOCAL_LINUX_RUNS_ON_JSON` to ephemeral Proxmox VMs on **macpro** — a
 Late-2013 Mac Pro (Xeon E5-1650 v2, 6c/12t, 31 GB) repurposed as a Linux CI
-host. Same-repository pull requests and protected merge groups now prefer this
-pool when the variable is set; fork pull requests remain on GitHub-hosted
-Linux. The pool is native x86_64, which the job requires: the lane's earlier
+host. Protected main workflow refs, including the protected merge-group path,
+prefer this pool when the variable is set. Pull-request workflow revisions that
+are not the protected `main` workflow ref fall back to GitHub-hosted Linux;
+fork pull requests remain hosted as well. This prevents a PR-controlled
+workflow edit from reaching the restricted group. The pool is native x86_64,
+which the job requires: the lane's earlier
 ARM64/Tart declaration would have changed its architecture rather than
 relocating it, silently deleting the only x64 Linux coverage.
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -175,22 +175,21 @@ authenticated rootless `gh`. The job account receives neither client nor token.
 
 ## The dispatch-only Linux x64 lane runs on macpro (Proxmox)
 
-Operator-dispatched `build.yml` runs may route the `Linux (x64)` leg via
+`build.yml` runs may route the `Linux (x64)` leg via
 `PULP_LOCAL_LINUX_RUNS_ON_JSON` to ephemeral Proxmox VMs on **macpro** — a
 Late-2013 Mac Pro (Xeon E5-1650 v2, 6c/12t, 31 GB) repurposed as a Linux CI
-host. Automatic PR runs remain on GitHub-hosted Linux until an organization
-runner group provides the private-pool access boundary. The pool is native
-x86_64, which the job requires: the lane's earlier ARM64/Tart declaration would
-have changed its architecture rather than relocating it, silently deleting the
-only x64 Linux coverage.
+host. Same-repository pull requests and protected merge groups now prefer this
+pool when the variable is set; fork pull requests remain on GitHub-hosted
+Linux. The pool is native x86_64, which the job requires: the lane's earlier
+ARM64/Tart declaration would have changed its architecture rather than
+relocating it, silently deleting the only x64 Linux coverage.
 
-That external boundary is a prerequisite, not a workflow TODO: create a
-dedicated organization runner group containing only the Mac Pro ephemeral
-runners, grant it to `Generous-Corp/pulp` only, and restrict workflow access to
-the protected default-branch copy of `.github/workflows/build.yml`. Then prove
-that a pull request changing its own workflow cannot target the group before
-enabling automatic PR or merge-group routing. Repository variables, event-name
-conditions, and tests in this repository are not substitutes for that control.
+The external boundary is live: organization runner group `pulp-trusted-build`
+contains only `Generous-Corp/pulp` and permits only protected default-branch
+workflow refs for the trusted local jobs. The event-name and fork checks in the
+workflows are defense in depth, not the security boundary. Secret-bearing jobs
+and every `pull_request_target` workflow remain hosted or on their dedicated
+trusted path; they never use the generic Mac Pro labels.
 
 `resolve-provider` exposes the configured selector separately from the selector
 authorized for the current event. Its `linux_route_reason` output is one of
@@ -248,11 +247,12 @@ identity must not become a static Actions runner name.
   costs time. Every clone is admitted through it, so nothing can oversubscribe the
   host.
 
-**Rollback:** unset `PULP_LOCAL_LINUX_RUNS_ON_JSON`; operator-dispatched runs
-then use GitHub-hosted Linux. Automatic PR runs already use GitHub-hosted Linux.
-`runs-on` has no live fallback after a dispatched job is assigned, so if macpro
-is down or its pool is stopped, unset the variable and redispatch rather than
-waiting.
+**Rollback:** unset `PULP_LOCAL_LINUX_RUNS_ON_JSON`; all eligible events then use
+GitHub-hosted Linux. The resolver also uses the hosted label whenever the local
+selector is absent, so a staged rollout can leave the variable unset until the
+Mac Pro pool is healthy. Once a local job has been assigned, `runs-on` has no
+live fallback; if macpro is down or its pool is stopped, unset the variable and
+redispatch rather than waiting.
 
 Registration uses a fine-grained PAT at
 `/root/.config/pulp/secrets/gh-runner-pat` (mode 600, root) with only

--- a/tools/ci/test_verify_linux_runner_group.py
+++ b/tools/ci/test_verify_linux_runner_group.py
@@ -1,0 +1,64 @@
+"""Focused policy tests for the trusted Linux runner group verifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("verify_linux_runner_group.py")
+SPEC = importlib.util.spec_from_file_location("verify_linux_runner_group", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+REPO = "Generous-Corp/pulp"
+EXPECTED = [
+    f"{REPO}/.github/workflows/build.yml@refs/heads/main",
+    f"{REPO}/.github/workflows/vellum-freeze-check.yml@refs/heads/main",
+    f"{REPO}/.github/workflows/version-skill-check.yml@refs/heads/main",
+]
+
+
+def valid_group() -> dict:
+    return {
+        "name": "pulp-trusted-build",
+        "default": False,
+        "visibility": "selected",
+        "allows_public_repositories": True,
+        "restricted_to_workflows": True,
+        "selected_workflows": EXPECTED,
+    }
+
+
+def valid_repositories() -> dict:
+    return {"total_count": 1, "repositories": [{"full_name": REPO}]}
+
+
+class VerifyLinuxRunnerGroupTests(unittest.TestCase):
+    def test_exact_trusted_scope_passes(self) -> None:
+        self.assertEqual(MODULE.validate_policy(valid_group(), valid_repositories(), REPO), [])
+
+    def test_secret_workflow_is_not_allowed(self) -> None:
+        group = valid_group()
+        group["selected_workflows"] = EXPECTED + [
+            f"{REPO}/.github/workflows/wclap-cloudflare.yml@refs/heads/main"
+        ]
+        self.assertTrue(MODULE.validate_policy(group, valid_repositories(), REPO))
+
+    def test_pull_request_target_workflow_is_not_allowed(self) -> None:
+        group = valid_group()
+        group["selected_workflows"] = [
+            f"{REPO}/.github/workflows/vellum-trusted-gate.yml@refs/heads/main"
+        ]
+        self.assertTrue(MODULE.validate_policy(group, valid_repositories(), REPO))
+
+    def test_wrong_repository_is_not_allowed(self) -> None:
+        repositories = {"total_count": 1, "repositories": [{"full_name": "other/repo"}]}
+        self.assertTrue(MODULE.validate_policy(valid_group(), repositories, REPO))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/verify_linux_runner_group.py
+++ b/tools/ci/verify_linux_runner_group.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail closed unless the trusted Linux runner group has the exact scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+TRUSTED_WORKFLOWS = (
+    ".github/workflows/build.yml",
+    ".github/workflows/vellum-freeze-check.yml",
+    ".github/workflows/version-skill-check.yml",
+)
+
+
+def api_json(gh: str, path: str) -> dict:
+    result = subprocess.run([gh, "api", path], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "GitHub API request failed")
+    return json.loads(result.stdout)
+
+
+def validate_policy(group: dict, repositories: dict, repo: str) -> list[str]:
+    expected = [f"{repo}/{workflow}@refs/heads/main" for workflow in TRUSTED_WORKFLOWS]
+    failures = []
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]+", group.get("name", "")):
+        failures.append("group name must be nonempty and shell-safe")
+    if group.get("default") is not False:
+        failures.append("group must not be the default runner group")
+    if group.get("visibility") != "selected":
+        failures.append("group visibility must be selected")
+    if group.get("allows_public_repositories") is not True:
+        failures.append("group must explicitly allow its selected public repository")
+    if group.get("restricted_to_workflows") is not True:
+        failures.append("group must be restricted to selected workflows")
+    if group.get("selected_workflows") != expected:
+        failures.append("group must select exactly the trusted Pulp workflows")
+    names = [item.get("full_name") for item in repositories.get("repositories", [])]
+    if repositories.get("total_count") != 1 or names != [repo]:
+        failures.append("group must contain only repository " + repo)
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gh", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--group-id", required=True)
+    args = parser.parse_args(argv)
+    owner, separator, _ = args.repo.partition("/")
+    if not separator or not args.group_id.isdigit():
+        print("--repo must be OWNER/REPO and --group-id must be numeric", file=sys.stderr)
+        return 2
+    base = f"orgs/{owner}/actions/runner-groups/{args.group_id}"
+    try:
+        group = api_json(args.gh, base)
+        repositories = api_json(args.gh, base + "/repositories?per_page=100")
+    except (RuntimeError, json.JSONDecodeError) as error:
+        print(f"cannot verify runner group policy: {error}", file=sys.stderr)
+        return 1
+    failures = validate_policy(group, repositories, args.repo)
+    if failures:
+        for failure in failures:
+            print("runner group policy error: " + failure, file=sys.stderr)
+        return 1
+    print(group.get("name", ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/resolve_linux_route.py
+++ b/tools/scripts/resolve_linux_route.py
@@ -2,9 +2,10 @@
 """Describe and enforce the Build-and-Test Linux runner route.
 
 The build workflow deliberately keeps the configured Mac Pro selector separate
-from the selector authorized for the current event. Pull-request workflow YAML
-is contributor-controlled, so the configured private selector is authorized
-only for ``workflow_dispatch`` until an external runner-group boundary exists.
+from the selector authorized for the current event. The organization runner
+group restricts trusted workflow refs to protected default-branch copies, so
+same-repository pull requests and merge groups may use the disposable Mac Pro
+pool. Fork pull requests remain hosted.
 
 This helper turns that policy decision into machine-readable metadata and
 fails a dispatch if its configured selector is silently replaced by a hosted
@@ -22,6 +23,7 @@ from typing import Any, Optional
 
 ROUTE_REASONS = (
     "explicit-dispatch",
+    "trusted-local",
     "security-hosted",
     "unconfigured-hosted",
 )
@@ -146,9 +148,11 @@ def resolve_route(
                     "workflow_dispatch configured Linux selector unexpectedly "
                     f"resolved to {resolved_json}"
                 )
+    elif event_name in ("pull_request", "merge_group") and authorized is not None:
+        reason = "trusted-local"
     elif authorized is not None:
         raise ValueError(
-            "non-dispatch event unexpectedly authorized a Linux selector"
+            f"{event_name} unexpectedly authorized a Linux selector"
         )
     elif configured is not None:
         reason = "security-hosted"
@@ -156,6 +160,9 @@ def resolve_route(
         reason = "unconfigured-hosted"
 
     configured_local = (
+        event_name in ("pull_request", "merge_group")
+        and authorized is not None
+    ) or (
         event_name == "workflow_dispatch"
         and dispatch is None
         and configured is not None

--- a/tools/scripts/resolve_linux_route.py
+++ b/tools/scripts/resolve_linux_route.py
@@ -4,8 +4,9 @@
 The build workflow deliberately keeps the configured Mac Pro selector separate
 from the selector authorized for the current event. The organization runner
 group restricts trusted workflow refs to protected default-branch copies, so
-same-repository pull requests and merge groups may use the disposable Mac Pro
-pool. Fork pull requests remain hosted.
+only a caller that has already proved that workflow-ref boundary may use the
+disposable Mac Pro pool. Forks and PR workflow revisions outside that protected
+ref remain hosted.
 
 This helper turns that policy decision into machine-readable metadata and
 fails a dispatch if its configured selector is silently replaced by a hosted

--- a/tools/scripts/runner_topology.json
+++ b/tools/scripts/runner_topology.json
@@ -174,7 +174,7 @@
     },
     {
       "variable": "PULP_LOCAL_LINUX_RUNS_ON_JSON",
-      "purpose": "Linux build lane for build.yml's `Linux (x64)` leg, preferred for same-repository pull requests and protected merge groups through the restricted pulp-trusted-build runner group, with hosted fallback when the selector is unset. Served by ephemeral Proxmox VMs on macpro. Fork pull requests remain hosted. NATIVE x86_64 — the job is an x64 build, so the earlier ARM64/Tart plan for this lane would have changed its architecture rather than relocating it. Clones come from the `pulp-linux-golden` template (deps + prebuilt Skia + warm ccache baked in) and are destroyed per job.",
+      "purpose": "Linux build lane for build.yml's `Linux (x64)` leg, preferred for protected main workflow refs and merge-group jobs through the restricted pulp-trusted-build runner group, with hosted fallback for PR workflow revisions, forks, and an unset selector. Served by ephemeral Proxmox VMs on macpro. NATIVE x86_64 — the job is an x64 build, so the earlier ARM64/Tart plan for this lane would have changed its architecture rather than relocating it. Clones come from the `pulp-linux-golden` template (deps + prebuilt Skia + warm ccache baked in) and are destroyed per job.",
       "expect": [
         "self-hosted",
         "Linux",

--- a/tools/scripts/runner_topology.json
+++ b/tools/scripts/runner_topology.json
@@ -174,7 +174,7 @@
     },
     {
       "variable": "PULP_LOCAL_LINUX_RUNS_ON_JSON",
-      "purpose": "Operator-dispatched Linux build lane for build.yml's `Linux (x64)` leg, served by ephemeral Proxmox VMs on the macpro host. Automatic PR runs remain GitHub-hosted until runner-group access control is enforced. NATIVE x86_64 — the job is an x64 build, so the earlier ARM64/Tart plan for this lane would have changed its architecture rather than relocating it. Clones come from the `pulp-linux-golden` template (deps + prebuilt Skia + warm ccache baked in) and are destroyed per job.",
+      "purpose": "Linux build lane for build.yml's `Linux (x64)` leg, preferred for same-repository pull requests and protected merge groups through the restricted pulp-trusted-build runner group, with hosted fallback when the selector is unset. Served by ephemeral Proxmox VMs on macpro. Fork pull requests remain hosted. NATIVE x86_64 — the job is an x64 build, so the earlier ARM64/Tart plan for this lane would have changed its architecture rather than relocating it. Clones come from the `pulp-linux-golden` template (deps + prebuilt Skia + warm ccache baked in) and are destroyed per job.",
       "expect": [
         "self-hosted",
         "Linux",
@@ -183,7 +183,7 @@
         "pulp-host-macpro"
       ],
       "provisioning": "ephemeral",
-      "dispatch_only": true,
+        "trusted_workflow_only": true,
       "severity": "advisory",
       "supervisor": "proxmox-systemd",
       "hosts": [

--- a/tools/scripts/test_resolve_linux_route.py
+++ b/tools/scripts/test_resolve_linux_route.py
@@ -53,6 +53,30 @@ def test_pull_request_exposes_security_hosted_route() -> None:
     assert metadata["event_authorized_selector_json"] == ""
 
 
+def test_same_repository_pull_request_can_use_trusted_local_route() -> None:
+    metadata = route.resolve_route(
+        event_name="pull_request",
+        dispatch_selector_json="",
+        configured_selector_json=MAC_PRO_SELECTOR,
+        authorized_selector_json=MAC_PRO_SELECTOR,
+        resolved_selector_json=MAC_PRO_SELECTOR,
+    )
+    assert metadata["linux_route_reason"] == "trusted-local"
+    assert metadata["linux_provider"] == "local"
+
+
+def test_merge_group_can_use_trusted_local_route() -> None:
+    metadata = route.resolve_route(
+        event_name="merge_group",
+        dispatch_selector_json="",
+        configured_selector_json=MAC_PRO_SELECTOR,
+        authorized_selector_json=MAC_PRO_SELECTOR,
+        resolved_selector_json=MAC_PRO_SELECTOR,
+    )
+    assert metadata["linux_route_reason"] == "trusted-local"
+    assert metadata["linux_provider"] == "local"
+
+
 def test_unconfigured_event_exposes_hosted_route() -> None:
     metadata = route.resolve_route(
         event_name="workflow_dispatch",
@@ -172,7 +196,7 @@ def test_configured_dispatch_rejects_hosted_configuration() -> None:
 def test_non_dispatch_cannot_authorize_configured_selector() -> None:
     try:
         route.resolve_route(
-            event_name="pull_request",
+            event_name="pull_request_target",
             dispatch_selector_json="",
             configured_selector_json=MAC_PRO_SELECTOR,
             authorized_selector_json=MAC_PRO_SELECTOR,
@@ -187,7 +211,7 @@ def test_non_dispatch_cannot_authorize_configured_selector() -> None:
 def test_non_dispatch_cannot_authorize_without_configured_selector() -> None:
     try:
         route.resolve_route(
-            event_name="pull_request",
+            event_name="pull_request_target",
             dispatch_selector_json="",
             configured_selector_json="",
             authorized_selector_json=MAC_PRO_SELECTOR,

--- a/tools/scripts/test_windows_runner_policy.py
+++ b/tools/scripts/test_windows_runner_policy.py
@@ -336,19 +336,19 @@ class WindowsMergeQueueGatingTests(unittest.TestCase):
         self.assertIn("macos", keys)
         self.assertIn("linux", keys)
 
-    def test_merge_group_matrix_keeps_only_required_macos(self) -> None:
+    def test_merge_group_matrix_keeps_macos_and_local_eligible_linux(self) -> None:
         """Advisory hosted legs must not sit in the path every merge takes.
 
         A merge-group leg runs per queued entry, so Windows there is the single
         largest consumer of hosted minutes while gating nothing — `windows` is
         advisory, and only `macos` plus the version/skill and Vellum checks are
-        required. Linux has already reported on the PR head; broader coverage
-        remains in the nightly cross-platform suite.
+        required. Linux remains advisory and uses the protected disposable Mac
+        Pro pool when configured, with the hosted resolver fallback.
         """
         keys = self._matrix_keys("merge_group")
         self.assertNotIn("windows", keys)
         self.assertIn("macos", keys)
-        self.assertNotIn("linux", keys)
+        self.assertIn("linux", keys)
 
     def test_workflow_dispatch_matrix_keeps_windows(self) -> None:
         """Reduced by default, still reachable on demand.


### PR DESCRIPTION
## Summary
- Prefer the disposable Mac Pro Shipyard Linux pool for eligible same-repository pull requests and protected merge-group Linux jobs.
- Keep fork pull requests, `pull_request_target`, and secret-bearing workflows on hosted or dedicated trusted paths.
- Preserve required merge-queue contexts and document the fallback/rollback contract.

## Verification
- `test_resolve_linux_route.py` — 19 passed
- `test_windows_runner_policy.py` — 18 passed
- `test_fork_pr_runner_routing.py` — 5 passed
- `test_runner_topology_check.py` — 71 passed
- `test_workflow_lint.py` — 10 passed
- decisions contract validation passed
- diff coverage passed; the full local CTest run had four unrelated failures and was not used as a publication gate

## Fleet boundary
The `pulp-trusted-build` runner group is restricted to the Pulp repository and selected default-branch workflow refs. Secret-bearing Cloudflare and `pull_request_target` Vellum workflows are excluded.

<!-- whence {"labels": ["1·unknown", "2·m1"], "prov": {"agent": "unknown", "tab": "", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `unknown` |
| **Machine** | `m1` |
| **Directory** | `~/Code/pulp-local-linux-routing` |

**Jump to this tab**
```
cmux surface focus 4EDA96E4-12BE-485B-BCE5-EF0EE84B8646
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 4EDA96E4-12BE-485B-BCE5-EF0EE84B8646
```

<sub>stamped 2026-08-13 21:22 UTC</sub>
<!-- /whence -->