### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMacOsArch.cmake)  # macOS ar
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpMinOs.cmake)
 
 project(Pulp
-    VERSION 0.829.1
+    VERSION 0.830.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/Generous-Corp/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on e0407c4e71f4..d4ab59c883a9.
sdk 0.829.0->0.830.0 (minor)

Version-Bump-Applied: d4ab59c883a99b23d456e56ef9b6b6a0eebcb3ba
