### PR TITLE
fix(view): do not pre-seed a popup's keyboard cursor on open

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -501,6 +501,33 @@ painted. `"transparent"` is NOT a substitute: `css_color.cpp` maps it to
 (`textColor` removed → `setTextColor(id,"")`) is currently inert on the native
 side. Fix that half the same way when it next bites.
 
+### A popup has TWO states, and only one of them belongs on screen at open
+
+`web-compat-document.js` owns any popup it can reach by ARIA shape -- a
+trigger carrying `aria-haspopup` over a `role="listbox"`/`role="menu"` -- and
+paints a keyboard cursor on one row. That cursor is NOT the app's selection.
+The app paints its own selected row however it likes; the owner's cursor is
+navigation position. Both on screen at once reads as two selections, which is
+exactly what a user reports as "why is it showing me two".
+
+So the cursor is created at open (an arrow needs somewhere to start) but not
+painted until the user asks for one: `pointerenter` on a row, an arrow key, or
+an arrow that opened the popup in the first place. `state.activeVisible` is
+that flag and `paint()` is gated on it.
+
+The seed comes from `selectedIndexIn()`, which reads
+`aria-activedescendant` / `aria-selected` / `aria-checked` / `.checked` /
+`aria-current` in that order. **An app whose rows advertise none of those gets
+index 0**, so a listbox whose current value is any row but the first shows the
+app's selection on one row and the owner's cursor on another. The fix is on
+the app side and is required for assistive technology anyway: a `role="listbox"`
+whose children are bare `<button>`s has no selection to report. Mark the rows.
+
+Where the first arrow lands then depends on whether the cursor had a home.
+Seeded from a real selection it steps off it, the way a platform combo box
+does. Seeded from an edge because nothing was marked, it lands ON that edge --
+otherwise the first ArrowDown skips the row the user was aiming at.
+
 ### `confirm_failure.sh` needs `--object` to verdict a `.js` prelude edit
 
 Preludes are embedded into a generated `build/core/view/web_compat_preludes_gen.cpp`,

--- a/.github/vellum-expansion-watch-events/20260912-popup-active-highlight-deferred-watch.json
+++ b/.github/vellum-expansion-watch-events/20260912-popup-active-highlight-deferred-watch.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kind": "authority-expansion-watch-change",
+  "event_id": "20260912-popup-active-highlight-deferred-watch",
+  "created_at": "2026-09-12T21:40:00Z",
+  "acceptance_id": "full-design-import-render-v1-pulp-watch",
+  "acceptance_sha256": "1535d76e34dfc80eda55247c1b0d47b9f47b3e58a08b6f1ab4b749692e6056fd",
+  "capability_families": ["render-assets-and-backends"],
+  "rationale": "An opened dropdown lit two rows: the app's own selected row plus the web-compat popup owner's keyboard cursor, painted before any pointer or key input. The cursor is now created but not painted until the user reveals it by hovering a row, pressing an arrow, or opening the popup with an arrow, and the first arrow steps off an ARIA-selected seed while landing on an edge seed. render-assets-and-backends is crossed only because core/view/js/web-compat-document.js sits under that family's selector; the diff changes when one inline background is assigned and which index an arrow key computes, inside one popup-ownership IIFE. No renderer, backend, Skia pin, asset, font, shader, surface, harness, fixture, snapshot or threshold changes, and no bridge function, manifest row or generated artifact. Registered watch-only so the family's coverage stays honest about a change that crossed its selector. No authority moves and no Vellum artifact changes.",
+  "tests": ["pulp-test-mac-platform-harness", "confirm-failure-harness", "vellum-expansion-watch"],
+  "disposition": "watch-only-no-authority",
+  "authority_effect": "none"
+}

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -634,10 +634,18 @@ globalThis.self = window;
         if (option._nativeCreated && typeof clearBackground === "function")
             clearBackground(option._id);
     }
