### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.443.1",
+      "version": "0.443.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.443.1"
+  "version": "0.443.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.443.1",
+  "version": "0.443.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4675,7 +4675,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.1",
+        "version": "0.443.2",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4690,13 +4690,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.443.1",
+        "catalog_version": "0.443.2",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.1",
+        "version": "0.443.2",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on a1078457872e..781e1198f768.
plugin 0.443.1->0.443.2 (patch)

Version-Bump-Applied: 781e1198f768676672ebdc1bfcb88ee03c2da392
