### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.433.9",
+      "version": "0.433.10",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.433.9"
+  "version": "0.433.10"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.433.9",
+  "version": "0.433.10",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.811.7
+    VERSION 0.811.8
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4494,7 +4494,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.433.9",
+        "version": "0.433.10",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4509,13 +4509,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.433.9",
+        "catalog_version": "0.433.10",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.433.9",
+        "version": "0.433.10",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 28425cd18a99..59c992eff894.
sdk 0.811.7->0.811.8 (patch); plugin 0.433.9->0.433.10 (patch)

Version-Bump-Applied: 59c992eff8946e4067cec49b4124c77ea14fb516
