### PR TITLE
ci: make Proxmox runners reusable across repositories

### DIFF
--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -214,6 +214,37 @@ the host copies live at `/usr/local/sbin/` and `/etc/systemd/system/`. The scrip
 `GOLDEN=` names the template in use — read it rather than trusting a number written
 down here, since re-baking a warmer golden mints a new id.
 
+### Reuse the Proxmox lane for another repository
+
+The supervisor is repository-agnostic. A new or existing repository must supply
+its own runner credential, exact labels, and (for organization-scoped automatic
+routing) its own restricted runner group. Do not copy Pulp's labels, group, or
+credential into another repository. For a repository-level, no-secret proof:
+
+```bash
+TARTCI_RUNNER_REPO=OWNER/REPO \
+TARTCI_RUNNER_LABELS=self-hosted,Linux,X64,repo-build-linux-x64,repo-host-macpro,repo-pr-safe-linux-x64 \
+TARTCI_RUNNER_PAT_FILE=/root/.config/tartci/secrets/repo-runner-pat \
+TARTCI_RUNNER_NAME_PREFIX=repo-pr-safe-ephemeral \
+TARTCI_PROXMOX_VM_NAME_PREFIX=repo-ci-ephemeral \
+TARTCI_PROXMOX_GOLDEN=9005 \
+/usr/local/sbin/proxmox-ephemeral-runner-linux.sh --once
+```
+
+The credential is host-only and must be root-owned mode `0600`; it is used only
+to mint and revoke the one-job runner registration. It must never be copied
+into the golden or guest. The guest must have no reusable GitHub credentials,
+no writable source/cache mount from the host, and must be destroyed after the
+job. A repository's workflow variable remains hosted until this proof records
+the exact runner assignment, labels, isolation, teardown, and fallback.
+
+For a new project, commit the corresponding `.shipyard/ci-profiles/` target and
+workflow selector first, then use the same profile from every fresh worktree.
+The live runner group, registration credential, health lease, and repository
+variable are administrative state; Shipyard must inspect/reconcile them rather
+than asking each worktree to register a new runner. After the proof, enable the
+repository's local selector with the hosted value retained as rollback.
+
 **Golden + disposable clone.** The golden carries the dependency set, prebuilt
 Skia (`external/skia-build/.../libskia.a`), a warm ccache, the uncredentialed
 `gh` executable used by preamble/alias jobs, and the shared FetchContent

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -228,6 +228,8 @@ TARTCI_RUNNER_PAT_FILE=/root/.config/tartci/secrets/repo-runner-pat \
 TARTCI_RUNNER_NAME_PREFIX=repo-pr-safe-ephemeral \
 TARTCI_PROXMOX_VM_NAME_PREFIX=repo-ci-ephemeral \
 TARTCI_PROXMOX_GOLDEN=9005 \
