### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.434.0",
+      "version": "0.434.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.434.0"
+  "version": "0.434.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.434.0",
+  "version": "0.434.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4494,7 +4494,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.434.0",
+        "version": "0.434.1",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4509,13 +4509,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.434.0",
+        "catalog_version": "0.434.1",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.434.0",
+        "version": "0.434.1",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 64aba0a77c78..3708cccca9bf.
plugin 0.434.0->0.434.1 (patch)

Version-Bump-Applied: 3708cccca9bf2dc39119fdcc09763eb8683cd166

<!-- whence {"labels": ["1·codex", "2·m3", "3·SYLF · Delivery", "4·DSP Survey · 003/010/15…", "5·unresolved"], "prov": {"agent": "codex", "tab": "DSP Survey · 003/010/151 · Active", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `SYLF · Delivery` |
| **Tab** | DSP Survey · 003/010/151 · Active |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a02190-87b6-77e3-89c7-98f76a95d4f6` |

**Resume**
```
codex resume 01a02190-87b6-77e3-89c7-98f76a95d4f6
```
**Jump to this tab**
```
cmux surface focus 21A2C51D-8015-4132-BEA1-1156361ACBC2
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 21A2C51D-8015-4132-BEA1-1156361ACBC2
```

<sub>stamped 2026-08-28 19:30 UTC</sub>
<!-- /whence -->