### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.443.8",
+      "version": "0.443.9",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.443.8"
+  "version": "0.443.9"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.443.8",
+  "version": "0.443.9",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4679,7 +4679,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.8",
+        "version": "0.443.9",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4694,13 +4694,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.443.8",
+        "catalog_version": "0.443.9",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.443.8",
+        "version": "0.443.9",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on a7cb88e32205..468e29dcf4f4.
plugin 0.443.8->0.443.9 (patch)

Version-Bump-Applied: 468e29dcf4f4897c5ee9de346f7193407d3f7b11
