### PR TITLE
perf(materialized-runtime): stop rebuilding the path index per binding

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -6819,3 +6819,41 @@ Note the **Swift** emitter (`design_swift_codegen.cpp`) is a deliberate fourth
 lowering that shares only `resolve_design_ir_native` and re-derives the rest, so
 "all native lanes share X" is false for it. Plan for two full sharers (runtime +
 C++ baker), one partial (native-JS), and one non-sharer (Swift).
+
+## The materialized runtime pays its metadata cost on EVERY React commit
+
+`materialized_runtime_entry.mjs` reapplies import metadata from
+`resetAfterCommit` — every commit, not just mount. Two shapes inside it are
+therefore multiplied by the commit rate, and both read as "fine" in isolation:
+
+- `materializedNodeAtPath` used to rebuild its whole root/registry index per
+  **binding**, so one application cost O(bindings × registry).
+- `materializedMatches` re-parsed its selector text per **candidate node**, so
+  one registry scan cost regex work proportional to the node count rather than
+  to the selector vocabulary.
+
+Neither is visible at small registry sizes. A UI change that mounts a large
+always-present hidden subtree (a settings panel kept in the tree so keyboard
+traversal can reach it) triples the registry and turns both into a per-commit
+tax — which surfaces as unrelated-looking jank in whatever gesture happens to
+commit most often (a slider drag), not in the feature that grew the tree.
+
+The index is deliberately rebuilt once per application rather than cached
+across commits: a retained index resolves stale paths after any reparent. The
+selector parse memo has no such concern — a parse is a pure function of the
+selector text.
+
+**Guarding a change here:** `materializedMatches` is reachable from nearly every
+metadata binding, yet hard-breaking it leaves the dropdown arrow-traversal and
+settings cases GREEN. The case that actually catches it is *every native
+dropdown dismisses by Escape and outside press*. Run that one, not just the
+arrow cases, whenever this function changes.
+
+**Editing the file at all:** the runtime is returned as a single template
+literal (`const entry = \`…\`; return entry;`), so a regex in the source needs
+doubled backslashes (`\\[` emits `\[`), and a bare backtick or `${` anywhere in
+that region silently corrupts the emitted bundle. `node --check` does **not**
+catch that corruption — it exits 0 on truncated and broken files. Verify an
+emitted classic bundle with `vm.Script`, and an ESM source with a dynamic
+`import()` discriminating on `SyntaxError`; plant a break first and confirm the
+checker rejects it.

--- a/.github/vellum-expansion-watch-events/20260911-pr8223-materialized-commit-cost-watch.json
+++ b/.github/vellum-expansion-watch-events/20260911-pr8223-materialized-commit-cost-watch.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "authority-expansion-watch-change",
+  "event_id": "20260911-pr8223-materialized-commit-cost-watch",
+  "created_at": "2026-09-11T12:00:00Z",
+  "acceptance_id": "full-design-import-render-v1-pulp-watch",
+  "acceptance_sha256": "1535d76e34dfc80eda55247c1b0d47b9f47b3e58a08b6f1ab4b749692e6056fd",
+  "capability_families": [
+    "design-output-and-packaging",
+    "design-source-ingest"
+  ],
+  "rationale": "Record a Pulp-owned cost reduction in the materialized runtime's import-metadata reapplication, which runs from resetAfterCommit on every React commit. Two shapes scaled with the registry rather than with the work: materializedNodeAtPath rebuilt its root and registry index once per binding, giving O(bindings x registry) per commit, and materializedMatches re-parsed its selector text once per candidate node. Neither is visible at a small registry, and a downstream change that mounts a large always-present hidden subtree turns both into a per-commit tax that surfaces as interaction jank. The index is now built once per metadata application and passed down, and selector parses are memoized by selector text. The index is deliberately not cached across applications: it is a pure projection of the registry snapshot, and a retained index would resolve stale paths after any reparent, while every binding within one application reads the same snapshot. Resolution order, match semantics, and the emitted result are unchanged; this alters no design ingest, no captured output, no rendering or layout behavior, no packaging boundary, no accepted expansion boundary, and no Vellum source authority.",
+  "tests": [
+    "Spectr-native-n1-test \"[arrow-traversal],[arrow-nav]\"",
+    "Spectr-native-n1-test \"[dismissal],[modal-dismissal]\"",
+    "python3 tools/scripts/vellum_expansion_watch_check.py --base <PR base> --head HEAD",
+    "vellum-expansion-watch"
+  ],
+  "disposition": "watch-only-no-authority",
+  "authority_effect": "none"
+}