+    // A list that shows both its selection and a keyboard cursor the instant
+    // it opens reads as two selections, and a user who has not touched the
+    // keyboard or the mouse has not asked for a cursor at all. So the cursor
+    // exists from the moment the popup is owned -- arrow keys need somewhere
+    // to start from -- but it is not PAINTED until the user reveals it by
+    // moving the pointer over a row, by pressing an arrow, or by opening the
+    // popup with an arrow in the first place. Until then the only thing on
+    // screen is whatever the app paints for its own selected row.
     function paint() {
         if (!state) return;
         for (var i = 0; i < state.options.length; ++i) {
-            var active = i === state.activeIndex;
+            var active = state.activeVisible && i === state.activeIndex;
             state.options[i].setAttribute("data-pulp-popup-active", active ? "true" : "false");
             if (active) {
                 state.options[i].style.background = "rgba(120,180,255,0.18)";
@@ -684,7 +692,7 @@ globalThis.self = window;
         }
         return -1;
     }
-    function activate(trigger, edge) {
+    function activate(trigger, edge, reveal) {
         var popup = popupFor(trigger);
         var options = optionsFor(popup);
         // Resolve the replacement before retiring what is already owned. A
@@ -720,6 +728,11 @@ globalThis.self = window;
                   popup: popup, options: options,
                   baseBackgrounds: baseBackgrounds,
                   hoverHandlers: hoverHandlers,
+                  seededFromSelection: selectedIndex >= 0,
+                  // An arrow key is itself the request for a cursor, so a
+                  // popup opened that way shows one immediately; a pointer
+                  // press is not.
+                  activeVisible: !!reveal,
                   activeIndex: selectedIndex >= 0 ? selectedIndex
                       : (edge === "last" ? options.length - 1 : 0) };
         state.onNativeDismiss = function() {
@@ -735,6 +748,7 @@ globalThis.self = window;
                 var onEnter = function() {
                     if (!state || state.options[index] !== options[index]) return;
                     state.activeIndex = index;
+                    state.activeVisible = true;
                     paint();
                 };
                 hoverHandlers.push(onEnter);
@@ -862,6 +876,7 @@ globalThis.self = window;
             for (var i = 0; i < state.options.length; ++i)
                 if (state.options[i].contains(event.target)) {
                     state.activeIndex = i;
+                    state.activeVisible = true;
                     paint();
                     return;
                 }
@@ -874,8 +889,8 @@ globalThis.self = window;
             event.preventDefault();
             clickSelf(trigger);
             var edge = event.key === "ArrowUp" ? "last" : "first";
-            if (!activate(trigger, edge))
-                requestAnimationFrame(function() { activate(trigger, edge); });
+            if (!activate(trigger, edge, true))
+                requestAnimationFrame(function() { activate(trigger, edge, true); });
             return;
         }
         if (!state || optedOut(state.trigger)) return;
@@ -887,10 +902,25 @@ globalThis.self = window;
         } else if (event.key === "ArrowDown" || event.key === "ArrowUp"
                    || event.key === "Home" || event.key === "End") {
             event.preventDefault();
-            state.activeIndex = event.key === "Home" ? 0
-                : event.key === "End" ? count - 1
-                : event.key === "ArrowDown" ? (state.activeIndex + 1) % count
-                : (state.activeIndex - 1 + count) % count;
+            // The first arrow on a popup whose cursor is still hidden has to
+            // decide whether it REVEALS the cursor or MOVES it. Both, but the
+            // answer differs by whether the cursor had a home: seeded from the
+            // app's own selected row it steps off it, the way every platform
+            // combo box steps from the selection (ArrowDown on a list showing
+            // LEVEL goes to the row after LEVEL, not back onto LEVEL). Seeded
+            // from an edge because nothing was selected, there is nothing to
+            // step away from, so the first arrow lands ON that edge rather
+            // than skipping the row the user was aiming at.
+            var landOnSeed = !state.activeVisible && !state.seededFromSelection
+                && (event.key === "ArrowDown" || event.key === "ArrowUp");
+            state.activeVisible = true;
+            if (landOnSeed)
+                state.activeIndex = event.key === "ArrowUp" ? count - 1 : 0;
+            else
+                state.activeIndex = event.key === "Home" ? 0
+                    : event.key === "End" ? count - 1
+                    : event.key === "ArrowDown" ? (state.activeIndex + 1) % count
+                    : (state.activeIndex - 1 + count) % count;
             paint();
             state.options[state.activeIndex].focus();
         } else if (event.key === "Enter" || event.key === " ") {

--- a/test/test_mac_platform_harness.cpp
+++ b/test/test_mac_platform_harness.cpp
@@ -1637,18 +1637,20 @@ TEST_CASE("a mouse-opened popup accepts arrow navigation and paints its highligh
     REQUIRE(engine.evaluate("document.activeElement !== trigger")
                 .getWithDefault<bool>(false));
 
-    // The claim itself: a mouse-opened popup is owned, and its first option is
-    // painted, not merely marked.
+    // The claim itself: a mouse-opened popup is owned. The keyboard cursor
+    // exists so an arrow has somewhere to start, but NOTHING is painted --
+    // a user who has only pressed the trigger has not asked for a cursor, and
+    // a row lit next to the app's own selected row reads as two selections.
     REQUIRE(engine.evaluate("!!globalThis.__pulpPopupDefaultState__")
                 .getWithDefault<bool>(false));
     REQUIRE(engine.evaluate(
-        "globalThis.__pulpPopupDefaultState__.activeIndex === 0")
+        "globalThis.__pulpPopupDefaultState__.activeIndex === 0 && "
+        "globalThis.__pulpPopupDefaultState__.activeVisible === false")
                 .getWithDefault<bool>(false));
     REQUIRE(engine.evaluate(
-        "globalThis.__pulpPopupDefaultState__.options[0]."
-        "getAttribute('data-pulp-popup-active') === 'true' && "
-        "globalThis.__pulpPopupDefaultState__.options[0].style.background === "
-        "'rgba(120,180,255,0.18)'")
+        "globalThis.__pulpPopupDefaultState__.options.every(function(o) { "
+        "return o.getAttribute('data-pulp-popup-active') === 'false' "
+        "&& o.style.background !== 'rgba(120,180,255,0.18)'; })")
                 .getWithDefault<bool>(false));
 
     const auto option_id = [&engine](int index) {
@@ -1662,13 +1664,32 @@ TEST_CASE("a mouse-opened popup accepts arrow navigation and paints its highligh
     auto* option1_view = bridge.widget(option_id(1));
     REQUIRE(option0_view != nullptr);
     REQUIRE(option1_view != nullptr);
-    // Control for the pair of widget assertions below: the highlighted row is
-    // painted natively, so a later "no background" reading means the highlight
-    // came off, not that the instrument is looking at the wrong widget.
+    // These are the PIXELS for the assertion above. The attribute can read
+    // "false" while the row is still painted, so the unpainted open state has
+    // to be read off the widget as well: neither row carries a background.
+    REQUIRE_FALSE(option0_view->has_background_color());
+    REQUIRE_FALSE(option1_view->has_background_color());
+
+    // The first arrow REVEALS the cursor. This popup's rows carry no ARIA
+    // selection, so the cursor was seeded at an edge rather than at a row the
+    // user picked -- there is nothing to step away from, and ArrowDown must
+    // land ON the first row rather than skipping it.
+    REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::down));
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.activeIndex === 0 && "
+        "globalThis.__pulpPopupDefaultState__.activeVisible === true && "
+        "globalThis.__pulpPopupDefaultState__.options[0]."
+        "getAttribute('data-pulp-popup-active') === 'true' && "
+        "globalThis.__pulpPopupDefaultState__.options[0].style.background === "
+        "'rgba(120,180,255,0.18)'")
+                .getWithDefault<bool>(false));
+    // Positive control for the "nothing painted" reading above: the very same
+    // widget instrument now DOES report a background, so the earlier absence
+    // was the deferred highlight and not a dead probe.
     REQUIRE(option0_view->has_background_color());
     REQUIRE_FALSE(option1_view->has_background_color());
 
