### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.443.5",
+      "version": "0.443.6",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.443.5"
+  "version": "0.443.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.443.5",
+  "version": "0.443.6",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4675,7 +4675,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.5",
+        "version": "0.443.6",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4690,13 +4690,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.443.5",
+        "catalog_version": "0.443.6",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.5",
+        "version": "0.443.6",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on 7cc6bf4033e1..0f5fc78f21aa.
plugin 0.443.5->0.443.6 (patch)

Version-Bump-Applied: 0f5fc78f21aacc117b0121f02c005b6198252e7a