--- a/tools/import-design/jsx-runtime/materialized_runtime_entry.mjs
+++ b/tools/import-design/jsx-runtime/materialized_runtime_entry.mjs
@@ -199,13 +199,22 @@ function materializedElementChildren(node, registrySet) {
 function materializedNodeTag(node) {
   return String(node && node.tagName || '').toLowerCase();
 }
-function materializedNodeAtPath(binding, values) {
+function materializedPathIndex(values) {
   const registrySet = new Set(values);
   const roots = values.filter(node => {
     const parent = node && (node.parentElement || node._parentElement);
     return !parent || !registrySet.has(parent);
   });
-  let siblings = roots;
+  return { registrySet, roots };
+}
+// The index is a pure projection of the registry snapshot, so it is rebuilt
+// once per metadata application rather than cached across commits: a retained
+// index would resolve stale paths after any reparent, and every binding in a
+// single application reads the same snapshot anyway.
+function materializedNodeAtPath(binding, values, pathIndex) {
+  const index = pathIndex || materializedPathIndex(values);
+  const registrySet = index.registrySet;
+  let siblings = index.roots;
   let node = null;
   for (const step of binding.path) {
     node = siblings[step.index] || null;
@@ -227,6 +236,7 @@ function materializedOptionalTextNode(binding, values) {
 }
 function applyMaterializedImportMetadata(metadata) {
   const values = materializedDomRegistryValues();
+  const pathIndex = materializedPathIndex(values);
   const activeLayoutBindings = Array.isArray(metadata && metadata.layout_bindings)
     ? metadata.layout_bindings : [];
   const activeTextBindings = Array.isArray(metadata && metadata.text_bindings)
@@ -261,7 +271,7 @@ function applyMaterializedImportMetadata(metadata) {
   // their captured state contributes an equivalent binding.
   if (typeof g.setPosition === 'function' && typeof g.setFlex === 'function') {
     for (const binding of activeLayoutBindings) {
-      const node = materializedNodeAtPath(binding, values);
+      const node = materializedNodeAtPath(binding, values, pathIndex);
       const id = node && (node.__pulpId || node.id);
       if (!id) {
         ++diagnostics.layout_node_miss;
@@ -295,7 +305,7 @@ function applyMaterializedImportMetadata(metadata) {
   // attributes. This intentionally wins over currentColor and stylesheet
   // tokens: the frozen computed value is the visual authority for this state.
   for (const binding of activePaintBindings) {
-    const node = materializedNodeAtPath(binding, values);
+    const node = materializedNodeAtPath(binding, values, pathIndex);
     const id = node && (node.__pulpId || node.id);
     if (!id) {
       ++diagnostics.paint_node_miss;
@@ -338,7 +348,7 @@ function applyMaterializedImportMetadata(metadata) {
   if (typeof g.setCapturedLineBoxes !== 'function') return applied;
   for (const binding of activeTextBindings) {
     const optional = binding.runtime_optional === true;
-    const node = materializedNodeAtPath(binding, values)
+    const node = materializedNodeAtPath(binding, values, pathIndex)
       || (optional ? materializedOptionalTextNode(binding, values) : null);
     if (!node) {
       if (optional) ++diagnostics.text_optional_miss;
@@ -437,13 +447,14 @@ g.__pulpApplyMaterializedImportMetadata__ = function () {
     syncMaterializedCanvasBehaviorsAfterCommit();
   return applied;
 };
-function materializedMatches(node, selector) {
-  if (!node || typeof selector !== 'string') return false;
-  // The web-compat Element shim intentionally supports only a bounded CSS
-  // selector subset. A false result is not authoritative for semantic
-  // data/ARIA attributes added by the native React host, so fall through to
-  // the deterministic fallback matcher.
-  if (typeof node.matches === 'function' && node.matches(selector)) return true;
+// A selector's parse is a pure function of its text, and the registry scan
+// re-tests one selector against every candidate node. Parse once per distinct
+// selector so a scan costs regex work proportional to the selector vocabulary
+// rather than to the number of nodes.
+const materializedSelectorParses = new Map();
+function materializedParseSelector(selector) {
+  const memo = materializedSelectorParses.get(selector);
+  if (memo) return memo;
   let remaining = selector.trim();
   const attributes = [];
   remaining = remaining.replace(
@@ -455,16 +466,34 @@ function materializedMatches(node, selector) {
       return '';
     });
   const idMatch = remaining.match(/#([A-Za-z0-9_-]+)/);
-  const classMatches = Array.from(remaining.matchAll(/\\.([A-Za-z0-9_-]+)/g));
-  const tag = remaining.replace(/#[A-Za-z0-9_-]+/g, '')
-    .replace(/\\.[A-Za-z0-9_-]+/g, '').trim().toLowerCase();
+  const parsed = {
+    attributes: attributes,
+    id: idMatch ? idMatch[1] : null,
+    classes: Array.from(remaining.matchAll(/\\.([A-Za-z0-9_-]+)/g))
+      .map(function (match) { return match[1]; }),
+    tag: remaining.replace(/#[A-Za-z0-9_-]+/g, '')
+      .replace(/\\.[A-Za-z0-9_-]+/g, '').trim().toLowerCase(),
+  };
+  materializedSelectorParses.set(selector, parsed);
+  return parsed;
+}
+function materializedMatches(node, selector) {
+  if (!node || typeof selector !== 'string') return false;
+  // The web-compat Element shim intentionally supports only a bounded CSS
+  // selector subset. A false result is not authoritative for semantic
+  // data/ARIA attributes added by the native React host, so fall through to
+  // the deterministic fallback matcher.
+  if (typeof node.matches === 'function' && node.matches(selector)) return true;
+  const parsed = materializedParseSelector(selector);
+  const attributes = parsed.attributes;
+  const tag = parsed.tag;
   if (tag && String(node.tagName || '').toLowerCase() !== tag) return false;
-  if (idMatch && String(node.id || node.getAttribute?.('id') || '') !== idMatch[1]) {
+  if (parsed.id && String(node.id || node.getAttribute?.('id') || '') !== parsed.id) {
     return false;
   }
   const classes = String(node.className || node.getAttribute?.('class') || '')
     .split(/\\s+/).filter(Boolean);
-  for (const match of classMatches) if (!classes.includes(match[1])) return false;
+  for (const wanted of parsed.classes) if (!classes.includes(wanted)) return false;
   for (const attribute of attributes) {
     if (typeof node.getAttribute !== 'function') return false;
     const actual = node.getAttribute(attribute.name);


### PR DESCRIPTION
## What

The materialized runtime reapplies import metadata from `resetAfterCommit` —
on **every** React commit, not just on mount. Two shapes inside that path were
multiplied by the commit rate:

1. `materializedNodeAtPath` rebuilt its root/registry index **per binding**, so
   one application cost `O(bindings × registry)`.
2. `materializedMatches` re-parsed its selector text **per candidate node**, so
   one registry scan cost regex work proportional to the node count rather than
   to the selector vocabulary.

Both are invisible at a small registry. A downstream UI change that mounts a
large always-present hidden subtree (a settings panel kept in the tree so
keyboard traversal can reach it) tripled the registry 82 → 248 nodes and turned
both into a per-commit tax — surfacing as jank in whichever gesture commits most
often, not in the feature that grew the tree.

## Measured

A/B on one downstream app, two binaries from the same worktree, same SDK, same
commit, differing **only** by this change. 5 interleaved reps per condition,
gesture driven through the native pointer path. Present mode is `Fifo`, so the
median is pinned at the vsync interval and carries no information — p95, worst,
and the count of inter-frame gaps ≥ 25 ms are the signal.

**Slider drag (the gesture that commits most):**

| | n | p95 | worst | gaps ≥ 25 ms |
|---|---|---|---|---|
| before | 5 | 582.61 ms | 657.6 ms | 82 |
| after | 5 | **208.93 ms** | **221.8 ms** | 82 |
| | | **−64.1%** | **−66.3%** | ±0 |

**Viewport/minimap drag:**

| | n | p95 | worst | gaps ≥ 25 ms |
|---|---|---|---|---|
| before | 5 | 90.38 ms | 149.2 ms | 26 |
| after | 5 | **41.63 ms** | **54.6 ms** | **19** |
| | | **−53.9%** | **−63.4%** | **−26.9%** |

Per-run spreads are non-overlapping on every column except the slider gap
count, which is identical by construction: gap *count* there is governed by a
downstream publish threshold, not by commit cost. This change makes each gap
~3× shorter without changing how many there are — so it is a real improvement
on that gesture but not the whole of it.

## Design notes

The path index is deliberately rebuilt **once per application** rather than
cached across commits: a retained index would resolve stale paths after any
reparent, and every binding in a single application reads the same registry
snapshot anyway. The selector-parse memo has no such concern — a parse is a pure
function of the selector text.

## Verification

`materializedMatches` is reachable from nearly every metadata binding, yet
hard-breaking it leaves the dropdown arrow-traversal and settings cases green.
The case that catches it is *every native dropdown dismisses by Escape and
outside press*. Both were run against a downstream build carrying this change:

- arrow traversal + arrow nav — 328 assertions, 2 cases, pass
- dismissal + modal dismissal — 870 assertions, 3 cases, pass

Fix markers were confirmed present in the measured binaries, with
`materializedNodeAtPath` as a positive control and a rejected cache-based
variant's symbol as a negative control (absent, as expected).

The gotcha is recorded in the `import-design` skill.

<!-- whence {"labels": ["1·claude", "2·m5", "3·Session 3 (M5) —…", "4·spectr vNext", "5·unresolved"], "prov": {"agent": "claude", "host": "m5", "workspace": "Session 3 (M5) — Spectr & lifecycle.", "tab": "spectr vNext", "launcher": "unresolved", "terminal": "cmux", "terminal_address": "1088493E-29BE-4CD1-B4DC-9C91A6968576", "route": "unresolved", "origin_state": "known", "path": "~/Code/pulp-matrt-perf-20260911", "session": "6ba79f7c-db7c-471c-8fbf-6446902a0905", "resume": "claude \u002d\u002dresume 6ba79f7c-db7c-471c-8fbf-6446902a0905", "jump": "cmux surface focus 1088493E-29BE-4CD1-B4DC-9C91A6968576", "relaunch": "cmux surface resume get \u002d\u002dsurface 1088493E-29BE-4CD1-B4DC-9C91A6968576"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m5` |
| **Workspace** | `Session 3 (M5) — Spectr & lifecycle.` |
| **Tab** | spectr vNext |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Terminal** | `cmux` |
| **Terminal address** | `1088493E-29BE-4CD1-B4DC-9C91A6968576` |
| **Origin state** | `known` |
| **Directory** | `~/Code/pulp-matrt-perf-20260911` |
| **Session** | `6ba79f7c-db7c-471c-8fbf-6446902a0905` |

**Resume**
```
claude --resume 6ba79f7c-db7c-471c-8fbf-6446902a0905
```
**Jump to this tab**
```
cmux surface focus 1088493E-29BE-4CD1-B4DC-9C91A6968576
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 1088493E-29BE-4CD1-B4DC-9C91A6968576
```

<sub>stamped 2026-09-11 11:07 UTC</sub>
<!-- /whence -->