-    // Arrow navigation moves the selection and repaints the highlight.
+    // Once revealed, arrows move normally and the highlight follows.
     REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::down));
     REQUIRE(engine.evaluate(
         "globalThis.__pulpPopupDefaultState__.activeIndex === 1 && "
@@ -1699,5 +1720,155 @@ TEST_CASE("a mouse-opened popup accepts arrow navigation and paints its highligh
     // a selection rather than decoration.
     REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::enter));
     REQUIRE(engine.evaluate("selected === 'A' && popup === null")
+                .getWithDefault<bool>(false));
+}
+
+TEST_CASE("a mouse-opened popup shows no cursor until asked, then steps off the "
+          "selected row",
+          "[mac][platform-harness][keyboard][popup-default]") {
+    // The shape a real app ships: a listbox that paints its OWN selected row,
+    // and marks it for assistive technology with aria-selected. Two things are
+    // pinned here. First, opening with the mouse must not add a second lit row
+    // -- an app that already shows which value is current does not want the
+    // popup owner painting a competing one before the user has asked for a
+    // cursor. Second, the cursor is still seeded at the selection, so the
+    // first arrow steps OFF it the way a platform combo box does, rather than
+    // restarting from the top of the list.
+    pulp::view::ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 320, 240});
+    pulp::state::StateStore store;
+    pulp::view::WidgetBridge bridge(engine, root, store);
+    bridge.load_script(R"(
+        var popup = null;
+        var selected = 'B';
+        var trigger = document.createElement('button');
+        trigger.setAttribute('aria-haspopup', 'listbox');
+        trigger.setAttribute('aria-controls', 'seeded-popup');
+        trigger.textContent = 'B';
+        trigger.style.position = 'absolute';
+        trigger.style.left = '8px';
+        trigger.style.top = '8px';
+        trigger.style.width = '80px';
+        trigger.style.height = '24px';
+        trigger.addEventListener('click', function() {
+            if (popup) {
+                popup.parentNode.removeChild(popup);
+                popup = null;
+                return;
+            }
+            popup = document.createElement('div');
+            popup.id = 'seeded-popup';
+            popup.setAttribute('role', 'listbox');
+            popup.style.position = 'absolute';
+            popup.style.left = '8px';
+            popup.style.top = '36px';
+            popup.style.width = '100px';
+            popup.style.height = '96px';
+            ['A', 'B', 'C'].forEach(function(label) {
+                var option = document.createElement('button');
+                option.setAttribute('role', 'option');
+                option.setAttribute(
+                    'aria-selected', label === selected ? 'true' : 'false');
+                option.textContent = label;
+                option.addEventListener('click', function() {
+                    selected = label;
+                    trigger.textContent = label;
+                    if (popup) popup.parentNode.removeChild(popup);
+                    popup = null;
+                });
+                popup.appendChild(option);
+            });
+            document.body.appendChild(popup);
+        });
+        document.body.appendChild(trigger);
+    )");
+    const auto trigger_id = std::string(
+        engine.evaluate("trigger._id").getWithDefault<std::string_view>(""));
+    auto* trigger_view = bridge.widget(trigger_id);
+    REQUIRE(trigger_view != nullptr);
+    trigger_view->set_position(View::Position::absolute);
+    trigger_view->set_left(8.0f);
+    trigger_view->set_top(8.0f);
+    trigger_view->flex().preferred_width = 80.0f;
+    trigger_view->flex().preferred_height = 24.0f;
+    trigger_view->set_bounds({8, 8, 80, 24});
+    trigger_view->set_hit_testable(true);
+
+    auto host = pt::make_test_window(root);
+    REQUIRE(host != nullptr);
+    host->set_app_key_monitor([](const pulp::view::KeyEvent&) { return false; });
+    REQUIRE(root.hit_test({40, 20}) == trigger_view);
+
+    REQUIRE(pt::run_hidden_event_loop(
+        *host,
+        {{.at_ms = 10,
+          .events = {{.phase = pt::SimulatedMouse::Phase::down, .x = 40, .y = 20}}},
+         {.at_ms = 30,
+          .events = {{.phase = pt::SimulatedMouse::Phase::up, .x = 40, .y = 20}}}},
+        /*stop_after_ms=*/250));
+
+    // Controls: the menu really opened and the owner really claimed it, so a
+    // later "nothing is painted" reading cannot be a popup that never existed.
+    REQUIRE(engine.evaluate("!!document.getElementById('seeded-popup')")
+                .getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate("!!globalThis.__pulpPopupDefaultState__")
+                .getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.options.length === 3")
+                .getWithDefault<bool>(false));
+
+    // The cursor found the app's selected row rather than the top of the list,
+    // and it is deliberately invisible.
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.activeIndex === 1 && "
+        "globalThis.__pulpPopupDefaultState__.seededFromSelection === true && "
+        "globalThis.__pulpPopupDefaultState__.activeVisible === false")
+                .getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.options.every(function(o) { "
+        "return o.getAttribute('data-pulp-popup-active') === 'false' "
+        "&& o.style.background !== 'rgba(120,180,255,0.18)'; })")
+                .getWithDefault<bool>(false));
+
+    const auto row = [&](int index) -> View* {
+        auto id = engine
+                      .evaluate("globalThis.__pulpPopupDefaultState__.options["
+                                + std::to_string(index) + "]._id")
+                      .getWithDefault<std::string>("");
+        REQUIRE_FALSE(id.empty());
+        return bridge.widget(id);
+    };
+    REQUIRE(row(0) != nullptr);
+    REQUIRE(row(1) != nullptr);
+    REQUIRE(row(2) != nullptr);
+    // The pixels agree with the attributes: no row is painted by the owner.
+    REQUIRE_FALSE(row(0)->has_background_color());
+    REQUIRE_FALSE(row(1)->has_background_color());
+    REQUIRE_FALSE(row(2)->has_background_color());
+
+    // The first arrow reveals the cursor AND moves it, because it had a home
+    // to move from. ArrowDown on a list showing 'B' goes to 'C'.
+    REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::down));
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.activeIndex === 2 && "
+        "globalThis.__pulpPopupDefaultState__.activeVisible === true && "
+        "globalThis.__pulpPopupDefaultState__.options[2]."
+        "getAttribute('data-pulp-popup-active') === 'true'")
+                .getWithDefault<bool>(false));
+    // Positive control for the three "no background" readings above: the same
+    // instrument now reports a painted row, so their absence was the deferral.
+    REQUIRE(row(2)->has_background_color());
+    REQUIRE_FALSE(row(1)->has_background_color());
+
+    // ArrowUp walks back over the selected row, which is ordinary movement.
+    REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::up));
+    REQUIRE(engine.evaluate(
+        "globalThis.__pulpPopupDefaultState__.activeIndex === 1")
+                .getWithDefault<bool>(false));
+
+    // And Enter commits whatever the cursor is on, closing the menu.
+    REQUIRE(pt::simulate_app_key(*host, pulp::view::KeyCode::enter));
+    REQUIRE(engine.evaluate("selected === 'B' && popup === null")
                 .getWithDefault<bool>(false));
 }