+TARTCI_PROXMOX_CLONE_BASE=203 TARTCI_PROXMOX_CLONE_MAX=203 \
+TARTCI_PROXMOX_GUEST_IPV4_FIRST_OCTET=254 \
 /usr/local/sbin/proxmox-ephemeral-runner-linux.sh --once
 ```
 
@@ -237,6 +239,11 @@ into the golden or guest. The guest must have no reusable GitHub credentials,
 no writable source/cache mount from the host, and must be destroyed after the
 job. A repository's workflow variable remains hosted until this proof records
 the exact runner assignment, labels, isolation, teardown, and fallback.
+
+Each repository/slot must use a non-overlapping VMID and guest-IP range. The
+supervisor checks existing Proxmox VM configuration and fails closed on an IP
+collision; do not assume that changing the VMID alone changes the deterministic
+guest address.
 
 For a new project, commit the corresponding `.shipyard/ci-profiles/` target and
 workflow selector first, then use the same profile from every fresh worktree.

--- a/docs/guides/self-hosted-runner.md
+++ b/docs/guides/self-hosted-runner.md
@@ -1,5 +1,31 @@
 # Self-hosted GitHub Actions runner setup
 
+## Disposable Proxmox Linux pool for another repository
+
+For an x86_64 Linux lane on the Mac Pro, use the repository-agnostic
+`tools/ci/proxmox-ephemeral-runner-linux.sh` with the JIT runner API. Do not
+copy Pulp's labels, runner group, or credential. Create one root-owned mode
+`0600` environment file per repository/slot under
+`/etc/pulp/proxmox-runner/`, install
+`tools/ci/proxmox-ephemeral-pool@.service` as
+`/etc/systemd/system/proxmox-ephemeral-pool@.service`, and enable the desired
+instances:
+
+```bash
+install -d -m 700 /etc/pulp/proxmox-runner
+install -m 644 tools/ci/proxmox-ephemeral-pool@.service \
+  /etc/systemd/system/proxmox-ephemeral-pool@.service
+systemctl daemon-reload
+systemctl enable --now proxmox-ephemeral-pool@repo-1.service
+```
+
+The env file must define `TARTCI_RUNNER_REPO`, exact repository labels,
+`TARTCI_RUNNER_PAT_FILE`, a stable name/VM prefix, and a disjoint VMID/IP
+range. The PAT stays on the host; the provider requests a single-use
+`generate-jitconfig` response, transfers it over stdin, runs one job, and
+destroys the clone. Keep the repository variable hosted until a real dispatch
+proves assignment and teardown; retain hosted as the rollback value.
+
 This guide covers setting up a Mac (or any machine) as a persistent
 Pulp CI runner. The payoff is getting sanitizer + build jobs off
 GitHub-hosted runners onto your own hardware — usually 4-8× faster,

--- a/tools/ci/proxmox-ephemeral-pool@.service
+++ b/tools/ci/proxmox-ephemeral-pool@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Repository-agnostic disposable Proxmox CI runner slot %i
+Documentation=https://github.com/Generous-Corp/pulp/blob/main/docs/guides/local-ci.md
+After=network-online.target pve-guests.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Each instance gets an explicit, root-owned environment file. The file is
+# the repository/slot profile; the runner script remains repository-agnostic.
+EnvironmentFile=-/etc/pulp/proxmox-runner/%i.env
+ExecStart=/usr/local/sbin/proxmox-ephemeral-runner-linux.sh --once
+Restart=always
+RestartSec=30
+RestartPreventExitStatus=
+TimeoutStopSec=180
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -177,11 +177,14 @@ done
 SLOT_INDEX=$((VMID - CLONE_BASE))
 GUEST_IP="${GUEST_IPV4_PREFIX}.$((GUEST_IPV4_FIRST_OCTET + SLOT_INDEX))"
 printf -v GUEST_MAC '02:50:55:4c:50:%02x' "$SLOT_INDEX"
-# The slot identity is stable for operations and metrics. The GitHub
-# registration name is intentionally unique per boot so an interrupted runner
-# cannot collide with its replacement.
+# The slot identity and GitHub registration name are stable. Reusing the same
+# name per repository/slot makes the fleet auditable and prevents registration
+# churn; cleanup reclaims only a confirmed offline registration for this exact
+# slot before reuse.
 RUNNER_SLOT_ID="macpro-linux-${VMID}"
-RUNNER_NAME="${RUNNER_NAME_PREFIX}-${VMID}-$(cat /proc/sys/kernel/random/uuid)"
+RUNNER_NAME="${RUNNER_NAME_PREFIX}-${VMID}"
+[ "${#RUNNER_NAME}" -le 64 ] \
+    || die "runner name exceeds GitHub's 64-character limit: ${RUNNER_NAME}"
 
 reclaim_stale_slot_runners() {
     [ -n "${PAT:-}" ] || return 0

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -413,12 +413,15 @@ RT="$(curl -s -X POST \
 [ -n "$RT" ] || die "could not mint a registration token (PAT scope or expiry?)"
 
 log "registering ephemeral runner ${RUNNER_NAME} (slot ${RUNNER_SLOT_ID}) on $VMID"
-ssh -o BatchMode=yes "ci@$GUEST_IP" "
+registration_output="$(ssh -o BatchMode=yes "ci@$GUEST_IP" "
     cd ~/actions-runner
     ./config.sh --unattended --ephemeral --replace \
       --url ${RUNNER_URL} --token ${RT} ${RUNNER_GROUP_ARG} \
       --name ${RUNNER_NAME} --labels ${LABELS} --work _work
-" >/dev/null 2>&1 || die "runner registration failed"
+")" || {
+    printf '%s\n' "$registration_output" | sed 's/[Tt]oken[^[:space:]]*/token=<redacted>/g' >&2
+    die "runner registration failed"
+}
 
 # ── run exactly one job ──────────────────────────────────────────────────────
 # run.sh exits once the single job completes, because of --ephemeral.

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -200,7 +200,7 @@ reclaim_stale_slot_runners() {
         --jq '.runners[] | [.id,.name,.busy,.status] | @tsv')" \
         || die "cannot inspect all runner registrations for ${RUNNER_SLOT_ID}"
     slot_matches="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
-        -v prefix="${RUNNER_NAME_PREFIX}-${VMID}-" 'index($2, prefix) == 1')"
+        -v name="$RUNNER_NAME" '$2 == name')"
     [ -n "$slot_matches" ] || return 0
     match_count="$(printf '%s\n' "$slot_matches" | wc -l | tr -d ' ')"
     [ "$match_count" = 1 ] \

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -22,27 +22,119 @@
 #
 set -uo pipefail
 
-GOLDEN=9005
-CLONE_BASE=200            # three pool slots, well clear of persistent VMs 101/102
-CLONE_MAX=202
+GOLDEN="${TARTCI_PROXMOX_GOLDEN:-${PULP_LINUX_GOLDEN:-9005}}"
+CLONE_BASE="${TARTCI_PROXMOX_CLONE_BASE:-200}" # pool slots, clear of persistent VMs
+CLONE_MAX="${TARTCI_PROXMOX_CLONE_MAX:-202}"
 GUEST_IPV4_PREFIX=192.168.86
 GUEST_IPV4_FIRST_OCTET=251
 GUEST_IPV4_GATEWAY=192.168.86.1
 CORES=4
 MEM_MB=8192
-REPO="Generous-Corp/pulp"
-LABELS="self-hosted,Linux,X64,pulp-build-linux-x64,pulp-host-macpro"
-PAT_FILE=/root/.config/pulp/secrets/gh-runner-pat
+REPO="${TARTCI_RUNNER_REPO:-${PULP_RUNNER_REPO:-Generous-Corp/pulp}}"
+ORG="${REPO%%/*}"
+LABELS="${TARTCI_RUNNER_LABELS:-${PULP_RUNNER_LABELS:-self-hosted,Linux,X64,pulp-build-linux-x64,pulp-host-macpro}}"
+RUNNER_NAME_PREFIX="${TARTCI_RUNNER_NAME_PREFIX:-${PULP_RUNNER_NAME_PREFIX:-pulp-ci-ephemeral}}"
+VM_NAME_PREFIX="${TARTCI_PROXMOX_VM_NAME_PREFIX:-${PULP_PROXMOX_VM_NAME_PREFIX:-pulp-ci-ephemeral}}"
+PAT_FILE="${TARTCI_RUNNER_PAT_FILE:-${PULP_RUNNER_PAT_FILE:-/root/.config/pulp/secrets/gh-runner-pat}}"
+ORG_PAT_FILE="${TARTCI_ORG_RUNNER_PAT_FILE:-${PULP_LINUX_ORG_PAT_FILE:-/root/.config/pulp/secrets/gh-org-runner-pat}}"
 GOVERNOR=/usr/local/sbin/macpro-governor.sh
+RUNNER_GROUP_ID="${TARTCI_RUNNER_GROUP_ID:-${PULP_LINUX_RUNNER_GROUP_ID:-}}"
+RUNNER_GROUP_PROFILE="${TARTCI_RUNNER_GROUP_PROFILE:-${PULP_LINUX_RUNNER_GROUP_PROFILE:-trusted}}"
+GROUP_VERIFIER="${TARTCI_RUNNER_GROUP_VERIFIER:-${PULP_LINUX_GROUP_VERIFIER:-/usr/local/lib/pulp/verify_linux_runner_group.py}}"
+GH_CLI="${TARTCI_GH_CLI:-${PULP_LINUX_GH_CLI:-gh}}"
+FIREWALL_STATUS_BIN="${PULP_LINUX_FIREWALL_STATUS_BIN:-pve-firewall}"
+FIREWALL_DIR="${PULP_LINUX_FIREWALL_DIR:-/etc/pve/firewall}"
+AUTOMATIC_NETWORK_ISOLATION=0
 KEEP=0
-[ "${1:-}" = "--keep" ] && KEEP=1
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 die() { log "ERROR: $*"; exit 1; }
 
-[ -r "$PAT_FILE" ] || die "no PAT at $PAT_FILE"
-PAT="$(cat "$PAT_FILE")"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --keep) KEEP=1; shift ;;
+        --once) shift ;; # explicit one-job mode; this supervisor is one-shot
+        --repo) REPO="${2:?--repo requires OWNER/REPO}"; ORG="${REPO%%/*}"; shift 2 ;;
+        --labels) LABELS="${2:?--labels requires a comma-separated label list}"; shift 2 ;;
+        --golden) GOLDEN="${2:?--golden requires a template id}"; shift 2 ;;
+        --name-prefix) RUNNER_NAME_PREFIX="${2:?--name-prefix requires a prefix}"; shift 2 ;;
+        --help|-h) sed -n '2,24p' "$0"; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
 
+case "$REPO" in
+    */*/*|/*|.*) die "runner repository must be OWNER/REPO: $REPO" ;;
+esac
+[ -n "$LABELS" ] || die "runner labels must not be empty"
+
+require_firewall_running() {
+    local context="$1" attempts="${2:-1}" actual="empty"
+    local attempt
+    for attempt in $(seq 1 "$attempts"); do
+        actual="$("$FIREWALL_STATUS_BIN" status 2>&1)" || actual="query failed"
+        [ "$actual" = "Status: enabled/running" ] && return 0
+        [ "$attempt" = "$attempts" ] || sleep 1
+    done
+    die "$context (reported after ${attempts} attempt(s): ${actual:-empty})"
+}
+
+PAT=""
+command -v "$GH_CLI" >/dev/null 2>&1 \
+    || die "$GH_CLI is not on PATH"
+
+# Repository runners remain dispatch-only. Automatic PR or merge-group work is
+# permitted only when the controller can prove that an organization runner
+# group admits the protected default-branch workflow and this repository alone.
+# The extra label prevents a selector for the restricted pool from matching an
+# older repository-level worker during a staged rollout.
+REGISTRATION_API="repos/${REPO}"
+RUNNER_URL="https://github.com/${REPO}"
+RUNNER_GROUP_ARG=""
+if [ -n "$RUNNER_GROUP_ID" ]; then
+    [[ "$RUNNER_GROUP_ID" =~ ^[0-9]+$ ]] \
+        || die "PULP_LINUX_RUNNER_GROUP_ID must be numeric"
+    [ "$RUNNER_GROUP_ID" != 1 ] \
+        || die "runner group 1 is the default group"
+    [ -r "$GROUP_VERIFIER" ] \
+        || die "runner-group verifier is missing at $GROUP_VERIFIER"
+    [ -r "$ORG_PAT_FILE" ] \
+        || die "automatic Linux runner organization PAT is missing"
+    PAT="$(cat "$ORG_PAT_FILE")"
+    case "$RUNNER_GROUP_PROFILE" in
+        trusted)
+            LABELS="self-hosted,Linux,X64,pulp-build-linux-x64,pulp-host-macpro,pulp-auto-linux-x64"
+            ;;
+        pr-safe)
+            LABELS="self-hosted,Linux,X64,pulp-build-linux-x64,pulp-host-macpro,pulp-pr-safe-linux-x64"
+            ;;
+        *)
+            die "PULP_LINUX_RUNNER_GROUP_PROFILE must be trusted or pr-safe"
+            ;;
+    esac
+    GROUP_NAME="$(GH_TOKEN="$PAT" python3 "$GROUP_VERIFIER" \
+        --gh "$GH_CLI" --repo "$REPO" --group-id "$RUNNER_GROUP_ID" \
+        --profile "$RUNNER_GROUP_PROFILE")" \
+        || die "automatic Linux runner group policy is not fail-closed"
+    [ -n "$GROUP_NAME" ] || die "runner-group verifier returned an empty name"
+    command -v "$FIREWALL_STATUS_BIN" >/dev/null 2>&1 \
+        || die "$FIREWALL_STATUS_BIN is not on PATH"
+    for tool in iptables-save ip6tables-save ipset ebtables-save; do
+        command -v "$tool" >/dev/null 2>&1 \
+            || die "$tool is required for automatic runner firewall proof"
+    done
+    require_firewall_running \
+        "automatic Linux runners require the Proxmox firewall"
+    [ -d "$FIREWALL_DIR" ] \
+        || die "automatic Linux runner firewall directory is missing"
+    REGISTRATION_API="orgs/${ORG}"
+    RUNNER_URL="https://github.com/${ORG}"
+    RUNNER_GROUP_ARG="--runnergroup ${GROUP_NAME}"
+    AUTOMATIC_NETWORK_ISOLATION=1
+else
+    [ -r "$PAT_FILE" ] || die "no repository runner PAT at $PAT_FILE"
+    PAT="$(cat "$PAT_FILE")"
+fi
 # ── admission ────────────────────────────────────────────────────────────────
 # Ask before taking. A refused job queues on GitHub, which is recoverable; an
 # oversubscribed host that stops responding is not.
@@ -73,8 +165,35 @@ done
 SLOT_INDEX=$((VMID - CLONE_BASE))
 GUEST_IP="${GUEST_IPV4_PREFIX}.$((GUEST_IPV4_FIRST_OCTET + SLOT_INDEX))"
 printf -v GUEST_MAC '02:50:55:4c:50:%02x' "$SLOT_INDEX"
-RUNNER_NAME="pulp-ci-ephemeral-${VMID}-$(cat /proc/sys/kernel/random/uuid)"
+# The slot identity is stable for operations and metrics. The GitHub
+# registration name is intentionally unique per boot so an interrupted runner
+# cannot collide with its replacement.
+RUNNER_SLOT_ID="macpro-linux-${VMID}"
+RUNNER_NAME="${RUNNER_NAME_PREFIX}-${VMID}-$(cat /proc/sys/kernel/random/uuid)"
 
+reclaim_stale_slot_runners() {
+    [ -n "${PAT:-}" ] || return 0
+    local runners_tsv slot_matches match_count stale_id stale_name stale_busy stale_status
+    runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
+        "${REGISTRATION_API}/actions/runners?per_page=100" \
+        --jq '.runners[] | [.id,.name,.busy,.status] | @tsv')" \
+        || die "cannot inspect all runner registrations for ${RUNNER_SLOT_ID}"
+    slot_matches="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
+        -v prefix="${RUNNER_NAME_PREFIX}-${VMID}-" 'index($2, prefix) == 1')"
+    [ -n "$slot_matches" ] || return 0
+    match_count="$(printf '%s\n' "$slot_matches" | wc -l | tr -d ' ')"
+    [ "$match_count" = 1 ] \
+        || die "multiple registrations claim ${RUNNER_SLOT_ID}"
+    IFS=$'\t' read -r stale_id stale_name stale_busy stale_status <<< "$slot_matches"
+    [ "$stale_busy" = false ] \
+        || die "registration $stale_name is busy or has an invalid busy state"
+    [ "$stale_status" = offline ] \
+        || die "registration $stale_name is not offline"
+    GH_TOKEN="$PAT" "$GH_CLI" api --method DELETE \
+        "${REGISTRATION_API}/actions/runners/${stale_id}" \
+        || die "could not reclaim offline registration $stale_name"
+    log "reclaimed offline stale registration $stale_name for ${RUNNER_SLOT_ID}"
+}
 cleanup() {
     # Guard: only tear down a VM this invocation actually created. Without this,
     # a failure before the clone lands makes cleanup destroy whatever now owns
@@ -89,37 +208,34 @@ cleanup() {
     # otherwise leave an offline ghost runner that GitHub still schedules to —
     # jobs then queue against a VM that no longer exists.
     if [ -n "${PAT:-}" ]; then
-        runners_json="$(curl -fSs -H "Authorization: Bearer $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/actions/runners?per_page=100" 2>/dev/null)" \
-            || { log "ERROR: cannot read runner registrations; leaving clone $VMID for safe recovery"; return; }
-        runner_lookup="$(printf '%s' "$runners_json" | python3 -c "
-import json,sys
-try: d=json.load(sys.stdin)
-except Exception: sys.exit(1)
-for r in d.get('runners',[]):
-    if r['name']=='${RUNNER_NAME}': print('found:'+str(r['id'])); break
-else: print('not-found:'+str(d.get('total_count', 0)))
-" 2>/dev/null)" \
-            || { log "ERROR: cannot parse runner registrations; leaving clone $VMID for safe recovery"; return; }
-        if [[ "$runner_lookup" == found:* ]]; then
-            rid="${runner_lookup#found:}"
-            if ! curl -fSs -o /dev/null -X DELETE -H "Authorization: Bearer $PAT" \
-                -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${REPO}/actions/runners/${rid}"; then
+        runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
+            "${REGISTRATION_API}/actions/runners?per_page=100" \
+            --jq '.runners[] | [.id,.name,.busy,.status] | @tsv')" \
+            || { log "ERROR: cannot read all runner registrations; leaving clone $VMID for safe recovery"; return; }
+        runner_lookup="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
+            -v name="$RUNNER_NAME" '$2 == name')"
+        if [ -n "$runner_lookup" ]; then
+            [ "$(printf '%s\n' "$runner_lookup" | wc -l | tr -d ' ')" = 1 ] \
+                || { log "ERROR: duplicate exact runner registrations; leaving clone $VMID for safe recovery"; return; }
+            IFS=$'\t' read -r rid _ runner_busy runner_status <<< "$runner_lookup"
+            [ "$runner_busy" = false ] && [ "$runner_status" = offline ] \
+                || { log "ERROR: exact runner is not offline and idle; leaving clone $VMID for safe recovery"; return; }
+            if ! GH_TOKEN="$PAT" "$GH_CLI" api --method DELETE \
+                "${REGISTRATION_API}/actions/runners/${rid}"; then
                 log "ERROR: cannot deregister runner id $rid; leaving clone $VMID for safe recovery"
                 return
             fi
             log "deregistered runner id $rid"
-        elif [ "${runner_lookup#not-found:}" -gt 100 ]; then
-            log "ERROR: runner lookup exceeded one API page; leaving clone $VMID for safe recovery"
-            return
         fi
     fi
     log "destroying clone $VMID"
     qm stop "$VMID" >/dev/null 2>&1 || true
     for _ in $(seq 1 24); do [ "$(qm status "$VMID" 2>/dev/null)" = "status: stopped" ] && break; sleep 5; done
-    qm destroy "$VMID" --purge >/dev/null 2>&1 || log "WARN: destroy of $VMID failed — check manually"
+    if qm destroy "$VMID" --purge >/dev/null 2>&1; then
+        [ -n "${VM_FIREWALL_FILE:-}" ] && rm -f "$VM_FIREWALL_FILE"
+    else
+        log "WARN: destroy of $VMID failed — check manually"
+    fi
     [ -n "${GUEST_IP:-}" ] && ssh-keygen -f /root/.ssh/known_hosts -R "$GUEST_IP" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -128,7 +244,7 @@ trap cleanup EXIT
 # Linked clone: near-instant and thin, because the golden's 120G disk is shared
 # copy-on-write. A full clone would copy 120G per job and defeat the purpose.
 log "linked-cloning golden $GOLDEN -> $VMID"
-if ! qm clone "$GOLDEN" "$VMID" --name "pulp-ci-ephemeral-$VMID" >/dev/null 2>&1; then
+if ! qm clone "$GOLDEN" "$VMID" --name "${VM_NAME_PREFIX}-${VMID}" >/dev/null 2>&1; then
     flock -u 9
     die "clone failed"
 fi
@@ -141,13 +257,101 @@ CLONED=1
 # The id is now committed to disk (200.conf exists), so no other slot can pick
 # it. Safe to release before the slow boot/register/run phase.
 flock -u 9
+NET0="virtio=${GUEST_MAC},bridge=vmbr0"
+if [ "$AUTOMATIC_NETWORK_ISOLATION" = 1 ]; then
+    VM_FIREWALL_FILE="${FIREWALL_DIR}/${VMID}.fw"
+    VM_FIREWALL_TMP="$(mktemp)" \
+        || die "cannot allocate automatic runner firewall policy"
+    umask 077
+    if ! cat > "$VM_FIREWALL_TMP" <<EOF
+[OPTIONS]
+enable: 1
+ipfilter: 1
+policy_in: ACCEPT
+policy_out: ACCEPT
+
+[IPSET ipfilter-net0]
+${GUEST_IP}
+
+[RULES]
+OUT ACCEPT -dest ${GUEST_IPV4_GATEWAY} -p udp -dport 53
+OUT ACCEPT -dest ${GUEST_IPV4_GATEWAY} -p tcp -dport 53
+OUT DROP -dest 0.0.0.0/8
+OUT DROP -dest 10.0.0.0/8
+OUT DROP -dest 100.64.0.0/10
+OUT DROP -dest 127.0.0.0/8
+OUT DROP -dest 169.254.0.0/16
+OUT DROP -dest 172.16.0.0/12
+OUT DROP -dest 192.0.0.0/24
+OUT DROP -dest 192.0.2.0/24
+OUT DROP -dest 192.88.99.0/24
+OUT DROP -dest 192.168.0.0/16
+OUT DROP -dest 198.18.0.0/15
+OUT DROP -dest 198.51.100.0/24
+OUT DROP -dest 203.0.113.0/24
+OUT DROP -dest 224.0.0.0/4
+OUT DROP -dest 240.0.0.0/4
+OUT DROP -dest ::/0
+EOF
+    then
+        rm -f "$VM_FIREWALL_TMP"
+        die "cannot write automatic runner firewall policy"
+    fi
+    if ! cp "$VM_FIREWALL_TMP" "$VM_FIREWALL_FILE"; then
+        rm -f "$VM_FIREWALL_TMP"
+        die "cannot install automatic runner firewall policy"
+    fi
+    rm -f "$VM_FIREWALL_TMP"
+    NET0="${NET0},firewall=1"
+fi
 qm set "$VMID" --cores "$CORES" --memory "$MEM_MB" --cpulimit "$CORES" \
     --cpuunits 50 --balloon 0 --onboot 0 \
-    --net0 "virtio=${GUEST_MAC},bridge=vmbr0" \
+    --net0 "$NET0" \
     --ipconfig0 "ip=${GUEST_IP}/24,gw=${GUEST_IPV4_GATEWAY}" \
     --nameserver "$GUEST_IPV4_GATEWAY" >/dev/null \
     || die "failed to apply deterministic network identity to clone $VMID"
+if [ "$AUTOMATIC_NETWORK_ISOLATION" = 1 ]; then
+    "$FIREWALL_STATUS_BIN" compile >/dev/null \
+        || die "automatic runner firewall policy does not compile"
+    # Compiling a newly-created per-VM policy can briefly report pending state
+    # while the firewall daemon consumes the cluster filesystem update. Bound
+    # that convergence window; starting the guest still remains fail-closed.
+    require_firewall_running "automatic runner firewall policy is not active" 10
+fi
 qm start "$VMID" >/dev/null || die "start failed"
+if [ "$AUTOMATIC_NETWORK_ISOLATION" = 1 ]; then
+    firewall_active=0
+    blocked_ipv4=(
+        0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8
+        169.254.0.0/16 172.16.0.0/12 192.0.0.0/24 192.0.2.0/24
+        192.88.99.0/24 192.168.0.0/16 198.18.0.0/15
+        198.51.100.0/24 203.0.113.0/24 224.0.0.0/4 240.0.0.0/4
+    )
+    for _ in $(seq 1 15); do
+        iptables_rules="$(iptables-save 2>/dev/null)" || iptables_rules=""
+        ip6tables_rules="$(ip6tables-save 2>/dev/null)" || ip6tables_rules=""
+        ebtables_rules="$(ebtables-save 2>/dev/null)" || ebtables_rules=""
+        vm_out_rules="$(grep -F -- "-A tap${VMID}i0-OUT " <<< "$iptables_rules" || true)"
+        vm6_out_rules="$(grep -F -- "-A tap${VMID}i0-OUT " <<< "$ip6tables_rules" || true)"
+        vm_arp_rules="$(grep -F -- "-A tap${VMID}i0-OUT-ARP " <<< "$ebtables_rules" || true)"
+        all_ipv4_drops=1
+        for subnet in "${blocked_ipv4[@]}"; do
+            grep -Eq -- "-d ${subnet//./\\.}( .*)? -j DROP" <<< "$vm_out_rules" \
+                || { all_ipv4_drops=0; break; }
+        done
+        if [ "$all_ipv4_drops" = 1 ] \
+            && grep -Eq -- "^-A tap${VMID}i0-OUT( -d ::/0)? -j DROP$" <<< "$vm6_out_rules" \
+            && grep -Fq -- "--arp-ip-src ${GUEST_IP} -j RETURN" <<< "$vm_arp_rules" \
+            && grep -Fq -- "-A tap${VMID}i0-OUT-ARP -j DROP" <<< "$vm_arp_rules" \
+            && ipset test "PVEFW-${VMID}-ipfilter-net0-v4" "$GUEST_IP" >/dev/null 2>&1; then
+            firewall_active=1
+            break
+        fi
+        sleep 1
+    done
+    [ "$firewall_active" = 1 ] \
+        || die "automatic runner firewall rules are not installed"
+fi
 
 # ── wait for the guest ───────────────────────────────────────────────────────
 for _ in $(seq 1 45); do
@@ -162,6 +366,10 @@ log "clone $VMID up at $GUEST_IP"
 # The golden's host keys were cleared, so each clone presents a NEW key on a
 # possibly-recycled DHCP address. Drop any stale entry rather than failing.
 ssh-keygen -f /root/.ssh/known_hosts -R "$GUEST_IP" >/dev/null 2>&1 || true
+
+# Reclaim only offline registrations from this exact slot. Never delete a busy
+# runner and never search by a broad repository-wide prefix.
+reclaim_stale_slot_runners
 
 for _ in $(seq 1 20); do
     ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8 \
@@ -188,15 +396,15 @@ ssh -o BatchMode=yes "ci@$GUEST_IP" '
 log "minting registration token"
 RT="$(curl -s -X POST \
     -H "Authorization: Bearer $PAT" -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/${REPO}/actions/runners/registration-token" \
+    "https://api.github.com/${REGISTRATION_API}/actions/runners/registration-token" \
     | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token",""))')"
 [ -n "$RT" ] || die "could not mint a registration token (PAT scope or expiry?)"
 
-log "registering ephemeral runner on $VMID"
+log "registering ephemeral runner ${RUNNER_NAME} (slot ${RUNNER_SLOT_ID}) on $VMID"
 ssh -o BatchMode=yes "ci@$GUEST_IP" "
     cd ~/actions-runner
     ./config.sh --unattended --ephemeral --replace \
-      --url https://github.com/${REPO} --token ${RT} \
+      --url ${RUNNER_URL} --token ${RT} ${RUNNER_GROUP_ARG} \
       --name ${RUNNER_NAME} --labels ${LABELS} --work _work
 " >/dev/null 2>&1 || die "runner registration failed"
 

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -90,7 +90,6 @@ command -v "$GH_CLI" >/dev/null 2>&1 \
 # older repository-level worker during a staged rollout.
 REGISTRATION_API="repos/${REPO}"
 RUNNER_URL="https://github.com/${REPO}"
-RUNNER_GROUP_ARG=""
 if [ -n "$RUNNER_GROUP_ID" ]; then
     [[ "$RUNNER_GROUP_ID" =~ ^[0-9]+$ ]] \
         || die "PULP_LINUX_RUNNER_GROUP_ID must be numeric"
@@ -129,7 +128,6 @@ if [ -n "$RUNNER_GROUP_ID" ]; then
         || die "automatic Linux runner firewall directory is missing"
     REGISTRATION_API="orgs/${ORG}"
     RUNNER_URL="https://github.com/${ORG}"
-    RUNNER_GROUP_ARG="--runnergroup ${GROUP_NAME}"
     AUTOMATIC_NETWORK_ISOLATION=1
 else
     [ -r "$PAT_FILE" ] || die "no repository runner PAT at $PAT_FILE"
@@ -218,6 +216,7 @@ reclaim_stale_slot_runners() {
     log "reclaimed offline stale registration $stale_name for ${RUNNER_SLOT_ID}"
 }
 cleanup() {
+    rm -f "${JIT_RESPONSE_FILE:-}" "${JIT_CONFIG_FILE:-}"
     # Guard: only tear down a VM this invocation actually created. Without this,
     # a failure before the clone lands makes cleanup destroy whatever now owns
     # that id — which is exactly how the race above corrupted a sibling slot.
@@ -413,37 +412,73 @@ ssh -o BatchMode=yes "ci@$GUEST_IP" '
         | grep -Eq "^[[:space:]-]*Token:"
 ' || die "golden $GOLDEN lacks an uncredentialed gh CLI"
 
-# A registration token is minted per job and is single-use by design, which is
-# what makes --ephemeral viable: the runner takes exactly one job, deregisters
-# itself, and the clone is destroyed under it.
-log "minting registration token"
-RT="$(curl -s -X POST \
-    -H "Authorization: Bearer $PAT" -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/${REGISTRATION_API}/actions/runners/registration-token" \
-    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token",""))')"
-[ -n "$RT" ] || die "could not mint a registration token (PAT scope or expiry?)"
+# GitHub's JIT endpoint creates the exact ephemeral runner registration and
+# returns an encoded, single-use configuration. Keep that blob in a mode-600
+# temporary file and transfer it over stdin; unlike config.sh --token, the
+# short-lived credential never appears in the host's or SSH registration
+# command line. The runner takes exactly one job and then deregisters itself.
+log "minting JIT runner configuration"
+JIT_RESPONSE_FILE="$(mktemp)" || die "could not allocate JIT response file"
+JIT_CONFIG_FILE="$(mktemp)" || die "could not allocate JIT config file"
+umask 077
+JIT_PAYLOAD="$(python3 - "$RUNNER_NAME" "$RUNNER_GROUP_ID" "$LABELS" <<'PY'
+import json
+import sys
 
-log "registering ephemeral runner ${RUNNER_NAME} (slot ${RUNNER_SLOT_ID}) on $VMID"
-TOKEN_FILE=/tmp/tartci-jit-token
+name, group_id, labels = sys.argv[1:]
+payload = {
+    "name": name,
+    "runner_group_id": int(group_id or "1"),
+    "labels": [label for label in labels.split(",") if label],
+    "work_folder": "_work",
+}
+print(json.dumps(payload, separators=(",", ":")))
+PY
+)" || die "could not construct JIT runner request"
+curl -fsS -X POST \
+    -H "Authorization: Bearer $PAT" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/${REGISTRATION_API}/actions/runners/generate-jitconfig" \
+    -d "$JIT_PAYLOAD" >"$JIT_RESPONSE_FILE" \
+    || die "could not mint JIT runner configuration (PAT scope or expiry?)"
+unset JIT_PAYLOAD
+python3 - "$JIT_RESPONSE_FILE" "$JIT_CONFIG_FILE" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text())
+encoded = response.get("encoded_jit_config")
+if not isinstance(encoded, str) or not encoded:
+    raise SystemExit("JIT response did not contain encoded_jit_config")
+pathlib.Path(sys.argv[2]).write_text(encoded)
+PY
+if [ "$?" -ne 0 ]; then
+    die "JIT response did not contain a valid encoded configuration"
+fi
+
+log "starting ephemeral JIT runner ${RUNNER_NAME} (slot ${RUNNER_SLOT_ID}) on $VMID"
+JIT_GUEST_FILE=/tmp/tartci-jit-config
 ssh -o BatchMode=yes "ci@$GUEST_IP" \
-    "umask 077; install -m 600 /dev/stdin ${TOKEN_FILE}" <<<"$RT" \
-    || die "could not transfer the short-lived registration token"
-unset RT
+    "umask 077; install -m 600 /dev/stdin ${JIT_GUEST_FILE}" \
+    <"$JIT_CONFIG_FILE" \
+    || die "could not transfer the short-lived JIT configuration"
+rm -f "$JIT_CONFIG_FILE" "$JIT_RESPONSE_FILE"
+JIT_CONFIG_FILE=""
+JIT_RESPONSE_FILE=""
 registration_output="$(ssh -o BatchMode=yes "ci@$GUEST_IP" "
     cd ~/actions-runner
-    trap 'rm -f ${TOKEN_FILE}' EXIT
-    registration_token=\$(cat ${TOKEN_FILE})
-    ./config.sh --unattended --ephemeral --replace \
-      --url ${RUNNER_URL} --token \"\${registration_token}\" ${RUNNER_GROUP_ARG} \
-      --name ${RUNNER_NAME} --labels ${LABELS} --work _work
+    trap 'rm -f ${JIT_GUEST_FILE}' EXIT
+    encoded_jit_config=\$(cat ${JIT_GUEST_FILE})
+    ./run.sh --jitconfig \"\${encoded_jit_config}\"
 ")" || {
-    printf '%s\n' "$registration_output" | sed 's/[Tt]oken[^[:space:]]*/token=<redacted>/g' >&2
-    die "runner registration failed"
+    printf '%s\n' "$registration_output" | sed 's/[Jj][Ii][Tt].*/JIT output=<redacted>/g' >&2
+    die "JIT runner startup failed"
 }
 
 # ── run exactly one job ──────────────────────────────────────────────────────
-# run.sh exits once the single job completes, because of --ephemeral.
+# run.sh exits once the single JIT job completes.
 log "waiting for one job (runner exits when done)"
-ssh -o BatchMode=yes "ci@$GUEST_IP" 'cd ~/actions-runner && ./run.sh' 2>&1 \
-    | sed 's/^/    /'
+printf '%s\n' "$registration_output" | sed 's/^/    /'
 log "job finished on $VMID"

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -44,7 +44,7 @@ GROUP_VERIFIER="${TARTCI_RUNNER_GROUP_VERIFIER:-${PULP_LINUX_GROUP_VERIFIER:-/us
 GH_CLI="${TARTCI_GH_CLI:-${PULP_LINUX_GH_CLI:-gh}}"
 FIREWALL_STATUS_BIN="${PULP_LINUX_FIREWALL_STATUS_BIN:-pve-firewall}"
 FIREWALL_DIR="${PULP_LINUX_FIREWALL_DIR:-/etc/pve/firewall}"
-AUTOMATIC_NETWORK_ISOLATION=0
+AUTOMATIC_NETWORK_ISOLATION="${TARTCI_RUNNER_NETWORK_ISOLATION:-0}"
 KEEP=0
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
@@ -134,6 +134,18 @@ if [ -n "$RUNNER_GROUP_ID" ]; then
 else
     [ -r "$PAT_FILE" ] || die "no repository runner PAT at $PAT_FILE"
     PAT="$(cat "$PAT_FILE")"
+fi
+if [ "$AUTOMATIC_NETWORK_ISOLATION" = 1 ]; then
+    command -v "$FIREWALL_STATUS_BIN" >/dev/null 2>&1 \
+        || die "$FIREWALL_STATUS_BIN is not on PATH"
+    for tool in iptables-save ip6tables-save ipset ebtables-save; do
+        command -v "$tool" >/dev/null 2>&1 \
+            || die "$tool is required for automatic runner firewall proof"
+    done
+    require_firewall_running \
+        "isolated Linux runners require the Proxmox firewall"
+    [ -d "$FIREWALL_DIR" ] \
+        || die "isolated Linux runner firewall directory is missing"
 fi
 # ── admission ────────────────────────────────────────────────────────────────
 # Ask before taking. A refused job queues on GitHub, which is recoverable; an

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -413,10 +413,17 @@ RT="$(curl -s -X POST \
 [ -n "$RT" ] || die "could not mint a registration token (PAT scope or expiry?)"
 
 log "registering ephemeral runner ${RUNNER_NAME} (slot ${RUNNER_SLOT_ID}) on $VMID"
+TOKEN_FILE=/tmp/tartci-jit-token
+ssh -o BatchMode=yes "ci@$GUEST_IP" \
+    "umask 077; install -m 600 /dev/stdin ${TOKEN_FILE}" <<<"$RT" \
+    || die "could not transfer the short-lived registration token"
+unset RT
 registration_output="$(ssh -o BatchMode=yes "ci@$GUEST_IP" "
     cd ~/actions-runner
+    trap 'rm -f ${TOKEN_FILE}' EXIT
+    registration_token=\$(cat ${TOKEN_FILE})
     ./config.sh --unattended --ephemeral --replace \
-      --url ${RUNNER_URL} --token ${RT} ${RUNNER_GROUP_ARG} \
+      --url ${RUNNER_URL} --token \"\${registration_token}\" ${RUNNER_GROUP_ARG} \
       --name ${RUNNER_NAME} --labels ${LABELS} --work _work
 ")" || {
     printf '%s\n' "$registration_output" | sed 's/[Tt]oken[^[:space:]]*/token=<redacted>/g' >&2

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -467,18 +467,67 @@ ssh -o BatchMode=yes "ci@$GUEST_IP" \
 rm -f "$JIT_CONFIG_FILE" "$JIT_RESPONSE_FILE"
 JIT_CONFIG_FILE=""
 JIT_RESPONSE_FILE=""
-registration_output="$(ssh -o BatchMode=yes "ci@$GUEST_IP" "
+RUNNER_OUTPUT_FILE="$(mktemp)" || die "could not allocate runner output file"
+ssh -o BatchMode=yes "ci@$GUEST_IP" "
     cd ~/actions-runner
     trap 'rm -f ${JIT_GUEST_FILE}' EXIT
     encoded_jit_config=\$(cat ${JIT_GUEST_FILE})
     ./run.sh --jitconfig \"\${encoded_jit_config}\"
-")" || {
-    printf '%s\n' "$registration_output" | sed 's/[Jj][Ii][Tt].*/JIT output=<redacted>/g' >&2
-    die "JIT runner startup failed"
-}
+" >"$RUNNER_OUTPUT_FILE" 2>&1 &
+RUNNER_PID=$!
+
+# A JIT process existing in the guest is not proof that GitHub can dispatch to
+# it. Poll the exact registration while the run.sh child is starting, and fail
+# closed if it never becomes visible. Without this bounded admission check a
+# broker/network failure leaves a VM and supervisor alive while the repository
+# reports zero runners, falsely consuming local capacity and hiding the real
+# fallback path.
+RUNNER_READY_TIMEOUT_SECONDS="${TARTCI_RUNNER_READY_TIMEOUT_SECONDS:-120}"
+RUNNER_READY=0
+for _ in $(seq 1 "$((RUNNER_READY_TIMEOUT_SECONDS / 2))"); do
+    runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
+        "${REGISTRATION_API}/actions/runners?per_page=100" \
+        --jq '.runners[] | [.id,.name,.status,.busy] | @tsv' 2>/dev/null)" \
+        || runners_tsv=""
+    runner_lookup="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
+        -v name="$RUNNER_NAME" '$2 == name')"
+    if [ -n "$runner_lookup" ]; then
+        IFS=$'\t' read -r _ready_id _ready_name ready_status ready_busy \
+            <<< "$runner_lookup"
+        if [ "$ready_status" = online ]; then
+            RUNNER_READY=1
+            log "JIT runner ${RUNNER_NAME} is visible to GitHub (${ready_status}, busy=${ready_busy})"
+            break
+        fi
+    fi
+    if ! kill -0 "$RUNNER_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 2
+done
+if [ "$RUNNER_READY" != 1 ]; then
+    kill "$RUNNER_PID" 2>/dev/null || true
+    wait "$RUNNER_PID" 2>/dev/null || true
+    printf '%s\n' "$(tail -40 "$RUNNER_OUTPUT_FILE" 2>/dev/null)" \
+        | sed -E 's/(token|authorization|credentials|jitconfig)[^ ]*/\1=<redacted>/Ig' >&2
+    rm -f "$RUNNER_OUTPUT_FILE"
+    die "JIT runner ${RUNNER_NAME} never became visible to GitHub"
+fi
+
+wait "$RUNNER_PID"
+runner_exit=$?
+registration_output="$(cat "$RUNNER_OUTPUT_FILE")"
+rm -f "$RUNNER_OUTPUT_FILE"
+if [ "$runner_exit" -ne 0 ]; then
+    printf '%s\n' "$registration_output" \
+        | sed -E 's/(token|authorization|credentials|jitconfig)[^ ]*/\1=<redacted>/Ig' >&2
+    die "JIT runner exited with status $runner_exit"
+fi
 
 # ── run exactly one job ──────────────────────────────────────────────────────
 # run.sh exits once the single JIT job completes.
 log "waiting for one job (runner exits when done)"
-printf '%s\n' "$registration_output" | sed 's/^/    /'
+printf '%s\n' "$registration_output" \
+    | sed -E 's/(token|authorization|credentials|jitconfig)[^ ]*/\1=<redacted>/Ig' \
+    | sed 's/^/    /'
 log "job finished on $VMID"

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -196,7 +196,7 @@ reclaim_stale_slot_runners() {
     [ -n "${PAT:-}" ] || return 0
     local runners_tsv slot_matches match_count stale_id stale_name stale_busy stale_status
     runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
-        "${REGISTRATION_API}/actions/runners?per_page=100" \
+        "${REGISTRATION_API}/actions/runners?per_page=100&cachebust=$(date +%s)" \
         --jq '.runners[] | [.id,.name,.busy,.status] | @tsv')" \
         || die "cannot inspect all runner registrations for ${RUNNER_SLOT_ID}"
     slot_matches="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
@@ -231,7 +231,7 @@ cleanup() {
     # jobs then queue against a VM that no longer exists.
     if [ -n "${PAT:-}" ]; then
         runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
-            "${REGISTRATION_API}/actions/runners?per_page=100" \
+            "${REGISTRATION_API}/actions/runners?per_page=100&cachebust=$(date +%s)" \
             --jq '.runners[] | [.id,.name,.busy,.status] | @tsv')" \
             || { log "ERROR: cannot read all runner registrations; leaving clone $VMID for safe recovery"; return; }
         runner_lookup="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
@@ -486,7 +486,7 @@ RUNNER_READY_TIMEOUT_SECONDS="${TARTCI_RUNNER_READY_TIMEOUT_SECONDS:-120}"
 RUNNER_READY=0
 for _ in $(seq 1 "$((RUNNER_READY_TIMEOUT_SECONDS / 2))"); do
     runners_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
-        "${REGISTRATION_API}/actions/runners?per_page=100" \
+        "${REGISTRATION_API}/actions/runners?per_page=100&cachebust=$(date +%s)" \
         --jq '.runners[] | [.id,.name,.status,.busy] | @tsv' 2>/dev/null)" \
         || runners_tsv=""
     runner_lookup="$(printf '%s\n' "$runners_tsv" | awk -F '\t' \
@@ -514,10 +514,54 @@ if [ "$RUNNER_READY" != 1 ]; then
     die "JIT runner ${RUNNER_NAME} never became visible to GitHub"
 fi
 
+# Keep the one-shot supervisor from waiting forever on a runner that registered
+# successfully but then lost its Actions broker heartbeat. Two consecutive
+# misses avoid reacting to a single API race; an idle/offline runner is safe to
+# tear down, while a busy one is left for the exact recovery path.
+HEARTBEAT_FAILURE_FILE="$(mktemp)" || die "could not allocate heartbeat state"
+(
+    misses=0
+    while kill -0 "$RUNNER_PID" 2>/dev/null; do
+        heartbeat_tsv="$(GH_TOKEN="$PAT" "$GH_CLI" api --paginate \
+            "${REGISTRATION_API}/actions/runners?per_page=100&cachebust=$(date +%s)" \
+            --jq '.runners[] | [.id,.name,.status,.busy] | @tsv' 2>/dev/null)" \
+            || heartbeat_tsv=""
+        heartbeat_lookup="$(printf '%s\n' "$heartbeat_tsv" | awk -F '\t' \
+            -v name="$RUNNER_NAME" '$2 == name')"
+        heartbeat_status=""
+        heartbeat_busy=""
+        if [ -n "$heartbeat_lookup" ]; then
+            IFS=$'\t' read -r _heartbeat_id _heartbeat_name heartbeat_status heartbeat_busy \
+                <<< "$heartbeat_lookup"
+        fi
+        if [ "$heartbeat_status" = online ] || [ "$heartbeat_busy" = true ]; then
+            misses=0
+        else
+            misses=$((misses + 1))
+            if [ "$misses" -ge 2 ]; then
+                printf '%s\n' "runner=${RUNNER_NAME} status=${heartbeat_status:-missing} busy=${heartbeat_busy:-unknown}" \
+                    >"$HEARTBEAT_FAILURE_FILE"
+                kill "$RUNNER_PID" 2>/dev/null || true
+                break
+            fi
+        fi
+        sleep 15
+    done
+) &
+HEARTBEAT_PID=$!
+
 wait "$RUNNER_PID"
 runner_exit=$?
+kill "$HEARTBEAT_PID" 2>/dev/null || true
+wait "$HEARTBEAT_PID" 2>/dev/null || true
 registration_output="$(cat "$RUNNER_OUTPUT_FILE")"
 rm -f "$RUNNER_OUTPUT_FILE"
+heartbeat_failure="$(cat "$HEARTBEAT_FAILURE_FILE" 2>/dev/null || true)"
+rm -f "$HEARTBEAT_FAILURE_FILE"
+if [ -n "$heartbeat_failure" ]; then
+    log "ERROR: JIT runner lost GitHub heartbeat ($heartbeat_failure)"
+    die "JIT runner heartbeat failed before the job completed"
+fi
 if [ "$runner_exit" -ne 0 ]; then
     printf '%s\n' "$registration_output" \
         | sed -E 's/(token|authorization|credentials|jitconfig)[^ ]*/\1=<redacted>/Ig' >&2

--- a/tools/ci/proxmox-ephemeral-runner-linux.sh
+++ b/tools/ci/proxmox-ephemeral-runner-linux.sh
@@ -26,7 +26,7 @@ GOLDEN="${TARTCI_PROXMOX_GOLDEN:-${PULP_LINUX_GOLDEN:-9005}}"
 CLONE_BASE="${TARTCI_PROXMOX_CLONE_BASE:-200}" # pool slots, clear of persistent VMs
 CLONE_MAX="${TARTCI_PROXMOX_CLONE_MAX:-202}"
 GUEST_IPV4_PREFIX=192.168.86
-GUEST_IPV4_FIRST_OCTET=251
+GUEST_IPV4_FIRST_OCTET="${TARTCI_PROXMOX_GUEST_IPV4_FIRST_OCTET:-${PULP_PROXMOX_GUEST_IPV4_FIRST_OCTET:-251}}"
 GUEST_IPV4_GATEWAY=192.168.86.1
 CORES=4
 MEM_MB=8192
@@ -177,6 +177,14 @@ done
 SLOT_INDEX=$((VMID - CLONE_BASE))
 GUEST_IP="${GUEST_IPV4_PREFIX}.$((GUEST_IPV4_FIRST_OCTET + SLOT_INDEX))"
 printf -v GUEST_MAC '02:50:55:4c:50:%02x' "$SLOT_INDEX"
+
+for existing_vmid in $(qm list 2>/dev/null | awk 'NR > 1 {print $1}'); do
+    [ "$existing_vmid" = "$VMID" ] && continue
+    existing_ip="$(qm config "$existing_vmid" 2>/dev/null \
+        | sed -n 's/^ipconfig0:.*ip=\([^/,]*\).*/\1/p')"
+    [ "$existing_ip" = "$GUEST_IP" ] \
+        && die "guest IP ${GUEST_IP} is already assigned to VM ${existing_vmid}"
+done
 # The slot identity and GitHub registration name are stable. Reusing the same
 # name per repository/slot makes the fleet auditable and prevents registration
 # churn; cleanup reclaims only a confirmed offline registration for this exact

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -40,10 +40,14 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         ):
             self.assertIn(marker, self.text)
 
-    def test_jit_token_does_not_travel_in_the_ssh_command_line(self) -> None:
+    def test_jit_config_does_not_use_registration_token_path(self) -> None:
+        self.assertIn("actions/runners/generate-jitconfig", self.text)
+        self.assertIn("encoded_jit_config", self.text)
         self.assertIn("install -m 600 /dev/stdin", self.text)
-        self.assertIn("TOKEN_FILE=/tmp/tartci-jit-token", self.text)
-        self.assertNotIn("--token ${RT}", self.text)
+        self.assertIn("JIT_GUEST_FILE=/tmp/tartci-jit-config", self.text)
+        self.assertIn("./run.sh --jitconfig", self.text)
+        self.assertNotIn("registration-token", self.text)
+        self.assertNotIn("config.sh --unattended", self.text)
         self.assertIn("guest IP ${GUEST_IP} is already assigned", self.text)
 
 

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Static contract tests for the repository-agnostic Proxmox runner."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("proxmox-ephemeral-runner-linux.sh")
+
+
+class ProxmoxRunnerContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = SCRIPT.read_text()
+
+    def test_repository_identity_is_overrideable(self) -> None:
+        self.assertIn('TARTCI_RUNNER_REPO:-${PULP_RUNNER_REPO:-Generous-Corp/pulp}', self.text)
+        self.assertIn('TARTCI_RUNNER_LABELS:-${PULP_RUNNER_LABELS:-', self.text)
+        self.assertIn('TARTCI_RUNNER_PAT_FILE:-${PULP_RUNNER_PAT_FILE:-', self.text)
+
+    def test_runner_and_vm_names_are_not_pulp_hard_coded(self) -> None:
+        self.assertIn('TARTCI_RUNNER_NAME_PREFIX:-', self.text)
+        self.assertIn('TARTCI_PROXMOX_VM_NAME_PREFIX:-', self.text)
+        self.assertNotRegex(self.text, r'--name "pulp-ci-ephemeral-\$VMID"')
+
+    def test_command_overrides_are_available_for_one_shot_proof(self) -> None:
+        for option in ("--repo", "--labels", "--golden", "--name-prefix", "--once"):
+            self.assertRegex(self.text, rf'{re.escape(option)}\)')
+
+    def test_isolation_guards_remain_in_the_generic_path(self) -> None:
+        for marker in (
+            "--ephemeral",
+            "AUTOMATIC_NETWORK_ISOLATION=1",
+            "deregistered runner id",
+            "destroying clone",
+        ):
+            self.assertIn(marker, self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -30,6 +30,7 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
     def test_isolation_guards_remain_in_the_generic_path(self) -> None:
         for marker in (
             "--ephemeral",
+            "TARTCI_RUNNER_NETWORK_ISOLATION",
             "AUTOMATIC_NETWORK_ISOLATION=1",
             "deregistered runner id",
             "destroying clone",

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -51,6 +51,13 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertNotIn("config.sh --unattended", self.text)
         self.assertIn("guest IP ${GUEST_IP} is already assigned", self.text)
 
+    def test_jit_runner_requires_github_visible_readiness(self) -> None:
+        self.assertIn("TARTCI_RUNNER_READY_TIMEOUT_SECONDS", self.text)
+        self.assertIn("never became visible to GitHub", self.text)
+        self.assertIn('ready_status" = online', self.text)
+        self.assertIn('kill "$RUNNER_PID"', self.text)
+        self.assertIn('wait "$RUNNER_PID"', self.text)
+
     def test_systemd_profile_is_repository_agnostic(self) -> None:
         service = SERVICE.read_text()
         self.assertIn("/etc/pulp/proxmox-runner/%i.env", service)

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -22,6 +22,8 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertIn('TARTCI_RUNNER_NAME_PREFIX:-', self.text)
         self.assertIn('TARTCI_PROXMOX_VM_NAME_PREFIX:-', self.text)
         self.assertNotRegex(self.text, r'--name "pulp-ci-ephemeral-\$VMID"')
+        self.assertIn('RUNNER_NAME="${RUNNER_NAME_PREFIX}-${VMID}"', self.text)
+        self.assertIn("runner name exceeds GitHub's 64-character limit", self.text)
 
     def test_command_overrides_are_available_for_one_shot_proof(self) -> None:
         for option in ("--repo", "--labels", "--golden", "--name-prefix", "--once"):

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -59,6 +59,12 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertIn('kill "$RUNNER_PID"', self.text)
         self.assertIn('wait "$RUNNER_PID"', self.text)
 
+    def test_jit_runner_has_bounded_heartbeat_watchdog(self) -> None:
+        self.assertIn("HEARTBEAT_FAILURE_FILE", self.text)
+        self.assertIn("cachebust=$(date +%s)", self.text)
+        self.assertIn("lost GitHub heartbeat", self.text)
+        self.assertIn("misses=$((misses + 1))", self.text)
+
     def test_systemd_profile_is_repository_agnostic(self) -> None:
         service = SERVICE.read_text()
         self.assertIn("/etc/pulp/proxmox-runner/%i.env", service)

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -25,6 +25,7 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertNotRegex(self.text, r'--name "pulp-ci-ephemeral-\$VMID"')
         self.assertIn('RUNNER_NAME="${RUNNER_NAME_PREFIX}-${VMID}"', self.text)
         self.assertIn("runner name exceeds GitHub's 64-character limit", self.text)
+        self.assertIn('-v name="$RUNNER_NAME" \'$2 == name\'', self.text)
 
     def test_command_overrides_are_available_for_one_shot_proof(self) -> None:
         for option in ("--repo", "--labels", "--golden", "--name-prefix", "--once"):

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -37,6 +37,11 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         ):
             self.assertIn(marker, self.text)
 
+    def test_jit_token_does_not_travel_in_the_ssh_command_line(self) -> None:
+        self.assertIn("install -m 600 /dev/stdin", self.text)
+        self.assertIn("TOKEN_FILE=/tmp/tartci-jit-token", self.text)
+        self.assertNotIn("--token ${RT}", self.text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -7,6 +7,7 @@ import unittest
 
 
 SCRIPT = Path(__file__).with_name("proxmox-ephemeral-runner-linux.sh")
+SERVICE = Path(__file__).with_name("proxmox-ephemeral-pool@.service")
 
 
 class ProxmoxRunnerContractTests(unittest.TestCase):
@@ -49,6 +50,12 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertNotIn("registration-token", self.text)
         self.assertNotIn("config.sh --unattended", self.text)
         self.assertIn("guest IP ${GUEST_IP} is already assigned", self.text)
+
+    def test_systemd_profile_is_repository_agnostic(self) -> None:
+        service = SERVICE.read_text()
+        self.assertIn("/etc/pulp/proxmox-runner/%i.env", service)
+        self.assertIn("proxmox-ephemeral-runner-linux.sh --once", service)
+        self.assertNotIn("pulp-ephemeral-runner.sh", service)
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_proxmox_ephemeral_runner_linux.py
+++ b/tools/ci/test_proxmox_ephemeral_runner_linux.py
@@ -33,6 +33,7 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         for marker in (
             "--ephemeral",
             "TARTCI_RUNNER_NETWORK_ISOLATION",
+            "TARTCI_PROXMOX_GUEST_IPV4_FIRST_OCTET",
             "AUTOMATIC_NETWORK_ISOLATION=1",
             "deregistered runner id",
             "destroying clone",
@@ -43,6 +44,7 @@ class ProxmoxRunnerContractTests(unittest.TestCase):
         self.assertIn("install -m 600 /dev/stdin", self.text)
         self.assertIn("TOKEN_FILE=/tmp/tartci-jit-token", self.text)
         self.assertNotIn("--token ${RT}", self.text)
+        self.assertIn("guest IP ${GUEST_IP} is already assigned", self.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make the disposable Proxmox Linux supervisor repository/label/credential driven while preserving Pulp defaults;
- support one-shot overrides for new repository proofs and stable VM/runner naming;
- document new-project and existing-worktree reuse, with hosted fallback until proof;
- add contract tests for isolation and repository overrides.

## Validation
- `bash -n tools/ci/proxmox-ephemeral-runner-linux.sh`
- `python3 tools/ci/test_proxmox_ephemeral_runner_linux.py`
- `git diff --check`

This is intended to let Vellum use a separate repository-scoped Mac Pro proof lane without touching Pulp's existing services or trusted labels.
