### PR TITLE
Let plugin bundles carry an icon, and let callers supply their own .icns

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -1047,3 +1047,22 @@ the deadline-bounded form (`pulp::test::wait_for_condition`, in
 The rule generalizes to any adapter test asserting a worker thread reached a
 specific call: wait for the outcome, never for a fixed budget, and always
 under a deadline.
+
+## The bundle carries its own icon, and the plist key is what makes it work
+
+`pulp_app_icon(<target>_AU ...)` brands `.component`: it copies the
+`.icns` into `Contents/Resources/` and sets `MACOSX_BUNDLE_ICON_FILE`, which
+CMake substitutes into the bundle's `Info.plist` at generate time.
+
+The load-bearing half is easy to miss. That substitution needs a
+`CFBundleIconFile` key in `tools/cmake/PulpInfoPlist.au.in` to land in.
+Without it the copy still happens and the property is still set, so nothing
+errors — the bundle just comes out unbranded. If an icon does not appear,
+check the template for the key before suspecting the helper.
+
+Prefer `ICNS` over `SOURCE` for a mark with fine detail. `SOURCE` derives
+every size from one PNG with `sips`, whose Lanczos kernel overshoots on hard
+edges: a feature one or two device pixels wide at 16x16 smears into its
+neighbours and the bundle edge picks up a bright halo. Render each size on
+its own pixel grid and pass the finished `.icns`.
+

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -1451,3 +1451,22 @@ things follow:
   `dlclose` runs freed code.
 
 No-op unless the build is configured `PULP_TRACING=ON`.
+
+## The bundle carries its own icon, and the plist key is what makes it work
+
+`pulp_app_icon(<target>_AU ...)` brands the appex: it copies the
+`.icns` into `Contents/Resources/` and sets `MACOSX_BUNDLE_ICON_FILE`, which
+CMake substitutes into the bundle's `Info.plist` at generate time.
+
+The load-bearing half is easy to miss. That substitution needs a
+`CFBundleIconFile` key in `tools/cmake/PulpInfoPlist.au.in` to land in.
+Without it the copy still happens and the property is still set, so nothing
+errors — the bundle just comes out unbranded. If an icon does not appear,
+check the template for the key before suspecting the helper.
+
+Prefer `ICNS` over `SOURCE` for a mark with fine detail. `SOURCE` derives
+every size from one PNG with `sips`, whose Lanczos kernel overshoots on hard
+edges: a feature one or two device pixels wide at 16x16 smears into its
+neighbours and the bundle edge picks up a bright halo. Render each size on
+its own pixel grid and pass the finished `.icns`.
+

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -1063,3 +1063,22 @@ things follow:
   `dlclose` runs freed code.
 
 No-op unless the build is configured `PULP_TRACING=ON`.
+
+## The bundle carries its own icon, and the plist key is what makes it work
+
+`pulp_app_icon(<target>_CLAP ...)` brands `.clap`: it copies the
+`.icns` into `Contents/Resources/` and sets `MACOSX_BUNDLE_ICON_FILE`, which
+CMake substitutes into the bundle's `Info.plist` at generate time.
+
+The load-bearing half is easy to miss. That substitution needs a
+`CFBundleIconFile` key in `tools/cmake/PulpInfoPlist.clap.in` to land in.
+Without it the copy still happens and the property is still set, so nothing
+errors — the bundle just comes out unbranded. If an icon does not appear,
+check the template for the key before suspecting the helper.
+
+Prefer `ICNS` over `SOURCE` for a mark with fine detail. `SOURCE` derives
+every size from one PNG with `sips`, whose Lanczos kernel overshoots on hard
+edges: a feature one or two device pixels wide at 16x16 smears into its
+neighbours and the bundle edge picks up a bright halo. Render each size on
+its own pixel grid and pass the finished `.icns`.
+

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -1203,3 +1203,22 @@ between targets or reworking the format defines, carry that define with it.
 the library-compiled adapter, requires non-null, then downcasts to
 `PulpPlugView*` and asserts on its internals. It is a plain ctest in the
 required gate, so the fumble goes red rather than silent.
+
+## The bundle carries its own icon, and the plist key is what makes it work
+
+`pulp_app_icon(<target>_VST3 ...)` brands `.vst3`: it copies the
+`.icns` into `Contents/Resources/` and sets `MACOSX_BUNDLE_ICON_FILE`, which
+CMake substitutes into the bundle's `Info.plist` at generate time.
+
+The load-bearing half is easy to miss. That substitution needs a
+`CFBundleIconFile` key in `tools/cmake/PulpInfoPlist.vst3.in` to land in.
+Without it the copy still happens and the property is still set, so nothing
+errors — the bundle just comes out unbranded. If an icon does not appear,
+check the template for the key before suspecting the helper.
+
+Prefer `ICNS` over `SOURCE` for a mark with fine detail. `SOURCE` derives
+every size from one PNG with `sips`, whose Lanczos kernel overshoots on hard
+edges: a feature one or two device pixels wide at 16x16 smears into its
+neighbours and the bundle edge picks up a bright halo. Render each size on
+its own pixel grid and pass the finished `.icns`.
+

--- a/docs/reference/cmake.md
+++ b/docs/reference/cmake.md
@@ -390,11 +390,27 @@ delivered as soon as one is installed.
 
 **Status**: usable
 
-Attach an icon source to an application or standalone target.
+Attach an icon source to an application, standalone, or plugin-format bundle
+target. The plugin bundles `pulp_add_plugin()` generates — `<target>_VST3`,
+`<target>_AU`, `<target>_CLAP`, `<target>_AAX` — are CFBundles and accept an
+icon the same way an app bundle does.
 
 Targets build normally if you never call `pulp_app_icon(...)`. The helper is an
 optional overlay, so removing the call cleanly removes the custom-icon
 behavior.
+
+`SOURCE` takes one PNG of at least 1024x1024 and derives every size from it
+with `sips`. That is fine for soft artwork and poor for a mark with fine
+detail: `sips` uses a Lanczos kernel, which overshoots on hard edges, so a
+1-2px feature at 16x16 smears and a tile edge picks up a visible halo. When
+the icon has crisp geometry, render each size on its own pixel grid, build the
+`.icns` yourself, and pass it as `ICNS` — it is bundled verbatim. `ICNS`
+applies to macOS only; keep `SOURCE` alongside it to cover Windows, Android,
+and Linux.
+
+```cmake
+pulp_app_icon(MyPlugin_VST3 ICNS assets/MyPlugin.icns)
+```
 
 ```cmake
 pulp_app_icon(<target>

--- a/docs/status/cmake-functions.yaml
+++ b/docs/status/cmake-functions.yaml
@@ -103,11 +103,12 @@ functions:
 
   - name: pulp_app_icon
     status: usable
-    summary: Attach app icon assets to a standalone application or generated app bundle target.
+    summary: Attach app icon assets to an application, standalone, or plugin-format bundle target.
     required:
       - target
     optional:
       - SOURCE
+      - ICNS
       - MACOS
       - WINDOWS
       - IOS

--- a/tools/cmake/PulpAppIcon.cmake
+++ b/tools/cmake/PulpAppIcon.cmake
@@ -1,10 +1,22 @@
 # PulpAppIcon.cmake — target-level app icon helper
 #
 # Provides:
-#   pulp_app_icon(<target> SOURCE icon.png [...])
+#   pulp_app_icon(<target> SOURCE icon.png [ICNS icon.icns] [...])
 #
 # Current scope:
-# - macOS: generates a bundled .icns via sips + iconutil
+# - macOS: generates a bundled .icns via sips + iconutil, or bundles the
+#   caller's own .icns when ICNS is given
+#
+# Prefer ICNS when the mark has fine detail. Generation downscales one PNG
+# with sips, whose Lanczos kernel overshoots on a hard edge: a bar one or two
+# device pixels wide at 16px smears, and a tile edge picks up a bright halo.
+# A caller that renders each size on its own pixel grid should pass the
+# finished .icns rather than let it be re-derived.
+#
+# Works on any bundle target, including the plugin format targets that
+# pulp_add_plugin() creates (<target>_VST3 / _AU / _CLAP / _AAX) — those
+# bundles are CFBundles, which honour both MACOSX_PACKAGE_LOCATION and the
+# generate-time MACOSX_BUNDLE_ICON_FILE substitution.
 # - Windows: generates an .ico + .rc via PowerShell/.NET
 # - Android: writes generated launcher PNGs under android/app/src/main/res-generated
 #
@@ -119,7 +131,18 @@ function(_pulp_icon_validate_source target source_path)
     endif()
 endfunction()
 
-function(_pulp_icon_configure_macos target source_path)
+function(_pulp_icon_configure_macos target source_path icns_path)
+    if(icns_path)
+        # The caller owns the asset; bundle it as-is.
+        get_filename_component(_icns_name "${icns_path}" NAME)
+        set_source_files_properties("${icns_path}" PROPERTIES
+            MACOSX_PACKAGE_LOCATION "Resources")
+        target_sources(${target} PRIVATE "${icns_path}")
+        set_target_properties(${target} PROPERTIES
+            MACOSX_BUNDLE_ICON_FILE "${_icns_name}")
+        return()
+    endif()
+
     find_program(_pulp_sips sips)
     find_program(_pulp_iconutil iconutil)
     if(NOT _pulp_sips OR NOT _pulp_iconutil)
@@ -220,7 +243,7 @@ endfunction()
 function(pulp_app_icon target)
     cmake_parse_arguments(ICON
         ""
-        "SOURCE;MACOS;WINDOWS;IOS;ANDROID;LINUX;DEBUG_ICON;RELEASE_ICON"
+        "SOURCE;ICNS;MACOS;WINDOWS;IOS;ANDROID;LINUX;DEBUG_ICON;RELEASE_ICON"
         ""
         ${ARGN}
     )
@@ -244,10 +267,30 @@ function(pulp_app_icon target)
         RELEASE_ICON "${ICON_RELEASE_ICON}"
     )
     _pulp_icon_abs_path(_selected_abs "${CMAKE_CURRENT_SOURCE_DIR}" "${_selected_rel}")
-    _pulp_icon_validate_source(${target} "${_selected_abs}")
+
+    set(_icns_abs "")
+    if(ICON_ICNS)
+        _pulp_icon_abs_path(_icns_abs "${CMAKE_CURRENT_SOURCE_DIR}" "${ICON_ICNS}")
+        if(NOT EXISTS "${_icns_abs}")
+            message(FATAL_ERROR
+                "pulp_app_icon(${target}): ICNS does not exist: ${_icns_abs}")
+        endif()
+        get_filename_component(_icns_ext "${_icns_abs}" EXT)
+        string(TOLOWER "${_icns_ext}" _icns_ext)
+        if(NOT _icns_ext STREQUAL ".icns")
+            message(FATAL_ERROR
+                "pulp_app_icon(${target}): ICNS must be a .icns: ${_icns_abs}")
+        endif()
+    endif()
+
+    # ICNS covers macOS only. Every other platform still needs the PNG, so
+    # validate it unless macOS is all that was asked for.
+    if(NOT _icns_abs OR NOT APPLE OR PULP_IOS OR IOS)
+        _pulp_icon_validate_source(${target} "${_selected_abs}")
+    endif()
 
     if(APPLE AND NOT (PULP_IOS OR IOS))
-        _pulp_icon_configure_macos(${target} "${_selected_abs}")
+        _pulp_icon_configure_macos(${target} "${_selected_abs}" "${_icns_abs}")
     elseif(PULP_IOS OR IOS)
         message(WARNING
             "pulp_app_icon(${target}): iOS app-icon catalog generation is not "
@@ -262,4 +305,7 @@ function(pulp_app_icon target)
     endif()
 
     set_property(TARGET ${target} PROPERTY PULP_APP_ICON_SOURCE "${_selected_abs}")
+    if(_icns_abs)
+        set_property(TARGET ${target} PROPERTY PULP_MACOS_APP_ICNS "${_icns_abs}")
+    endif()
 endfunction()

--- a/tools/cmake/PulpInfoPlist.aax.in
+++ b/tools/cmake/PulpInfoPlist.aax.in
@@ -6,6 +6,8 @@
     <string>English</string>
     <key>CFBundleExecutable</key>
     <string>@PULP_PLUGIN_NAME@</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
     <key>CFBundleIdentifier</key>
     <string>@PULP_BUNDLE_ID@.aax</string>
     <key>CFBundleGetInfoString</key>

--- a/tools/cmake/PulpInfoPlist.au.in
+++ b/tools/cmake/PulpInfoPlist.au.in
@@ -6,6 +6,8 @@
     <string>en</string>
     <key>CFBundleExecutable</key>
     <string>@PULP_PLUGIN_NAME@</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
     <key>CFBundleIdentifier</key>
     <string>@PULP_BUNDLE_ID@.au</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/tools/cmake/PulpInfoPlist.clap.in
+++ b/tools/cmake/PulpInfoPlist.clap.in
@@ -6,6 +6,8 @@
     <string>en</string>
     <key>CFBundleExecutable</key>
     <string>@PULP_PLUGIN_NAME@</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
     <key>CFBundleIdentifier</key>
     <string>@PULP_BUNDLE_ID@.clap</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/tools/cmake/PulpInfoPlist.vst3.in
+++ b/tools/cmake/PulpInfoPlist.vst3.in
@@ -6,6 +6,8 @@
     <string>en</string>
     <key>CFBundleExecutable</key>
     <string>@PULP_PLUGIN_NAME@</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
     <key>CFBundleIdentifier</key>
     <string>@PULP_BUNDLE_ID@.vst3</string>
     <key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Two gaps in `pulp_app_icon()`, both found while giving a plugin a product icon.

## A plugin bundle could not carry an icon at all

`pulp_app_icon()` already does the right things on any target: it copies the `.icns` into `Contents/Resources/` via `MACOSX_PACKAGE_LOCATION` and sets `MACOSX_BUNDLE_ICON_FILE`. The VST3/AU/CLAP/AAX bundles are CFBundles, which honour both. But their `Info.plist` templates carried no `CFBundleIconFile` key, so CMake's generate-time substitution had nothing to land in. Only the standalone template had it.

The failure mode is quiet, which is why it is worth a skill note: the copy still happens and the property is still set, nothing errors, and the bundle just comes out unbranded.

Adding the key to the four plugin templates is the whole fix. It uses the same `${}` form and the same position the standalone template already uses.

## `SOURCE` degrades a detailed mark at small sizes

`SOURCE` derives every size from one PNG with `sips`, whose Lanczos kernel overshoots on hard edges. On a mark whose features are one or two device pixels wide at 16x16 the result is not merely soft — the features smear together and the bundle's own edge picks up a bright halo, so the small icon reads as damaged rather than small. That is the size a DAW plugin list and a Finder list view actually show.

New `ICNS` option: a caller that renders each size on its own pixel grid passes the finished asset and it is bundled verbatim. `ICNS` covers macOS only, so `SOURCE` stays required whenever another platform is in play.

```cmake
pulp_app_icon(MyPlugin_VST3 ICNS assets/MyPlugin.icns)
```

## Verification

Exercised against the changed files themselves, not a mock. A CFBundle MODULE configured the way `PulpPluginFormats.cmake` configures a VST3 — real template, real `@ONLY` pass, real `pulp_app_icon()` — comes out with:

- `CFBundleIconFile = icon.icns`
- `Contents/Resources/icon.icns` byte-identical to the source (`750600e2…`)
- `CFBundleIdentifier = com.probe.two.vst3` as the **control**, proving the patched template is the one in use rather than a CMake default

Regression: the existing `SOURCE`/sips path still produces `AppIcon.icns` in an app bundle unchanged.

Two mechanisms were probed rather than assumed, since neither is obvious for a MODULE library: CMake's generate-time `${MACOSX_BUNDLE_ICON_FILE}` substitution does run for a CFBundle, and `MACOSX_PACKAGE_LOCATION Resources` does copy into one.

Gates green (`tools/scripts/gates.sh origin/main`). Vellum expansion watch `status: pass`, `affected_families: []`; freeze check reports no affected slice or authority transition.

Downstream: Spectr wants this — its plugin bundles stay unbranded until it repins onto an SDK carrying it (danielraffel/spectr#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["1·claude", "2·m5", "3·Session 3 (M5) —…", "4·Spectr Stale pulp…", "5·unresolved"], "prov": {"agent": "claude", "host": "m5", "workspace": "Session 3 (M5) — Spectr & lifecycle.", "tab": "Spectr Stale pulp v0.382.1 on PATH", "launcher": "unresolved", "terminal": "cmux", "terminal_address": "D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B", "route": "unresolved", "origin_state": "known", "path": "~/Code/pulp-plugin-icon-20260912", "session": "3edc10de-14b7-4828-b628-8998c334324f", "resume": "claude \u002d\u002dresume 3edc10de-14b7-4828-b628-8998c334324f", "jump": "cmux surface focus D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B", "relaunch": "cmux surface resume get \u002d\u002dsurface D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m5` |
| **Workspace** | `Session 3 (M5) — Spectr & lifecycle.` |
| **Tab** | Spectr Stale pulp v0.382.1 on PATH |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Terminal** | `cmux` |
| **Terminal address** | `D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B` |
| **Origin state** | `known` |
| **Directory** | `~/Code/pulp-plugin-icon-20260912` |
| **Session** | `3edc10de-14b7-4828-b628-8998c334324f` |

**Resume**
```
claude --resume 3edc10de-14b7-4828-b628-8998c334324f
```
**Jump to this tab**
```
cmux surface focus D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B
```
**Relaunch (any agent)**
```
cmux surface resume get --surface D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B
```

<sub>stamped 2026-09-12 21:11 UTC</sub>
<!-- /whence -->