### PR TITLE
chore: bump versions

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -20,7 +20,7 @@ mirror these records into `pulp` CLI or `pulp-mcp`; Shipyard is the metrics
 store and tartci is an optional VM runtime emitter.
 
 This metrics surface requires a Shipyard build that includes the
-`shipyard metrics` subcommand. Pulp's pin in `tools/shipyard.toml` is `v0.83.0`,
+`shipyard metrics` subcommand. Pulp's pin in `tools/shipyard.toml` is `v0.92.1`,
 which provides it, so the pinned binary is sufficient. That pin also makes
 formal GitHub stacks fail closed at every Shipyard merge-queue mutation
 boundary, including `shipyard runner steward`; use the native `gh stack`
@@ -2463,6 +2463,34 @@ skill; examples/config-only diffs still need a `Version-Bump: skip` trailer unde
 a `feat:`/`fix:` title) — expect to add those trailers too.
 
 ### Shipyard pin and behaviour notes
+
+#### v0.92.1 is the fleet floor for protected closure
+
+Keep the checked-in pin, the post-tag workflow pin, and every installed
+M1/M3/M5 binary on v0.92.1 together. This release retains v0.92.0's
+materialization of branch-protected required checks that GitHub has not yet
+exposed on the PR, preventing a false-green wait while a required producer is
+still absent. It also makes local signing unattended for release automation
+and preserves
+the queue-admission and PR-close guards, rejects unproved local x64 targets, and
+bounds retry waits without losing transient failure metadata. The practical
+value is one closure contract everywhere: Shipyard validates exact heads, but
+GitHub's protected merge queue owns the final Pulp mutation. A host on an older
+binary can otherwise finish valid tests while following obsolete direct-merge
+semantics and invalidate a precomputed queue lineage.
+
+Fleet observation also needs runner inventory visibility. The Shipyard GitHub
+App therefore needs Actions/runner read access (organization runner-group read
+access for protected groups, plus the existing repository runner
+administration used for ephemeral registration). Without that read access it
+cannot distinguish unavailable capacity from an idle or stale registration,
+prove group/label placement, or safely decide whether hosted fallback must
+remain active. This is read-side admission evidence, not permission to bypass
+the merge queue. v0.92.1 retains GitHub's contradictory `offline + busy`
+state as `offline_busy`; require the bounded VM/lease/supervisor/job ownership
+audit, but preserve and escalate because current TartCI does not emit a
+machine-checked orphan verdict. The symptom alone never authorizes a
+cancellation or registration removal.
 
 #### Shipyard cannot merge under a merge queue — it errors, and that is expected
 

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -2492,33 +2492,32 @@ audit, but preserve and escalate because current TartCI does not emit a
 machine-checked orphan verdict. The symptom alone never authorizes a
 cancellation or registration removal.
 
-#### Shipyard cannot merge under a merge queue — it errors, and that is expected
+#### Shipyard v0.92.1 owns exact-head merge-queue admission
 
-`shipyard pr` is still the right way to create a PR: it runs the gates, applies
-version bumps, pushes the branch, and opens and tracks the PR. It **cannot land
-it**. Confirmed at tag v0.78.0, `src/wait.rs:189`:
+`shipyard pr` remains the normal create-and-close path: it runs the gates,
+applies version bumps, pushes the branch, opens and tracks the PR, detects the
+live merge-queue requirement, and validates the exact head. On a governed base
+it does not issue a direct merge. It enqueues through GitHub's native GraphQL
+mutation with the server-atomic `expectedHeadOid` set to the validated SHA,
+then waits for the protected queue to land or reject that exact lineage.
 
-```rust
-if merge_state.contains("RULESET") || merge_state == "MERGE_QUEUED" {
-    return Err(Box::new(UnsupportedScopeError(
-        "Rulesets / merge-queue governance isn't supported by
-         `shipyard wait pr --state green` yet …")))
-}
-```
+Do not follow the pre-v0.92 manual-enqueue recipe after a successful Shipyard
+validation. A second `ghapp pr merge --auto` call bypasses Shipyard's durable
+admission state and can race head drift or queue removal. Manual enqueueing is
+an explicit recovery path only: first reconcile Shipyard's durable state with
+authoritative GitHub head/queue truth, prove the exact reviewed SHA, and record
+why the native admission path is unavailable. Never use `--admin` or a direct
+merge to bypass the queue.
 
-So a ship that reaches the wait/merge step under the `main-merge-queue` ruleset
-fails there. **That is not a broken branch and not a Shipyard bug to work
-around** — the ruleset (`bypass_actors: []`, `current_user_can_bypass: never`)
-is what makes the queue the real merge authority rather than theatre. Do not
-admin-merge past it. Enqueue instead:
+The standalone `shipyard wait pr --state green` command can still report its
+historical unsupported-scope exit for ruleset/queue governance. That read-only
+wait limitation is not the `shipyard ship` / `shipyard pr` merge path and does
+not mean an otherwise healthy ship must be manually enqueued.
 
