### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.432.0",
+      "version": "0.432.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.432.0"
+  "version": "0.432.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.432.0",
+  "version": "0.432.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.810.0
+    VERSION 0.810.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4494,7 +4494,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.432.0",
+        "version": "0.432.1",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4509,13 +4509,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.432.0",
+        "catalog_version": "0.432.1",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.432.0",
+        "version": "0.432.1",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 8948bb7347a1..a527163def38.
sdk 0.810.0->0.810.1 (patch); plugin 0.432.0->0.432.1 (patch)

Version-Bump-Applied: a527163def38e2c055357ca79c66f4740229b6ae

<!-- whence {"labels": ["1·codex", "2·m3", "3·pre-colo", "4·DSP", "5·unresolved"], "prov": {"agent": "codex", "tab": "DSP", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `pre-colo` |
| **Tab** | DSP |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a01d48-922d-7a92-8e49-40876ef346f6` |

**Resume**
```
codex resume 01a01d48-922d-7a92-8e49-40876ef346f6
```
**Jump to this tab**
```
cmux surface focus 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```

<sub>stamped 2026-08-20 13:18 UTC</sub>
<!-- /whence -->