### PR DESCRIPTION
## What a user saw

Opening a dropdown lit **two rows**: the app's own selected row, plus a second, differently treated row. Neither reads as "the current value", and the user had touched neither the mouse nor the keyboard.

The second one is this owner's keyboard cursor. It is a genuinely different state from selection — a listbox needs both — but it was being **pre-seeded and painted at open**, before anyone asked for it.

## The change

`activate()` still creates the cursor the moment the popup is owned, because an arrow key needs somewhere to start. It just is not painted until the user reveals it:

- `pointerenter` on a row (a real mouse move)
- an arrow / Home / End key
- an arrow that **opened** the popup — that key *is* the request, so a keyboard-opened menu shows its cursor immediately, exactly as before

`state.activeVisible` carries that, and `paint()` is gated on it.

### Where the first arrow lands

This is the part worth reviewing deliberately. It depends on whether the cursor had a home:

| seed | first ArrowDown |
|---|---|
| the list's own `aria-selected` row | **steps off it** — a list showing LEVEL goes to the row after LEVEL |
| an edge, because nothing was marked | **lands on that edge** — it must not skip the row the user was aiming at |

Stepping from the selection is what every platform combo box does (macOS popup menus, Chrome's `<select>`, GTK). Landing on the edge matters because with nothing selected there is nothing to step *away from*, and the old unconditional `+1` would have made the first ArrowDown skip row 0 once the paint was deferred.

Enter/Space are unchanged, and still commit whatever the cursor is on.

## The app's half

An app whose rows advertise no ARIA selection gets cursor index 0 — so a listbox whose current value is any row but the first shows its selection on one row and the cursor on another. That is the app-side half of the same defect and it is fixed app-side (Spectr `#96`); marking the rows is required for assistive technology regardless, since a `role="listbox"` of bare `<button>`s has no selection to report.

## Proof

`pulp-test-mac-platform-harness "[popup-default]"` — 3 cases, 92 assertions, green.

- The mouse-opened case now pins the unpainted open state **on the widget** as well as the attribute, because `data-pulp-popup-active="false"` can read correctly while the row is still painted — that exact split is an existing gotcha in this file's history.
- A new case covers the shape a real app ships: a 3-row listbox marking its middle row `aria-selected`, so "the cursor is on the selection" and "the cursor defaulted to index 0" are *different* readings. With the default-selected first row they are the same row and the assertion is vacuous.
- Every "nothing is painted" reading is paired with a positive control on the **same widget instrument** immediately afterwards, so an empty reading cannot be a dead probe.

Negative control, via `tools/scripts/confirm_failure.sh` with `--object web_compat_preludes_gen.cpp` (a `.js` prelude emits no compile line of its own):

```
baseline: recompiled -- Building CXX object .../web_compat_preludes_gen.cpp.o
broken:   recompiled -- Building CXX object .../web_compat_preludes_gen.cpp.o
restored: recompiled -- Building CXX object .../web_compat_preludes_gen.cpp.o
CONFIRMED — the test passes with the fix and fails without it.
```

## Notes for review

- **Not merged / not armed.** This is sequenced behind an SDK repin alongside #8272 and #8273.
- No bridge function, no manifest row, no generated artifact — so no conflict with the `setOverlayTrigger` regeneration on `fix/overlay-dismissal-unify`. That branch touches the native `ComboBox`; this one is the JS/web-compat popup owner, a different code path. No shared files.
- `tools/scripts/gates.sh origin/main` green. Vellum watch event registered watch-only (`render-assets-and-backends` is crossed only because the file sits under that selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- whence {"labels": ["1·claude", "2·m5", "3·Session 3 (M5) —…", "4·Spectr Stale pulp…", "5·unresolved"], "prov": {"agent": "claude", "host": "m5", "workspace": "Session 3 (M5) — Spectr & lifecycle.", "tab": "Spectr Stale pulp v0.382.1 on PATH", "launcher": "unresolved", "terminal": "cmux", "terminal_address": "D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B", "route": "unresolved", "origin_state": "known", "path": "~/Code/pulp-ah-popup-active-20260912", "session": "3edc10de-14b7-4828-b628-8998c334324f", "resume": "claude \u002d\u002dresume 3edc10de-14b7-4828-b628-8998c334324f", "jump": "cmux surface focus D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B", "relaunch": "cmux surface resume get \u002d\u002dsurface D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `claude` |
| **Machine** | `m5` |
| **Workspace** | `Session 3 (M5) — Spectr & lifecycle.` |
| **Tab** | Spectr Stale pulp v0.382.1 on PATH |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Terminal** | `cmux` |
| **Terminal address** | `D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B` |
| **Origin state** | `known` |
| **Directory** | `~/Code/pulp-ah-popup-active-20260912` |
| **Session** | `3edc10de-14b7-4828-b628-8998c334324f` |

**Resume**
```
claude --resume 3edc10de-14b7-4828-b628-8998c334324f
```
**Jump to this tab**
```
cmux surface focus D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B
```
**Relaunch (any agent)**
```
cmux surface resume get --surface D0DCF57A-E153-4C3B-9CD3-05D7F6CD024B
```

<sub>stamped 2026-09-13 01:01 UTC</sub>
<!-- /whence -->