-```bash
-ghapp pr merge <n> --repo Generous-Corp/pulp --auto
-```
-
-The PR enters the queue once its required contexts are green. Note GitHub uses
-the **latest** run for a required context, so a newly-queued re-run makes an
-already-green context pending again and delays entry — that resolves itself.
+GitHub uses the **latest** run for a required context, so a newly queued rerun
+can make an already-green context pending again and delay admission. Preserve
+healthy jobs and let the protected check resolve unless exact stale proof
+authorizes a narrow recovery.
 
 #### The pin is load-bearing at v0.78.0 because of the post-tag hook
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.428.1",
+      "version": "0.429.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.428.1"
+  "version": "0.429.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.428.1",
+  "version": "0.429.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.806.1
+    VERSION 0.807.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -492,7 +492,7 @@ investigating or just within the usual range?" Humans can use the same commands
 for high-level platform comparisons, but no observability service is required.
 
 The `shipyard metrics` commands require a Shipyard build that includes the
-metrics subcommand. Pulp's pin in `tools/shipyard.toml` is `v0.81.4`, which
+metrics subcommand. Pulp's pin in `tools/shipyard.toml` is `v0.92.1`, which
 provides it, so no separate binary is needed.
 
 ```bash
@@ -682,6 +682,40 @@ shipyard runner fleet-status --repo Generous-Corp/pulp --json
 The same report calls out Tart disk-floor and ccache-size admission failures and
 merge-group Linux jobs left on `ubuntu-latest` while online self-hosted Linux x64
 capacity is idle.
+
+### Reconcile `offline_busy` before recovering anything
+
+Shipyard v0.92.1 reports `offline_busy` when GitHub says a self-hosted runner is
+both offline and busy. That contradiction is a diagnostic signal, not authority
+to cancel a job or delete a VM. Capture two bounded snapshots separated by the
+configured TartCI stale-observation threshold; do not substitute an arbitrary
+short sleep or runner-name match:
+
+```bash
+shipyard runner status --repo Generous-Corp/pulp --runner-id <runner_id> --json
+tartci observe macos --json
+tartci doctor --reap --json
+tartci leases status --json
+ghapp api repos/Generous-Corp/pulp/actions/jobs/<job_id>
+ps -Ao pid,ppid,etime,command | rg '<runner_name>|<job_id>|<run_id>'
+```
+
+For each snapshot, record the exact runner ID and name, job and run IDs, last
+heartbeat/observation time, Tart VM identity, TartCI lease, supervisor state,
+and matching host process tree. Preserve the job whenever any ownership signal
+is live, changes between snapshots, or cannot be read. Current TartCI
+deliberately reports this as `problems: ["offline_busy_runner:<name>"]` with
+runner action `offline_busy_wait_for_github`; `doctor --reap` does not infer
+orphanhood or auto-delete the registration. Therefore the current result never
+authorizes cancellation/removal, even when both snapshots lack a matching VM,
+lease, supervisor, or process: preserve the job and escalate because missing or
+unreadable telemetry is not machine-checked proof. A future TartCI version may
+add an explicit orphan classification only after it binds those facts to the
+same runner/job across the configured threshold; update this runbook and pin
+that version before using the classification for narrow recovery. Never
+bulk-reap, reset a shared runner name, or cancel a healthy protected-queue job.
+After any separately authorized recovery, require a fresh disposable dispatch
+and teardown proof before declaring the lane healthy again.
 
 ```bash
 # What would happen, without touching anything:

--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -445,7 +445,36 @@ and asset metadata should move together.
 
 See [CLAUDE.md § Dependency Update Workflow](https://github.com/Generous-Corp/pulp/blob/main/CLAUDE.md#dependency-update-workflow) for the full procedure. The `ci` skill's path map catches the file change and demands a SKILL.md review.
 
-### Why the pin sits at v0.89.0 — exact-head stewardship is load-bearing
+### Why the pin sits at v0.92.1 — protected closure is load-bearing
+
+v0.92.1 is the common M1/M3/M5 floor. It retains v0.92.0's materialization of
+required checks that are configured in branch protection but not yet visible
+on the PR, so `shipyard wait` cannot report green merely because a required
+producer has not created its context. It also makes local signing unattended
+for release automation and carries fail-closed local-x64 proof, queue-admission
+and PR-close hardening, and bounded wait retries that preserve failure metadata.
+Together those properties keep Shipyard useful as the
+exact-head validator and fleet observer while GitHub's protected merge queue
+remains the only Pulp landing authority. Pin drift is operationally unsafe:
+an older host can validate the same commit but apply obsolete direct-merge
+semantics, invalidating a synthetic queue lineage. Update
+`tools/shipyard.toml`, the post-tag `SHIPYARD_VERSION`, and installed fleet
+binaries as one change, then verify `shipyard --version` on every host.
+
+Shipyard's App needs Actions/runner read access so fleet admission can see
+runner registrations and, for protected organization pools, runner-group
+membership. That evidence is what lets it prove labels/capacity and keep
+hosted fallback enabled when the local route is incomplete; it does not grant
+merge-queue bypass. The setup details and exact permission checks live in
+`docs/guides/local-ci.md`.
+
+v0.92.1 also retains GitHub's contradictory `offline + busy` state as
+`offline_busy`. Treat that as a reconciliation signal, not cancellation
+authority. Current TartCI does not emit machine-checked orphan proof, so the
+documented two-snapshot VM, lease, supervisor, runner, and job audit preserves
+and escalates the job rather than authorizing recovery.
+
+v0.88.0 introduced the exact-head stewardship foundation retained here.
 
 v0.88.0 adds an explicit handoff contract for unattended PR stewardship. A PR
 is mutable only when its current commit has a successful

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4494,7 +4494,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.428.1",
+        "version": "0.429.0",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4509,13 +4509,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.428.1",
+        "catalog_version": "0.429.0",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.428.1",
+        "version": "0.429.0",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,6 +50,19 @@
 # Full Shipyard release history lives with the Shipyard release notes. Keep this
 # file focused on the current Pulp pin and Pulp-specific operational reasons.
 #
+# v0.92.1 (current pin) — keeps PR closure queue-aware and fail-closed while
+#   materializing required checks that GitHub has not yet exposed on the PR.
+#   That closes the false-green wait seam without treating a missing context as
+#   success. It also carries bounded wait retries, preserved failure metadata,
+#   the v0.90.3 local-x64 proof guard, and v0.91.0 queue-admission/PR-close
+#   hardening. Pinning this fleet-wide matters because an older `shipyard ship`
+#   can otherwise validate correctly but use pre-queue merge semantics, while
+#   newer hosts correctly defer the final mutation to GitHub's protected merge
+#   queue. The shared pin gives M1/M3/M5 the same closure behavior and makes
+#   runner or token stalls diagnosable instead of silently dropping evidence.
+#   Its `offline_busy` signal requests bounded ownership reconciliation; it is
+#   never cancellation authority by itself.
+#
 # The current pin also carries the still-used recovery levers from v0.66/v0.67:
 # `shipyard ship/pr --adopt-head` for ship-state SHA drift (Shipyard #346),
 # local-first `shipyard rescue --rerun-failed` re-resolution for failed or


### PR DESCRIPTION
## Summary

- refresh the governed version bump onto exact current main `ba51e889f895ba6424b7bcc64c1e057b4e6e09f1`
- bump SDK `0.806.1 -> 0.807.0` and Claude plugin `0.428.1 -> 0.429.0`
- consolidate the exact #7528 Shipyard v0.92.1 lockstep payload so the 0.807 tag carries the current pin, post-tag workflow, and runner-access rationale
- replace the adjacent pre-v0.92 manual enqueue guidance with the v0.92.1 native `expectedHeadOid` merge-queue contract found by Sol-medium review

#7481 is not a release-integrity prerequisite: the release workflow is driven by the version-file change and changelog regeneration is intentionally post-tag. #7516 is already ahead in the protected queue, preserving the v0.806.1 changelog ordering.

## Validation

- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode report`
- version, pin, workflow, installer/autoupdate, control-shipping, and release workflow focused suites
- `tools/scripts/gates.sh origin/main`
- all four non-skill #7528 pin blobs are byte-identical; every #7528 CI-skill addition is present, plus the reviewed queue-guidance correction
- GPT-5.6 Sol-medium autoreview: one actionable stale-guidance finding accepted and fixed; same-model rerun was attempted three times but the reviewer account hit its usage limit

`Version-Bump-Applied: ba51e889f895ba6424b7bcc64c1e057b4e6e09f1`

Merge only through the protected GitHub merge queue tail. No direct or admin merge.

<!-- whence {"labels": ["1·codex", "2·m3", "3·pre-colo", "4·DSP", "5·unresolved"], "prov": {"agent": "codex", "tab": "DSP", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `pre-colo` |
| **Tab** | DSP |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a01d48-922d-7a92-8e49-40876ef346f6` |

**Resume**
```
codex resume 01a01d48-922d-7a92-8e49-40876ef346f6
```
**Jump to this tab**
```
cmux surface focus 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```

<sub>stamped 2026-08-20 13:18 UTC</sub>
<!-- /whence -->